### PR TITLE
Distutils is removed in Python 3.12 so switch to setuptools

### DIFF
--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -130,7 +130,7 @@ jobs:
             add-apt-repository ppa:deadsnakes/ppa
             apt update -y
             PYTHON=python${{ matrix.python.version }}
-            apt install -y $PYTHON $PYTHON-distutils $PYTHON-venv
+            apt install -y $PYTHON $PYTHON-setuptools $PYTHON-venv
           run: |
             ls -lrth /artifacts
             PYTHON=python${{ matrix.python.version }}

--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -131,7 +131,7 @@ jobs:
             add-apt-repository ppa:deadsnakes/ppa
             apt update -y
             PYTHON=python${{ matrix.python.version }}
-            apt install -y $PYTHON $PYTHON-setuptools $PYTHON-venv
+            apt install -y $PYTHON $PYTHON-venv
           run: |
             ls -lrth /artifacts
             PYTHON=python${{ matrix.python.version }}

--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -94,6 +94,7 @@ jobs:
   linux-cross:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python:
           [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.2.2
     hooks:
       - id: ruff
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.2.1
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
**Description**

This PR should fix the failing GitHub Actions `linux-cross` on Python 3.12.

https://docs.python.org/3/whatsnew/3.12.html#distutils

<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
@messense @konstin Do you have any hints on the [`linux-cross` failures on Py3.12](https://github.com/sparckles/Robyn/actions/runs/7969971919/job/21756682947?pr=753)?
Can `maturin` error logs be written to stderr instead of the tempfile?
