### PR TITLE
feat: add request.json() method

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -527,6 +527,25 @@ async def async_body_post(request: Request):
     return request.body
 
 
+# JSON Request
+
+
+@app.post("/sync/request_json")
+def sync_json_post(request: Request):
+    try:
+        return type(request.json())
+    except ValueError:
+        return None
+
+
+@app.post("/async/request_json")
+async def async_json_post(request: Request):
+    try:
+        return type(request.json())
+    except ValueError:
+        return None
+
+
 # --- PUT ---
 
 # dict

--- a/integration_tests/test_request_json.py
+++ b/integration_tests/test_request_json.py
@@ -1,0 +1,17 @@
+import pytest
+
+from integration_tests.helpers.http_methods_helpers import post
+
+
+@pytest.mark.parametrize(
+    "route, body, expected_result",
+    [
+        ("/sync/request_json", '{"hello": "world"}', "<class 'dict'>"),
+        ("/sync/request_json", '{"hello": "world"', "None"),
+        ("/async/request_json", '{"hello": "world"}', "<class 'dict'>"),
+        ("/async/request_json", '{"hello": "world"', "None"),
+    ],
+)
+def test_request(route, body, expected_result):
+    res = post(route, body)
+    assert res.text == expected_result

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -87,7 +87,7 @@ class Request:
     def json(self) -> dict:
         """
         If the body is a valid JSON this will return the parsed JSON data.
-        Otherwise, will throw a ValueError.
+        Otherwise, this will throw a ValueError.
         """
         pass
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -84,6 +84,9 @@ class Request:
     ip_addr: Optional[str]
     identity: Optional[Identity]
 
+    def json(self) -> dict:
+        pass
+
 @dataclass
 class Response:
     """

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -85,6 +85,10 @@ class Request:
     identity: Optional[Identity]
 
     def json(self) -> dict:
+        """
+        If the body is a valid JSON this will return the parsed JSON data.
+        Otherwise, will throw a ValueError.
+        """
         pass
 
 @dataclass

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -123,7 +123,7 @@ impl PyRequest {
 
     pub fn json(&self, py: Python) -> PyResult<PyObject> {
         match self.body.as_ref(py).downcast::<PyString>() {
-            Ok(python_string) => match serde_json::from_str(python_string.to_string().as_str()) {
+            Ok(python_string) => match serde_json::from_str(python_string.extract()?) {
                 Ok(Value::Object(map)) => {
                     let dict = PyDict::new(py);
 

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -124,20 +124,17 @@ impl PyRequest {
     pub fn json(&self, py: Python) -> PyResult<PyObject> {
         match self.body.as_ref(py).downcast::<PyString>() {
             Ok(python_string) => match serde_json::from_str(python_string.to_string().as_str()) {
-                Ok(json_value) => match json_value {
-                    Value::Object(map) => {
-                        let dict = PyDict::new(py);
+                Ok(Value::Object(map)) => {
+                    let dict = PyDict::new(py);
 
-                        for (key, value) in map.iter() {
-                            let py_key = key.to_string().into_py(py);
-                            let py_value = value.to_string().into_py(py);
-                            dict.set_item(py_key, py_value)?;
-                        }
-
-                        Ok(dict.into_py(py))
+                    for (key, value) in map.iter() {
+                        let py_key = key.to_string().into_py(py);
+                        let py_value = value.to_string().into_py(py);
+                        dict.set_item(py_key, py_value)?;
                     }
-                    _ => Err(PyValueError::new_err("Invalid JSON object")),
-                },
+
+                    Ok(dict.into_py(py))
+                }
                 _ => Err(PyValueError::new_err("Invalid JSON object")),
             },
             Err(e) => Err(e.into()),

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -1,6 +1,7 @@
 use actix_web::{web::Bytes, HttpRequest};
 use dashmap::DashMap;
-use pyo3::{prelude::*, types::PyDict};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict, types::PyString};
+use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::types::{check_body_type, get_body_from_pyobject, Url};
@@ -118,5 +119,28 @@ impl PyRequest {
         check_body_type(py, body.clone())?;
         self.body = body;
         Ok(())
+    }
+
+    pub fn json(&self, py: Python) -> PyResult<PyObject> {
+        match self.body.as_ref(py).downcast::<PyString>() {
+            Ok(python_string) => match serde_json::from_str(python_string.to_string().as_str()) {
+                Ok(json_value) => match json_value {
+                    Value::Object(map) => {
+                        let dict = PyDict::new(py);
+
+                        for (key, value) in map.iter() {
+                            let py_key = key.to_string().into_py(py);
+                            let py_value = value.to_string().into_py(py);
+                            dict.set_item(py_key, py_value)?;
+                        }
+
+                        Ok(dict.into_py(py))
+                    }
+                    _ => Err(PyValueError::new_err("Invalid JSON object")),
+                },
+                _ => Err(PyValueError::new_err("Invalid JSON object")),
+            },
+            Err(e) => Err(e.into()),
+        }
     }
 }


### PR DESCRIPTION
**Description**

This PR fixes #612 by adding a `request.json()` method, for example:
```py
@app.post("/hello")
def hello(request: Request):
    j = request.json()
    assert isinstance(j, dict)
```
Passing `'{"hello": "world"}'` would be a valid result, note that passing a non-json value e.g. `'Hello, World!'` would result in a ValueError and would require handling.

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
