### PR TITLE
fix: :bug: Fix bug in compile_rust_files where it returns a list of t…

### DIFF
--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -16,8 +16,10 @@ dir_path = None
 
 def compile_rust_files(directory_path: str):
     rust_files = glob.glob(os.path.join(directory_path, "**/*.rs"), recursive=True)
+    rust_binaries: list[str] = []
+
     for rust_file in rust_files:
-        print("Compiling rust file : %s", rust_file)
+        print(f"Compiling rust file: {rust_file}")
 
         result = subprocess.run(
             [sys.executable, "-m", "rustimport", "build", rust_file],
@@ -26,11 +28,29 @@ def compile_rust_files(directory_path: str):
             start_new_session=False,
         )
         if result.returncode != 0:
-            print("Error compiling rust file : %s %s", result.stderr.decode("utf-8"), result.stdout.decode("utf-8"))
+            print(
+                f"Error compiling rust file: {rust_file} \n {result.stderr.decode('utf-8')} \n {result.stdout.decode('utf-8')}"
+            )
         else:
-            print("Compiled rust file : %s", rust_file)
+            print(f"Compiled rust file: {rust_file}")
+            rust_file_base = rust_file.removesuffix(".rs")
 
-    return rust_files
+            # Define the search pattern for the binary file
+            if sys.platform == "win32":
+                binary_extension = ".dll"
+            elif sys.platform == "darwin":
+                binary_extension = ".so"
+            elif sys.platform == "linux":
+                binary_extension = ".so"
+            else:
+                raise ValueError(f"Unsupported platform: {sys.platform}")
+
+            search_pattern = f"{rust_file_base}.*{binary_extension}"
+            # Use glob to find matching binary files
+            matching_binaries = glob.glob(search_pattern)
+            rust_binaries.extend(matching_binaries)
+
+    return rust_binaries
 
 
 def create_rust_file(file_name: str):
@@ -47,7 +67,11 @@ def create_rust_file(file_name: str):
     )
 
     if result.returncode != 0:
-        print("Error creating rust file : %s %s", result.stderr.decode("utf-8"), result.stdout.decode("utf-8"))
+        print(
+            "Error creating rust file : %s %s",
+            result.stderr.decode("utf-8"),
+            result.stdout.decode("utf-8"),
+        )
     else:
         print("Created rust file : %s", rust_file)
 
@@ -97,17 +121,23 @@ class EventHandler(FileSystemEventHandler):
         self.process = None  # Keep track of the subprocess
         self.built_rust_binaries = []  # Keep track of the built rust binaries
 
-        self.last_reload = time.time()  # Keep track of the last reload. EventHandler is initialized with the process.
+        self.last_reload = (
+            time.time()
+        )  # Keep track of the last reload. EventHandler is initialized with the process.
 
     def stop_server(self):
         if self.process:
-            os.kill(self.process.pid, signal.SIGTERM)  # Stop the subprocess using os.kill()
+            os.kill(
+                self.process.pid, signal.SIGTERM
+            )  # Stop the subprocess using os.kill()
 
     def reload(self):
         self.stop_server()
 
         new_env = os.environ.copy()
-        new_env["IS_RELOADER_RUNNING"] = "True"  # This is used to check if a reloader is already running
+        new_env["IS_RELOADER_RUNNING"] = (
+            "True"  # This is used to check if a reloader is already running
+        )
 
         print(f"Reloading {self.file_path}...")
         arguments = [arg for arg in sys.argv[1:] if not arg.startswith("--dev")]


### PR DESCRIPTION
This PR fixes a bug in the reloader module's EventHandler class. 

**Description**
The Bug observed is when reloading the existing code in the `compile_rust_files` returned a list of the *source files* for any rust modules. when returned the EventHandler set those files as `self.built_rust_binaries` so when `clean_rust_binaries` ran it deleted the source files for rust modules and did not delete the binary.

Instead i fixed the return statement in `compile_rust_files` to return all matching binaries so the correct item will be deleted on reload and no the source code files.

This PR fixes # - I did not open an issue for this
