### PR TITLE
chore: decrease .whl filesize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "robyn"
 version = "0.40.0"
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A web server that is fast!"
 license = "BSD License (BSD)"
 homepage = "https://github.com/sansyrox/robyn"
@@ -38,6 +38,11 @@ serde_json = "1.0.104"
 [features]
 io-uring = ["actix-web/experimental-io-uring"]
 
+[profile.release]
+codegen-units = 1
+lto = true
+panic = "abort"
+strip = true
 
 [package.metadata.maturin]
 name = "robyn"


### PR DESCRIPTION
**Description**

This PR reduces the .whl file size to 2.2MB on release mode. This is about 30% smaller than current build size which is 3.4MB - I have not seen any performance degradation or issues arise from these changes so it's a net gain by tweaking these values.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
