### PR TITLE
feat: replace default jsonify with an orjson powered jsonify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   'watchdog == 2.2.1',
   'multiprocess == 0.70.14',
   'nestd == 0.3.1',
-  'ujson == 5.8.0',
+  'ujson == 5.7.0',
 # conditional
   'uvloop == 0.17.0; sys_platform == "darwin"',
   'uvloop == 0.17.0; platform_machine == "aarch_64"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   'watchdog == 2.2.1',
   'multiprocess == 0.70.14',
   'nestd == 0.3.1',
+  'orjson == 3.9.2',
 # conditional
   'uvloop == 0.17.0; sys_platform == "darwin"',
   'uvloop == 0.17.0; platform_machine == "aarch_64"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   'watchdog == 2.2.1',
   'multiprocess == 0.70.14',
   'nestd == 0.3.1',
-  'orjson == 3.9.2',
+  'ujson == 5.8.0',
 # conditional
   'uvloop == 0.17.0; sys_platform == "darwin"',
   'uvloop == 0.17.0; platform_machine == "aarch_64"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ watchdog==2.2.1
 multiprocess==0.70.14
 jinja2==3.1.2
 nestd==0.3.1
-ujson==5.8.0 
+ujson==5.7.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ watchdog==2.2.1
 multiprocess==0.70.14
 jinja2==3.1.2
 nestd==0.3.1
+orjson==3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ watchdog==2.2.1
 multiprocess==0.70.14
 jinja2==3.1.2
 nestd==0.3.1
-orjson==3.9.2
+ujson==5.8.0 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -13,7 +13,7 @@ from robyn.env_populator import load_vars
 from robyn.events import Events
 from robyn.logger import logger
 from robyn.processpool import run_processes
-from robyn.responses import jsonify, serve_file, serve_html
+from robyn.responses import jsonify, serve_file, serve_html, json
 from robyn.robyn import FunctionInfo, HttpMethod, Request, Response, get_version
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
 from robyn.types import Directory, Header
@@ -431,6 +431,7 @@ __all__ = [
     "Response",
     "status_codes",
     "jsonify",
+    "json",
     "serve_file",
     "serve_html",
     "ALLOW_CORS",

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -1,4 +1,4 @@
-import orjson
+import ujson
 from typing import Any, Dict
 
 
@@ -35,7 +35,7 @@ def jsonify(input_dict: dict) -> str:
     :param input_dict dict: response of the function
     """
 
-    return orjson.dumps(input_dict).decode()
+    return ujson.dumps(input_dict)
 
 
-json = orjson
+json = ujson

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 from typing import Any, Dict
 
 
@@ -35,4 +35,7 @@ def jsonify(input_dict: dict) -> str:
     :param input_dict dict: response of the function
     """
 
-    return json.dumps(input_dict)
+    return orjson.dumps(input_dict).decode()
+
+
+json = orjson


### PR DESCRIPTION
Robyn exposes a function named `jsonify`, which used the default json library. This commit replaces it with the faster `orjson` library.

**Description**

This PR fixes #525 

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
