### PR TITLE
Added add_template_global function to JinjaTemplate.

### DIFF
--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Callable
 
 from robyn import status_codes
 
@@ -27,6 +28,11 @@ class JinjaTemplate(TemplateInterface):
             description=rendered_template,
             headers=Headers({"Content-Type": "text/html; charset=utf-8"}),
         )
+
+    def add_template_global(self, func: Callable, name: str | None = None):
+        if not callable(func):
+            raise TypeError(f"Must be callable.")
+        self.env.globals[name or func.__name__] = func
 
 
 __all__ = ["TemplateInterface", "JinjaTemplate"]

--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -31,7 +31,7 @@ class JinjaTemplate(TemplateInterface):
 
     def add_template_global(self, func: Callable, name: str | None = None):
         if not callable(func):
-            raise TypeError(f"Must be callable.")
+            raise TypeError("Must be callable.")
         self.env.globals[name or func.__name__] = func
 
 


### PR DESCRIPTION
Method to allow functions that can be called from within jinja2 templates.


example usage can be like this

```python
from robyn import Robyn
from robyn.templating import JinjaTemplate

app = Robyn(__file__)

def uppercase(string):
    return string.upper()

current_file_path = pathlib.Path(__file__).parent.resolve() JINJA_TEMPLATE = JinjaTemplate(os.path.join(current_file_path, "templates")) 
JINJA_TEMPLATE.add_template_global(uppercase)
#or
JINJA_TEMPLATE.add_template_global(uppercase, 'upper')
```

in the jinja template the above example can be used like. 

```html

{{ uppercase('uppercase me') }}

or

{{ upper('uppercase me') }}

```
