### PR TITLE
chore: fix pyproject and poetry run test_server command

### DIFF
--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -548,7 +548,7 @@ Either, by using the `headers` field in the `Request` object:
       print("These are the request headers: ", headers)
 
       headers.set("modified", "modified_value")
-      # We can also write headers["modified"] = "modified_value"
+      headers["new_header"] = "new_value" # This syntax is also valid
 
       print("These are the modified request headers: ", headers)
       

--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -548,6 +548,7 @@ Either, by using the `headers` field in the `Request` object:
       print("These are the request headers: ", headers)
 
       headers.set("modified", "modified_value")
+      # We can also write headers["modified"] = "modified_value"
 
       print("These are the modified request headers: ", headers)
       

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -820,6 +820,9 @@ def main():
     class BasicAuthHandler(AuthenticationHandler):
         def authenticate(self, request: Request) -> Optional[Identity]:
             token = self.token_getter.get_token(request)
+            if token is not None:
+                # Useless but we call the set_token method for testing purposes
+                self.token_getter.set_token(request, token)
             if token == "valid":
                 return Identity(claims={"key": "value"})
             return None

--- a/integration_tests/helpers/network_helpers.py
+++ b/integration_tests/helpers/network_helpers.py
@@ -3,11 +3,10 @@ import platform
 
 
 def get_network_host():
-    hostname = socket.gethostname()
-    ip_address = socket.gethostbyname(hostname)
-
     # windows doesn't support 0.0.0.0
     if platform.system() == "Windows":
+        hostname = socket.gethostname()
+        ip_address = socket.gethostbyname(hostname)
         return ip_address
     else:
         return "0.0.0.0"

--- a/integration_tests/subroutes/__init__.py
+++ b/integration_tests/subroutes/__init__.py
@@ -1,6 +1,6 @@
 from robyn import SubRouter, jsonify, WebSocket
 
-from subroutes.di_subrouter import di_subrouter
+from .di_subrouter import di_subrouter
 
 sub_router = SubRouter(__name__, prefix="/sub_router")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,6 @@ name = "robyn"
 version = "0.51.1"
 description = "A High-Performance, Community-Driven, and Innovator Friendly Web Framework with a Rust runtime."
 authors = [{ name = "Sanskar Jethi", email = "sansyrox@gmail.com" }]
-repository = "https://github.com/sparckles/robyn"
-documentation = "https://robyn.tech/"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Web Environment",
@@ -40,13 +38,15 @@ robyn = "robyn.cli:run"
 "templating" = ["jinja2 == 3.0.1"]
 
 [project.urls]
+Documentation = "https://robyn.tech/"
+Repository = "https://github.com/sparckles/robyn"
 Issues = "https://github.com/sparckles/robyn/issues"
 Changelog = "https://github.com/sparckles/robyn/blob/main/CHANGELOG.md"
 
 
 [tool.poetry]
 name = "robyn"
-version = "0.51.0"
+version = "0.51.1"
 description = "A High-Performance, Community-Driven, and Innovator Friendly Web Framework with a Rust runtime."
 authors = ["Sanskar Jethi <sansyrox@gmail.com>"]
 

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractclassmethod, abstractmethod
+from abc import ABC, abstractmethod
 from typing import Optional
 
 from robyn.robyn import Headers, Identity, Request, Response
@@ -23,7 +23,8 @@ class TokenGetter(ABC):
         """
         return self.__class__.__name__
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def get_token(cls, request: Request) -> Optional[str]:
         """
         Gets the token from the request.
@@ -33,7 +34,8 @@ class TokenGetter(ABC):
         """
         raise NotImplementedError()
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def set_token(cls, request: Request, token: str):
         """
         Sets the token in the request.

--- a/robyn/cli.py
+++ b/robyn/cli.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import Optional
 import webbrowser
-from InquirerPy import prompt
+from InquirerPy.resolver import prompt
 from InquirerPy.base.control import Choice
 from .argument_parser import Config
 from .reloader import create_rust_file, setup_reloader
@@ -49,9 +49,9 @@ def create_robyn_app():
         },
     ]
     result = prompt(questions=questions)
-    project_dir_path = Path(result["directory"]).resolve()
+    project_dir_path = Path(str(result["directory"])).resolve()
     docker = result["docker"]
-    project_type = result["project_type"]
+    project_type = str(result["project_type"])
 
     final_project_dir_path = (CURRENT_WORKING_DIR / project_dir_path).resolve()
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -188,6 +188,9 @@ class Headers:
     def __init__(self, default_headers: Optional[dict]) -> None:
         pass
 
+    def __getitem__(self, key: str) -> Optional[str]:
+        pass
+
     def __setitem__(self, key: str, value: str) -> None:
         pass
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -188,6 +188,9 @@ class Headers:
     def __init__(self, default_headers: Optional[dict]) -> None:
         pass
 
+    def __setitem__(self, key: str, value: str) -> None:
+        pass
+
     def set(self, key: str, value: str) -> None:
         """
         Sets the value of the header with the given key.
@@ -224,6 +227,16 @@ class Headers:
 
         Args:
             key (str): The key of the header
+        """
+        pass
+
+    def append(self, key: str, value: str) -> None:
+        """
+        Appends the value to the header with the given key.
+
+        Args:
+            key (str): The key of the header
+            value (str): The value of the header
         """
         pass
 
@@ -290,9 +303,9 @@ class Server:
         index_file: Optional[str],
     ) -> None:
         pass
-    def apply_request_header(self, key: str, value: str) -> None:
+    def apply_request_headers(self, headers: Headers) -> None:
         pass
-    def apply_response_header(self, key: str, value: str) -> None:
+    def apply_response_headers(self, headers: Headers) -> None:
         pass
 
     def add_route(

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -143,6 +143,10 @@ impl Headers {
     pub fn __repr__(&self) -> String {
         format!("{:?}", self.headers)
     }
+
+    pub fn __setitem__(&mut self, key: String, value: String) {
+        self.set(key, value);
+    }
 }
 
 impl Headers {

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -147,6 +147,10 @@ impl Headers {
     pub fn __setitem__(&mut self, key: String, value: String) {
         self.set(key, value);
     }
+
+    pub fn __getitem__(&self, key: String) -> PyResult<String> {
+        self.get(key)
+    }
 }
 
 impl Headers {


### PR DESCRIPTION
**Description**

Hi, I came back to the project after some time and found a few things that didn't work, here is a fix for : 
- the `poetry run test_server` command, which failed because the `di_subrouter` import path was absolute and not relative
- links in the `pyproject.toml` file, this should make the links appear in pypi
- the version of the project under `tool.poetry` in the `pyproject.toml` file, to match the one under `project`

Cheers :smile: 

Edit : 

I added a few more fixes : 
- the `set_token` method of `BearerGetter` wasn't working because the `__setitem__` method wasn't implemented for `Headers`
- some typing related issues that Pylance noticed