### PR TITLE
fix: pass response headers from app to router

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -102,7 +102,12 @@ class Robyn:
         logger.info(f"Logging endpoint: method={route_type}, route={endpoint}")
 
         return self.router.add_route(
-            route_type, endpoint, handler, is_const, self.exception_handler
+            route_type,
+            endpoint,
+            handler,
+            is_const,
+            self.exception_handler,
+            self.response_headers,
         )
 
     def before_request(self, endpoint: Optional[str] = None) -> Callable[..., None]:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -57,7 +57,7 @@ class Router(BaseRouter):
             headers = res.get("headers", headers)
             description = res.get("description", "")
 
-            if type(status_code) != int:
+            if not isinstance(status_code, int):
                 status_code = int(status_code)  # status_code can potentially be string
 
             response = Response(
@@ -91,8 +91,7 @@ class Router(BaseRouter):
         exception_handler: Optional[Callable],
         default_response_headers: List[Header],
     ) -> Union[Callable, CoroutineType]:
-        headers_list = (h.as_list() for h in default_response_headers)
-        response_headers = {d[0]: d[1] for d in headers_list}
+        response_headers = {d.key: d.val for d in default_response_headers}
 
         @wraps(handler)
         async def async_inner_handler(*args):

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -91,9 +91,8 @@ class Router(BaseRouter):
         exception_handler: Optional[Callable],
         default_response_headers: List[Header],
     ) -> Union[Callable, CoroutineType]:
-        response_headers = {
-            d[0]: d[1] for d in (h.as_list() for h in default_response_headers)
-        }
+        headers_list = (h.as_list() for h in default_response_headers)
+        response_headers = {d[0]: d[1] for d in headers_list}
 
         @wraps(handler)
         async def async_inner_handler(*args):

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -8,6 +8,7 @@ from robyn.authentication import AuthenticationHandler, AuthenticationNotConfigu
 
 from robyn.robyn import FunctionInfo, HttpMethod, MiddlewareType, Request, Response
 from robyn import status_codes
+from robyn.types import Header
 from robyn.ws import WS
 
 
@@ -40,11 +41,20 @@ class Router(BaseRouter):
         super().__init__()
         self.routes: List[Route] = []
 
-    def _format_response(self, res):
+    def _format_response(
+        self,
+        res: dict,
+        default_response_header: dict,
+    ) -> Response:
+        headers = (
+            {"Content-Type": "text/plain"}
+            if not default_response_header
+            else default_response_header
+        )
         response = {}
         if isinstance(res, dict):
             status_code = res.get("status_code", status_codes.HTTP_200_OK)
-            headers = res.get("headers", {"Content-Type": "text/plain"})
+            headers = res.get("headers", headers)
             description = res.get("description", "")
 
             if type(status_code) != int:
@@ -67,7 +77,7 @@ class Router(BaseRouter):
         else:
             response = Response(
                 status_code=status_codes.HTTP_200_OK,
-                headers={"Content-Type": "text/plain"},
+                headers=headers,
                 description=str(res).encode("utf-8"),
             )
         return response
@@ -79,25 +89,42 @@ class Router(BaseRouter):
         handler: Callable,
         is_const: bool,
         exception_handler: Optional[Callable],
+        default_response_headers: List[Header],
     ) -> Union[Callable, CoroutineType]:
+        response_headers = {
+            d[0]: d[1] for d in (h.as_list() for h in default_response_headers)
+        }
+
         @wraps(handler)
         async def async_inner_handler(*args):
             try:
-                response = self._format_response(await handler(*args))
+                response = self._format_response(
+                    await handler(*args),
+                    response_headers,
+                )
             except Exception as err:
                 if exception_handler is None:
                     raise
-                response = self._format_response(exception_handler(err))
+                response = self._format_response(
+                    exception_handler(err),
+                    response_headers,
+                )
             return response
 
         @wraps(handler)
         def inner_handler(*args):
             try:
-                response = self._format_response(handler(*args))
+                response = self._format_response(
+                    handler(*args),
+                    response_headers,
+                )
             except Exception as err:
                 if exception_handler is None:
                     raise
-                response = self._format_response(exception_handler(err))
+                response = self._format_response(
+                    exception_handler(err),
+                    response_headers,
+                )
             return response
 
         number_of_params = len(signature(handler).parameters)


### PR DESCRIPTION
**Description**

This PR fixes #605

There was a conflict of Content-Type between what is defined in `app.response_headers` and having it being overridden in the `Router` class. I am unsure why this caused them to sometimes return `text/plain` and sometimes return the value defined in `app.response_headers`, but this fix guarantees that `app.response_headers` is the header that will be set in the `Response`.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
