### PR TITLE
Feat: split request params

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -830,6 +830,85 @@ def sync_router_di(request, router_dependencies):
     return router_dependencies["ROUTER_DEPENDENCY"]
 
 
+# ===== Split request body =====
+
+
+@app.get("/sync/split_request/query_params")
+def sync_split_request_basic(request: Request, query_params):
+    return jsonify(query_params.to_dict())
+
+
+@app.get("/async/split_request/query_params")
+async def async_split_request_basic(request: Request, query_params):
+    return jsonify(query_params.to_dict())
+
+
+@app.get("/sync/split_request/headers")
+def sync_split_request_headers(request: Request, headers):
+    return headers.get("server")
+
+
+@app.get("/async/split_request/headers")
+async def async_split_request_headers(request: Request, headers):
+    return headers.get("server")
+
+
+@app.get("/sync/split_request/path_params/:id")
+def sync_split_request_path_params(request: Request, path_params):
+    return path_params
+
+
+@app.get("/async/split_request/path_params/:id")
+async def async_split_request_path_params(request: Request, path_params):
+    return path_params
+
+
+@app.get("/sync/split_request/method")
+def sync_split_request_method(request: Request, method):
+    return method
+
+
+@app.get("/async/split_request/method")
+async def async_split_request_method(request: Request, method):
+    return method
+
+
+@app.post("/sync/split_request/body")
+def sync_split_request_body(request: Request, body):
+    return body
+
+
+@app.post("/async/split_request/body")
+async def async_split_request_body(request: Request, body):
+    return body
+
+
+@app.post("/sync/split_request/combined")
+def sync_split_request_combined(request: Request, body, query_params, method, url, headers):
+    return jsonify(
+        {
+            "body": body,
+            "query_params": query_params.to_dict(),
+            "method": method,
+            "url": url.path,
+            "headers": headers.get("server"),
+        }
+    )
+
+
+@app.post("/async/split_request/combined")
+async def async_split_request_combined(request: Request, body, query_params, method, url, headers):
+    return jsonify(
+        {
+            "body": body,
+            "query_params": query_params.to_dict(),
+            "method": method,
+            "url": url.path,
+            "headers": headers.get("server"),
+        }
+    )
+
+
 def main():
     app.set_response_header("server", "robyn")
     app.add_directory(

--- a/integration_tests/test_split_request_params.py
+++ b/integration_tests/test_split_request_params.py
@@ -1,0 +1,57 @@
+import pytest
+
+from integration_tests.helpers.http_methods_helpers import get, post
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_split_request_params_get_query_params(session, function_type):
+    r = get(f"/{function_type}/split_request/query_params?hello=robyn")
+    assert r.json() == {"hello": ["robyn"]}
+    r = get(f"/{function_type}/split_request/query_params?hello=robyn&a=1&b=2")
+    assert r.json() == {"hello": ["robyn"], "a": ["1"], "b": ["2"]}
+    r = get(f"/{function_type}/split_request/query_params")
+    assert r.json() == {}
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_split_request_params_get_headers(session, function_type):
+    r = get(f"/{function_type}/split_request/headers")
+    assert r.text == "robyn"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_split_request_params_get_path_params(session, function_type):
+    r = get(f"/{function_type}/split_request/path_params/123")
+    assert r.json() == {"id": "123"}
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_split_request_params_get_method(session, function_type):
+    r = get(f"/{function_type}/split_request/method")
+    assert r.text == "GET"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_split_request_params_get_body(session, function_type):
+    res = post(f"/{function_type}/split_request/body", data={"hello": "world"})
+    assert res.text == "hello=world"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_split_request_params_get_combined(session, function_type):
+    res = post(
+        f"/{function_type}/split_request/combined?hello=robyn&a=1&b=2",
+        data={"hello": "world"},
+    )
+    out = res.json()
+    assert out["query_params"] == {"hello": ["robyn"], "a": ["1"], "b": ["2"]}
+    assert out["body"] == "hello=world"
+    assert out["method"] == "POST"
+    assert out["url"] == f"/{function_type}/split_request/combined"
+    assert out["headers"] == "robyn"

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -18,7 +18,15 @@ from robyn.logger import Colors, logger
 from robyn.processpool import run_processes
 from robyn.reloader import compile_rust_files
 from robyn.responses import html, serve_file, serve_html
-from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, WebSocketConnector, get_version
+from robyn.robyn import (
+    FunctionInfo,
+    Headers,
+    HttpMethod,
+    Request,
+    Response,
+    WebSocketConnector,
+    get_version,
+)
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
 from robyn.types import Directory
 from robyn.ws import WebSocket

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -124,11 +124,38 @@ class Router(BaseRouter):
         exception_handler: Optional[Callable],
         injected_dependencies: dict,
     ) -> Union[Callable, CoroutineType]:
+        def wrapped_handler(*args, **kwargs):
+            # In the execute functions the request is passed into *args
+            handler_params = signature(handler).parameters
+            # If no request arg, assume no other args are present
+            requests = list(filter(lambda a: isinstance(a, Request), args))
+            if not len(requests):
+                return handler(*args, **kwargs)
+            request = requests[0]
+            request_components = {
+                "query_params": request.query_params,
+                "headers": request.headers,
+                "path_params": request.path_params,
+                "body": request.body,
+                "method": request.method,
+                "url": request.url,
+                "ip_addr": request.ip_addr,
+                "identity": request.identity,
+                "form_data": request.form_data,
+                "files": request.files,
+                "router_dependencies": injected_dependencies["router_dependencies"],
+                "global_dependencies": injected_dependencies["global_dependencies"],
+                **kwargs,
+            }
+            filtered_params = {k: v for k, v in request_components.items() if k in handler_params}
+
+            return handler(*args, **filtered_params)
+
         @wraps(handler)
         async def async_inner_handler(*args, **kwargs):
             try:
                 response = self._format_response(
-                    await handler(*args, **kwargs),
+                    await wrapped_handler(*args, **kwargs),
                 )
             except Exception as err:
                 if exception_handler is None:
@@ -142,7 +169,7 @@ class Router(BaseRouter):
         def inner_handler(*args, **kwargs):
             try:
                 response = self._format_response(
-                    handler(*args, **kwargs),
+                    wrapped_handler(*args, **kwargs),
                 )
             except Exception as err:
                 if exception_handler is None:


### PR DESCRIPTION
**Description**

This PR fixes #850

Fix is relatively simple, involves extracting Request object from Rust passing it in, and if no Request object is passed in simply call the handler function as usual.
<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
