### PR TITLE
Fixed #605 custom content-type setting not effected sometimes

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -262,8 +262,16 @@ impl Server {
     /// Adds a new response header to our concurrent hashmap
     /// this can be called after the server has started.
     pub fn add_response_header(&self, key: &str, value: &str) {
-        self.global_response_headers
-            .insert(key.to_string(), value.to_string());
+        match key.to_lowercase().as_str() {
+            "content-type" => {
+                self.global_response_headers
+                    .insert("Content-Type".to_str ing(), value.to_string());
+            }
+            _ => {
+                self.global_response_headers
+                    .insert(key.to_string(), value.to_string());
+            }
+        }
     }
 
     /// Removes a new request header to our concurrent hashmap

--- a/src/server.rs
+++ b/src/server.rs
@@ -262,16 +262,8 @@ impl Server {
     /// Adds a new response header to our concurrent hashmap
     /// this can be called after the server has started.
     pub fn add_response_header(&self, key: &str, value: &str) {
-        match key.to_lowercase().as_str() {
-            "content-type" => {
-                self.global_response_headers
-                    .insert("Content-Type".to_string(), value.to_string());
-            }
-            _ => {
-                self.global_response_headers
-                    .insert(key.to_string(), value.to_string());
-            }
-        }
+        self.global_response_headers
+            .insert(key.to_lowercase(), value.to_string());
     }
 
     /// Removes a new request header to our concurrent hashmap
@@ -444,6 +436,16 @@ async fn index(
     } else {
         Response::not_found(&request.headers)
     };
+
+    // turn all keys in response.headers into lowercase, even it's uppercase from Python code
+    for (k, v) in response.headers.clone().into_iter() {
+        let kl = k.to_lowercase();
+        if kl == k {
+            continue;
+        }
+        response.headers.insert(kl, v);
+        response.headers.remove(&k);
+    }
 
     response.headers.extend(
         global_response_headers

--- a/src/server.rs
+++ b/src/server.rs
@@ -265,7 +265,7 @@ impl Server {
         match key.to_lowercase().as_str() {
             "content-type" => {
                 self.global_response_headers
-                    .insert("Content-Type".to_str ing(), value.to_string());
+                    .insert("Content-Type".to_string(), value.to_string());
             }
             _ => {
                 self.global_response_headers


### PR DESCRIPTION
**Description**

This PR fixes #605 

`global_response_headers` in `Server` is a DashMap, which is case sensitive. 
The default key is `Content-Type` can be stay together with `content-type` in `global_response_headers`, so when it's extended , both `Content-Type` and `content-type` are written to http header without fixed sequence, but the browser is case insensitive, so it will take the last value in `Content-Type` and `content-type`, that's why this bug happened.



<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
