### PR TITLE
cast_to argument in query_params.get

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -494,7 +494,7 @@ async def async_query(request: Request):
 
 @app.get("/async/getqueries")
 async def async_query(request: Request):
-    query_data = request.query_params.get("skip", cast_to=int, default="0")
+    query_data = request.query_params.get("skip", default=0)
     return jsonify(query_data)
 
 # Status code

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -492,6 +492,10 @@ async def async_query(request: Request):
     query_data = request.query_params.to_dict()
     return jsonify(query_data)
 
+@app.get("/async/getqueries")
+async def async_query(request: Request):
+    query_data = request.query_params.get("skip", cast_to=int, default="0")
+    return jsonify(query_data)
 
 # Status code
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -108,7 +108,7 @@ class QueryParams:
         """
         pass
 
-    def get(self, key: str, cast_to: Optional[type] = None, default: Optional[str] = None ) -> Optional[str]:
+    def get(self, key: str, default: Optional[str] = None ) -> Optional[str]:
         """
         Gets the last value of the query parameter with the given key.
 
@@ -116,13 +116,7 @@ class QueryParams:
             key (str): The key of the query parameter
             default (Optional[str]): The default value if the key does not exist
         """
-        value = self.params.get(key, default)
-        if cast_to is not None and value is not None:
-            try:
-                return cast_to(value)
-            except ValueError:
-                return default
-        return value
+        pass
 
     def empty(self) -> bool:
         """

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -108,7 +108,7 @@ class QueryParams:
         """
         pass
 
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, key: str, cast_to: Optional[type] = None, default: Optional[str] = None ) -> Optional[str]:
         """
         Gets the last value of the query parameter with the given key.
 
@@ -116,7 +116,13 @@ class QueryParams:
             key (str): The key of the query parameter
             default (Optional[str]): The default value if the key does not exist
         """
-        pass
+        value = self.params.get(key, default)
+        if cast_to is not None and value is not None:
+            try:
+                return cast_to(value)
+            except ValueError:
+                return default
+        return value
 
     def empty(self) -> bool:
         """

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -108,7 +108,7 @@ class QueryParams:
         """
         pass
 
-    def get(self, key: str, default: Optional[str] = None ) -> Optional[str]:
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
         """
         Gets the last value of the query parameter with the given key.
 

--- a/src/types/multimap.rs
+++ b/src/types/multimap.rs
@@ -25,10 +25,10 @@ impl QueryParams {
         debug!("Multimap: {:?}", self.queries);
     }
 
-    pub fn get(&self, key: String, default: Option<String>) -> Option<String> {
+    pub fn get(&self, key: String, default: Option<i32>) -> Option<String> {
         match self.queries.get(&key) {
             Some(values) => values.last().cloned(),
-            None => default,
+            None => default.map(|d| d.to_string()),
         }
     }
 


### PR DESCRIPTION
Add a `cast_to` argument to the query_params.get method for bug #835  