### PR TITLE
docs: fix pip install command for strawberry and Robyn

### DIFF
--- a/docs_src/src/pages/documentation/api_reference/graphql-support.mdx
+++ b/docs_src/src/pages/documentation/api_reference/graphql-support.mdx
@@ -30,7 +30,7 @@ source venv/bin/activate
   <CodeGroup title="Installing Robyn and Strawberry">
 
 ```bash {{ title: 'pip' }}
-Installing Robyn and Strawberry
+pip install robyn strawberry-graphql
 ```
 
   </CodeGroup>

--- a/docs_src/src/pages/documentation/example_app/authentication.mdx
+++ b/docs_src/src/pages/documentation/example_app/authentication.mdx
@@ -66,7 +66,7 @@ def create_user(db: Session, user: User):
 
 Batman created utility functions to handle authentication, including hashing passwords and verifying passwords.
 
-```bash {{ title: 'Example request with bearer token' }}
+```python {{ title: 'Example request with bearer token' }}
 # crud.py
 # also need to do pip install passlib[bcrypt]
 # pip install "python-jose[cryptography]"


### PR DESCRIPTION
This is a quick fix for the command line for the installation of Robyn and Strawberry in the docs

**Description**

Fixing pip install command for Strawberry GraphQL and Robyn

This PR fixes #678

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
