### PR TITLE
fix: typo error in postgres scaffold

### DIFF
--- a/robyn/scaffold/postgres/app.py
+++ b/robyn/scaffold/postgres/app.py
@@ -27,4 +27,4 @@ def index():
 
 
 if __name__ == "__main__":
-    app.start(url="0.0.0.0", port=8080)
+    app.start(host="0.0.0.0", port=8080)


### PR DESCRIPTION


**Description**

The app.py of postgres scaffold was started with "url" prefix, as it doesn't exists anymore, it throws an error. Now, is changed to "host", as the other scaffolds.

