### PR TITLE
Typo-Fix in docs/features per-route-headers

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -231,7 +231,7 @@ Additionally, you can access headers for per route.
 @app.get("/test-headers")
 def sync_before_request(request: Request):
     request.headers["test"] = "we are modifying the request headers in the middle of the request!"
-    print(rquest)
+    print(request)
 ```
 
 ## Query Params


### PR DESCRIPTION


**Description**

fix: docs/features per-route-headers: fix variable typo `rquest`->`request`

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
