### PR TITLE
feat: add authentication support

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -2,8 +2,10 @@ import os
 
 import pathlib
 from collections import defaultdict
+from typing import Optional
 
 from robyn import WS, Robyn, Request, Response, jsonify, serve_file, serve_html
+from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
 from robyn.templating import JinjaTemplate
 
 from views import SyncView, AsyncView
@@ -692,6 +694,23 @@ async def async_exception_post(_: Request):
     raise ValueError("value error")
 
 
+# ===== Authentication =====
+
+
+@app.get("/sync/auth", auth_required=True)
+def sync_auth(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "authenticated"
+
+
+@app.get("/async/auth", auth_required=True)
+async def async_auth(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "authenticated"
+
+
 # ===== Main =====
 
 
@@ -706,4 +725,13 @@ if __name__ == "__main__":
     app.add_view("/sync/view", SyncView)
     app.add_view("/async/view", AsyncView)
     app.include_router(sub_router)
+
+    class BasicAuthHandler(AuthenticationHandler):
+        def authenticate(self, request: Request) -> Optional[Identity]:
+            token = self.token_getter.get_token(request)
+            if token == "valid":
+                return Identity(claims={"key": "value"})
+            return None
+
+    app.configure_authentication(BasicAuthHandler(token_getter=BearerGetter()))
     app.start(port=8080)

--- a/integration_tests/test_authentication.py
+++ b/integration_tests/test_authentication.py
@@ -1,0 +1,42 @@
+import pytest
+
+from helpers.http_methods_helpers import get
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_valid_authentication(session, function_type: str):
+    r = get(f"/{function_type}/auth", headers={"Authorization": "Bearer valid"})
+    assert r.text == "authenticated"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_token(session, function_type: str):
+    r = get(
+        f"/{function_type}/auth",
+        headers={"Authorization": "Bearer invalid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers["WWW-Authenticate"] == "BearerGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_header(session, function_type: str):
+    r = get(
+        f"/{function_type}/auth",
+        headers={"Authorization": "Bear valid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers["WWW-Authenticate"] == "BearerGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_no_token(session, function_type: str):
+    r = get(f"/{function_type}/auth", should_check_response=False)
+    assert r.status_code == 401
+    assert r.headers["WWW-Authenticate"] == "BearerGetter"

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -1,0 +1,91 @@
+from abc import ABC, abstractclassmethod, abstractmethod
+from typing import Optional
+
+from robyn.robyn import Identity, Request, Response
+from robyn.status_codes import HTTP_401_UNAUTHORIZED
+
+
+class AuthenticationNotConfiguredError(Exception):
+    """
+    This exception is raised when the authentication is not configured.
+    """
+
+    def __str__(self):
+        return "Authentication is not configured. Use app.configure_authentication() to configure it."
+
+
+class TokenGetter(ABC):
+    @property
+    def scheme(self) -> str:
+        """
+        Gets the scheme of the token.
+        :return: The scheme of the token.
+        """
+        return self.__class__.__name__
+
+    @abstractclassmethod
+    def get_token(cls, request: Request) -> Optional[str]:
+        """
+        Gets the token from the request.
+        This method should not decode the token. Decoding is the role of the authentication handler.
+        :param request: The request object.
+        :return: The encoded token.
+        """
+        raise NotImplementedError()
+
+    @abstractclassmethod
+    def set_token(cls, request: Request, token: str):
+        """
+        Sets the token in the request.
+        This method should not encode the token. Encoding is the role of the authentication handler.
+        :param request: The request object.
+        :param token: The encoded token.
+        """
+        raise NotImplementedError()
+
+
+class AuthenticationHandler(ABC):
+    def __init__(self, token_getter: TokenGetter):
+        """
+        Creates a new instance of the AuthenticationHandler class.
+        This class is an abstract class used to authenticate a user.
+        :param token_getter: The token getter used to get the token from the request.
+        """
+        self.token_getter = token_getter
+
+    @property
+    def unauthorized_response(self) -> Response:
+        return Response(
+            headers={"WWW-Authenticate": self.token_getter.scheme},
+            body="Unauthorized",
+            status_code=HTTP_401_UNAUTHORIZED,
+        )
+
+    @abstractmethod
+    def authenticate(self, request: Request) -> Optional[Identity]:
+        """
+        Authenticates the user.
+        :param request: The request object.
+        :return: The identity of the user.
+        """
+        raise NotImplementedError()
+
+
+class BearerGetter(TokenGetter):
+    """
+    This class is used to get the token from the Authorization header.
+    The scheme of the header must be Bearer.
+    """
+
+    @classmethod
+    def get_token(cls, request: Request) -> Optional[str]:
+        authorization_header = request.headers.get("authorization")
+
+        if not authorization_header or not authorization_header.startswith("Bearer "):
+            return None
+
+        return authorization_header[7:]
+
+    @classmethod
+    def set_token(cls, request: Request, token: str):
+        request.headers["Authorization"] = f"Bearer {token}"

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -50,6 +50,10 @@ class Url:
     path: str
 
 @dataclass
+class Identity:
+    claims: dict[str, str]
+
+@dataclass
 class Request:
     """
     The request object passed to the route handler.
@@ -70,6 +74,7 @@ class Request:
     method: str
     url: Url
     ip_addr: Optional[str]
+    identity: Optional[Identity]
 
 @dataclass
 class Response:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -4,8 +4,9 @@ from functools import wraps
 from inspect import signature
 from types import CoroutineType
 from typing import Callable, Dict, List, NamedTuple, Union, Optional
+from robyn.authentication import AuthenticationHandler, AuthenticationNotConfiguredError
 
-from robyn.robyn import FunctionInfo, HttpMethod, MiddlewareType, Response
+from robyn.robyn import FunctionInfo, HttpMethod, MiddlewareType, Request, Response
 from robyn import status_codes
 from robyn.ws import WS
 
@@ -116,6 +117,10 @@ class MiddlewareRouter(BaseRouter):
         super().__init__()
         self.global_middlewares: List[GlobalMiddleware] = []
         self.route_middlewares: List[RouteMiddleware] = []
+        self.authentication_handler: Optional[AuthenticationHandler] = None
+
+    def set_authentication_handler(self, authentication_handler: AuthenticationHandler):
+        self.authentication_handler = authentication_handler
 
     def add_route(
         self, middleware_type: MiddlewareType, endpoint: str, handler: Callable
@@ -126,6 +131,26 @@ class MiddlewareRouter(BaseRouter):
             RouteMiddleware(middleware_type, endpoint, function)
         )
         return handler
+
+    def add_auth_middleware(self, endpoint: str):
+        """
+        This method adds an authentication middleware to the specified endpoint.
+        """
+
+        def inner(handler):
+            def inner_handler(request: Request, *args):
+                if not self.authentication_handler:
+                    raise AuthenticationNotConfiguredError()
+                identity = self.authentication_handler.authenticate(request)
+                if identity is None:
+                    return self.authentication_handler.unauthorized_response
+                request.identity = identity
+                return request
+
+            self.add_route(MiddlewareType.BEFORE_REQUEST, endpoint, inner_handler)
+            return inner_handler
+
+        return inner
 
     # These inner functions are basically a wrapper around the closure(decorator) being returned.
     # They take a handler, convert it into a closure and return the arguments.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use shared_socket::SocketHeld;
 use pyo3::prelude::*;
 use types::{
     function_info::{FunctionInfo, MiddlewareType},
+    identity::Identity,
     request::PyRequest,
     response::PyResponse,
     HttpMethod,
@@ -30,6 +31,7 @@ pub fn robyn(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<Server>()?;
     m.add_class::<SocketHeld>()?;
     m.add_class::<FunctionInfo>()?;
+    m.add_class::<Identity>()?;
     m.add_class::<PyRequest>()?;
     m.add_class::<PyResponse>()?;
     m.add_class::<MiddlewareType>()?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -401,7 +401,7 @@ async fn index(
             }
             Err(e) => {
                 error!(
-                    "Error while executing after middleware function for endpoint `{}`: {}",
+                    "Error while executing before middleware function for endpoint `{}`: {}",
                     req.uri().path(),
                     get_traceback(e.downcast_ref::<PyErr>().unwrap())
                 );

--- a/src/types/identity.rs
+++ b/src/types/identity.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use pyo3::{pyclass, pymethods};
+
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct Identity {
+    #[pyo3(get, set)]
+    claims: HashMap<String, String>,
+}
+
+#[pymethods]
+impl Identity {
+    #[new]
+    pub fn new(claims: HashMap<String, String>) -> Self {
+        Self { claims }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,9 +5,11 @@ use pyo3::{
 };
 
 pub mod function_info;
+pub mod identity;
 pub mod request;
 pub mod response;
 
+#[allow(clippy::large_enum_variant)]
 pub enum MiddlewareReturn {
     Request(request::Request),
     Response(response::Response),

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 
 use crate::types::{check_body_type, get_body_from_pyobject, Url};
 
+use super::identity::Identity;
+
 #[derive(Default, Debug, Clone, FromPyObject)]
 pub struct Request {
     pub queries: HashMap<String, String>,
@@ -15,6 +17,7 @@ pub struct Request {
     pub body: Vec<u8>,
     pub url: Url,
     pub ip_addr: Option<String>,
+    pub identity: Option<Identity>,
 }
 
 impl ToPyObject for Request {
@@ -35,6 +38,7 @@ impl ToPyObject for Request {
             method: self.method.clone(),
             url: self.url.clone(),
             ip_addr: self.ip_addr.clone(),
+            identity: self.identity.clone(),
         };
         Py::new(py, request).unwrap().as_ref(py).into()
     }
@@ -80,6 +84,7 @@ impl Request {
             body: body.to_vec(),
             url,
             ip_addr,
+            identity: None,
         }
     }
 }
@@ -93,6 +98,8 @@ pub struct PyRequest {
     pub headers: Py<PyDict>,
     #[pyo3(get, set)]
     pub path_params: Py<PyDict>,
+    #[pyo3(get, set)]
+    pub identity: Option<Identity>,
     #[pyo3(get)]
     pub body: Py<PyAny>,
     #[pyo3(get)]


### PR DESCRIPTION
**Description**

This PR fixes #245 

/!\ This is a draft, there is still work to do for it to be functional

Currently missing:
- Ability to return a `Response` in a "before" middleware (this would be required to directly return a 401 if the authentication middleware failed), tracked by #500
- Documentation
- Tests
