### PR TITLE
fix: remove redundant Arc

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -100,7 +100,6 @@ impl Server {
         let global_request_headers = self.global_request_headers.clone();
         let global_response_headers = self.global_response_headers.clone();
         let directories = self.directories.clone();
-        let workers = Arc::new(workers);
 
         let asyncio = py.import("asyncio")?;
         let event_loop = asyncio.call_method0("new_event_loop")?;
@@ -124,7 +123,7 @@ impl Server {
 
         thread::spawn(move || {
             actix_web::rt::System::new().block_on(async move {
-                debug!("The number of workers is {}", workers.clone());
+                debug!("The number of workers is {}", workers);
                 execute_event_handler(startup_handler, &task_locals_copy)
                     .await
                     .unwrap();
@@ -210,7 +209,7 @@ impl Server {
                         ))
                 })
                 .keep_alive(KeepAlive::Os)
-                .workers(*workers.clone())
+                .workers(workers)
                 .client_request_timeout(std::time::Duration::from_secs(0))
                 .listen(raw_socket.try_into().unwrap())
                 .unwrap()


### PR DESCRIPTION
**Description**

This PR fixes #561 - The `Arc` on the workers is indeed redundant.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
