### PR TITLE
feat: add support to multiple authentication

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from collections import defaultdict
 from typing import Optional
+from base64 import b64encode
 
 from robyn import (
     Request,
@@ -13,7 +14,7 @@ from robyn import (
     serve_html,
     WebSocketConnector,
 )
-from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
+from robyn.authentication import AuthenticationHandler, BearerGetter, Identity, BasicGetter
 from robyn.robyn import Headers
 from robyn.templating import JinjaTemplate
 
@@ -794,6 +795,34 @@ async def async_auth(request: Request):
     return "authenticated"
 
 
+@app.get("/sync/auth/basic", auth_required=True, auth_middleware_name="basic")
+def sync_auth_basic(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "authenticated"
+
+
+@app.get("/async/auth/basic", auth_required=True, auth_middleware_name="basic")
+async def async_auth_basic(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "authenticated"
+
+
+@app.get("/sync/auth/bearer-2", auth_required=True, auth_middleware_name="bearer-2")
+def sync_auth_bearer_2(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "authenticated"
+
+
+@app.get("/async/auth/bearer-2", auth_required=True, auth_middleware_name="bearer-2")
+async def async_auth_bearer_2(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "authenticated"
+
+
 # ===== Main =====
 
 
@@ -845,7 +874,7 @@ def main():
     app.include_router(sub_router)
     app.include_router(di_subrouter)
 
-    class BasicAuthHandler(AuthenticationHandler):
+    class BearerAuthHandler(AuthenticationHandler):
         def authenticate(self, request: Request) -> Optional[Identity]:
             token = self.token_getter.get_token(request)
             if token is not None:
@@ -855,7 +884,29 @@ def main():
                 return Identity(claims={"key": "value"})
             return None
 
-    app.configure_authentication(BasicAuthHandler(token_getter=BearerGetter()))
+    class OtherBearerAuthHandler(AuthenticationHandler):
+        def authenticate(self, request: Request) -> Optional[Identity]:
+            token = self.token_getter.get_token(request)
+            if token is not None:
+                # Useless but we call the set_token method for testing purposes
+                self.token_getter.set_token(request, token)
+            if token == "valid-2":
+                return Identity(claims={"key": "value"})
+            return None
+
+    class BasicAuthHandler(AuthenticationHandler):
+        def authenticate(self, request: Request) -> Optional[Identity]:
+            username, password = self.token_getter.get_credentials(request)
+            if username is not None and password is not None:
+                # Useless but we call the set_token method for testing purposes
+                self.token_getter.set_token(request, b64encode(f"{username}:{password}".encode()).decode())
+            if username == "valid" and password == "valid":
+                return Identity(claims={"key": "value"})
+            return None
+
+    app.configure_authentication(BasicAuthHandler(token_getter=BasicGetter(), name="basic"))
+    app.configure_authentication(BearerAuthHandler(token_getter=BearerGetter(), name="bearer", default=True))
+    app.configure_authentication(OtherBearerAuthHandler(token_getter=BearerGetter(), name="bearer-2"))
     app.start(port=8080, _check_port=False)
 
 

--- a/integration_tests/test_authentication.py
+++ b/integration_tests/test_authentication.py
@@ -1,4 +1,5 @@
 import pytest
+from base64 import b64encode
 
 from integration_tests.helpers.http_methods_helpers import get
 
@@ -40,3 +41,81 @@ def test_invalid_authentication_no_token(session, function_type: str):
     r = get(f"/{function_type}/auth", should_check_response=False)
     assert r.status_code == 401
     assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_valid_authentication_bearer_2(session, function_type: str):
+    r = get(f"/{function_type}/auth/bearer-2", headers={"Authorization": "Bearer valid-2"})
+    assert r.text == "authenticated"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_token_bearer_2(session, function_type: str):
+    r = get(
+        f"/{function_type}/auth/bearer-2",
+        headers={"Authorization": "Bearer invalid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_header_bearer_2(session, function_type: str):
+    r = get(
+        f"/{function_type}/auth/bearer-2",
+        headers={"Authorization": "Bear valid-2"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_no_token_bearer_2(session, function_type: str):
+    r = get(f"/{function_type}/auth/bearer-2", should_check_response=False)
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_valid_authentication_basic(session, function_type: str):
+    r = get(f"/{function_type}/auth/basic", headers={"Authorization": f"Basic {b64encode('valid:valid'.encode()).decode()}"})
+    assert r.text == "authenticated"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_token_basic(session, function_type: str):
+    r = get(
+        f"/{function_type}/auth/basic",
+        headers={"Authorization": "Basic invalid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BasicGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_header_basic(session, function_type: str):
+    r = get(
+        f"/{function_type}/auth/basic",
+        headers={"Authorization": "Bear valid-2"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BasicGetter"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_invalid_authentication_no_token_basic(session, function_type: str):
+    r = get(f"/{function_type}/auth/basic", should_check_response=False)
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BasicGetter"

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Tuple, Union
+from base64 import b64decode
 
 from robyn.robyn import Headers, Identity, Request, Response
 from robyn.status_codes import HTTP_401_UNAUTHORIZED
@@ -45,15 +46,30 @@ class TokenGetter(ABC):
         """
         raise NotImplementedError()
 
+    @classmethod
+    def get_credentials(cls, request: Request):
+        """
+        Only available for Basic Getter.
+        Gets credentials from the request token basic.
+        This method will decode the token and return username password
+        :param request: The request object.
+        :return: Tuple of username and password.
+        """
+        pass
+
 
 class AuthenticationHandler(ABC):
-    def __init__(self, token_getter: TokenGetter):
+    def __init__(self, token_getter: TokenGetter, name: str, default: bool = False):
         """
         Creates a new instance of the AuthenticationHandler class.
         This class is an abstract class used to authenticate a user.
         :param token_getter: The token getter used to get the token from the request.
+        :param name: The name of authentication handler ex: jwt, basic, etc.
+        :param default: set authentication handler is the default handler.
         """
         self.token_getter = token_getter
+        self.name = name
+        self.default = default
 
     @property
     def unauthorized_response(self) -> Response:
@@ -94,3 +110,32 @@ class BearerGetter(TokenGetter):
     @classmethod
     def set_token(cls, request: Request, token: str):
         request.headers["Authorization"] = f"Bearer {token}"
+
+
+class BasicGetter(TokenGetter):
+    """
+    This class is used to get the token from the Authorization header.
+    The scheme of the header must be Basic.
+    """
+
+    @classmethod
+    def get_token(cls, request: Request) -> Optional[str]:
+        authorization_header = request.headers.get("authorization")
+        if not authorization_header or not authorization_header.startswith("Basic "):
+            return None
+
+        return authorization_header[6:]  # Remove the "Basic " prefix
+
+    @classmethod
+    def set_token(cls, request: Request, token: str):
+        request.headers["Authorization"] = f"Basic {token}"
+
+    @classmethod
+    def get_credentials(cls, request: Request) -> Union[Tuple[str, str], Tuple[None, None]]:
+        basic_token = cls.get_token(request)
+        try:
+            basic_token_decoded = b64decode(basic_token).decode()
+            username, _, password = basic_token_decoded.partition(":")
+            return (username, password)  # Return username password from basic authorization
+        except Exception:
+            return (None, None)


### PR DESCRIPTION
**Description**

This PR fixes #708

Hello @sansyrox. This is a split PR for support for multiple authentication, however it does not include support for subrouter. Because, as previously explained. When decorating is called, it registers the route. So the authentication handler is not registered on the subrouter because the subrouter already register the route before the authentication handler is registered. I'll include support for the subrouter in the nested router PR. But it will require this PR merge first. So check out this PR first.
<!--
Thank you for contributing to Robyn!

Contributing Conventions:

1. Include descriptive PR titles.
2. Build and test your changes before submitting a PR.

Pre-Commit Instructions:

Please ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

-->
