### PR TITLE
feat: enable lazy evaluation for logger

### DIFF
--- a/new_docs/src/pages/documentation/example_app/monitoring_and_logging.mdx
+++ b/new_docs/src/pages/documentation/example_app/monitoring_and_logging.mdx
@@ -9,11 +9,11 @@ logger = Logger(app)
 
 @app.before_request()
 async def log_request(request: Request):
-    logger.info(f"Received request: {request}")
+    logger.info(f"Received request: %s", request)
 
 @app.after_request()
 async def log_response(response: Response):
-    logger.info(f"Sending response: {response}")
+    logger.info(f"Sending response: %s", response)
 ```
 
 With monitoring and logging in place, Batman could now easily detect issues and analyze the performance of his web application, ensuring that it was always running optimally and ready to assist him in his fight against crime.

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -47,7 +47,7 @@ class Robyn:
         if self.config.log_level.lower() != "warn":
             logger.info(
                 "SERVER IS RUNNING IN VERBOSE/DEBUG MODE. Set --log-level to WARN to run in production mode.",
-                Colors.BLUE,
+                color=Colors.BLUE,
             )
         # If we are in dev mode, we need to setup the reloader
         # This process will be used by the watchdog observer while running the actual server as children processes
@@ -99,7 +99,7 @@ class Robyn:
             }
             route_type = http_methods[route_type]
 
-        logger.info(f"Logging endpoint: method={route_type}, route={endpoint}")
+        logger.info("Logging endpoint: method=%s, route=%s", route_type, endpoint)
 
         return self.router.add_route(
             route_type, endpoint, handler, is_const, self.exception_handler
@@ -148,7 +148,7 @@ class Robyn:
         self.web_socket_router.add_route(endpoint, ws)
 
     def _add_event_handler(self, event_type: Events, handler: Callable) -> None:
-        logger.info(f"Add event {event_type} handler")
+        logger.info("Add event %s handler", event_type)
         if event_type not in {Events.STARTUP, Events.SHUTDOWN}:
             return
 
@@ -172,8 +172,8 @@ class Robyn:
         port = int(os.getenv("ROBYN_PORT", port))
         open_browser = bool(os.getenv("ROBYN_BROWSER_OPEN", self.config.open_browser))
 
-        logger.info(f"Robyn version: {__version__}")
-        logger.info(f"Starting server at {url}:{port}")
+        logger.info("Robyn version: %s", __version__)
+        logger.info("Starting server at %s:%s", url, port)
 
         mp.allow_connection_pickling()
 

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -28,8 +28,8 @@ def load_vars(variables=None, project_root=""):
 
     for var in variables:
         if var[0] in os.environ:
-            logger.info(f" Variable {var[0]} already set")
+            logger.info(" Variable %s already set", var[0])
             continue
         else:
             os.environ[var[0]] = var[1]
-            logger.info(f" Variable {var[0]} set to {var[1]}")
+            logger.info(" Variable %s set to %s", var[0], var[1])

--- a/robyn/logger.py
+++ b/robyn/logger.py
@@ -39,38 +39,42 @@ class Logger:
     def error(
         self,
         msg: str,
+        *args,
         color: Optional[Colors] = Colors.RED,
         bold: bool = False,
         underline: bool = False,
     ):
-        self.logger.error(self._format_msg(msg, color, bold, underline))
+        self.logger.error(self._format_msg(msg, color, bold, underline), *args)
 
     def warn(
         self,
         msg: str,
+        *args,
         color: Optional[Colors] = Colors.YELLOW,
         bold: bool = False,
         underline: bool = False,
     ):
-        self.logger.warn(self._format_msg(msg, color, bold, underline))
+        self.logger.warn(self._format_msg(msg, color, bold, underline), *args)
 
     def info(
         self,
         msg: str,
+        *args,
         color: Optional[Colors] = Colors.GREEN,
         bold: bool = False,
         underline: bool = False,
     ):
-        self.logger.info(self._format_msg(msg, color, bold, underline))
+        self.logger.info(self._format_msg(msg, color, bold, underline), *args)
 
     def debug(
         self,
         msg: str,
+        *args,
         color: Colors = Colors.BLUE,
         bold: bool = False,
         underline: bool = False,
     ):
-        self.logger.debug(self._format_msg(msg, color, bold, underline))
+        self.logger.debug(self._format_msg(msg, color, bold, underline), *args)
 
 
 logger = Logger()

--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -16,8 +16,9 @@ def setup_reloader(directory_path: str, file_path: str):
     event_handler.reload()
 
     logger.info(
-        f"Dev server initialized with the directory_path : {directory_path}",
-        Colors.BLUE,
+        "Dev server initialized with the directory_path : %s",
+        directory_path,
+        color=Colors.BLUE,
     )
 
     def terminating_signal_handler(_sig, _frame):

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -25,5 +25,3 @@ def serve_file(file_path: str) -> Dict[str, Any]:
         "file_path": file_path,
         "headers": {"Content-Disposition": "attachment"},
     }
-
-


### PR DESCRIPTION
**Description**

This PR fixes #616 by enable `*args` on the logger class - Note that this forces custom arguments such as `color`, `bold`, etc... to be stated by keyword only!

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
