### PR TITLE
ci(commitizen): enforce conventional-commit syntax

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -21,3 +21,4 @@ sys.exit(1)
 # To be removed once GitHub catches up.
 
 setup(name="robyn", install_requires=[])
+ 

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,3 @@ sys.exit(1)
 # To be removed once GitHub catches up.
 
 setup(name="robyn", install_requires=[])
- 


### PR DESCRIPTION
**Description**

Hello world! :smile: 

This PR addresses #703, at least on a git-client-side. If a user runs the regular `git commit -m "..."` flow, they should now be prompted to use conventional commit syntax.

However, since git-users are always allowed to `git commit --no-verif` and skip commit hooks, let's discuss if you guys want this to run at a CI level as well.
