### PR TITLE
feat: Add OpenAPI middleware with comprehensive update_info 

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -22,6 +22,7 @@ from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, We
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
 from robyn.types import Directory
 from robyn.ws import WebSocket
+from robyn.openapi_middleware import OpenAPIMiddleware
 
 __version__ = get_version()
 
@@ -71,6 +72,7 @@ class Robyn:
         self.event_handlers = {}
         self.exception_handler: Optional[Callable] = None
         self.authentication_handler: Optional[AuthenticationHandler] = None
+        self.openapi_middleware = OpenAPIMiddleware(self)
 
     def _handle_dev_mode(self):
         cli_dev_mode = self.config.dev  # --dev

--- a/robyn/openapi_middleware.py
+++ b/robyn/openapi_middleware.py
@@ -1,0 +1,157 @@
+import json
+from typing import List, Optional, Dict
+import os
+from dataclasses import dataclass, field, asdict
+
+@dataclass
+class Contact:
+    name: Optional[str] = None
+    url: Optional[str] = None
+    email: Optional[str] = None
+
+@dataclass
+class License:
+    name: Optional[str] = None
+    url: Optional[str] = None
+
+@dataclass
+class Server:
+    url: str
+    description: Optional[str] = None
+
+@dataclass
+class ExternalDocumentation:
+    description: Optional[str] = None
+    url: Optional[str] = None
+
+@dataclass
+class Components:
+    schemas: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    responses: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    parameters: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    examples: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    requestBodies: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    securitySchemes: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    links: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    callbacks: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    pathItems: Optional[Dict[str, Dict]] = field(default_factory=dict)
+
+@dataclass
+class OpenAPIInfo:
+    title: str = "Robyn API"
+    version: str = "1.0.0"
+    description: Optional[str] = None
+    termsOfService: Optional[str] = None
+    contact: Contact = field(default_factory=Contact)
+    license: License = field(default_factory=License)
+    servers: List[Server] = field(default_factory=list)
+    externalDocs: Optional[ExternalDocumentation] = field(default_factory=ExternalDocumentation)
+    components: Components = field(default_factory=Components)
+
+@dataclass
+class OpenAPIMiddleware:
+    app: object
+    info: OpenAPIInfo = field(default_factory=OpenAPIInfo)
+    openapi_spec: dict = field(init=False)
+
+    def __post_init__(self):
+        self.openapi_spec = {
+            "openapi": "3.0.0",
+            "info": asdict(self.info),
+            "paths": {},
+            "components": asdict(self.info.components),
+            "servers": [asdict(server) for server in self.info.servers],
+            "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
+        }
+        self._wrap_app_methods()
+        self._register_openapi_routes()
+
+    def _wrap_app_methods(self):
+        original_get = self.app.get
+        original_post = self.app.post
+        original_put = self.app.put
+        original_delete = self.app.delete
+        original_patch = self.app.patch
+        original_head = self.app.head
+        original_options = self.app.options
+
+        def wrapped_get(path, *args, **kwargs):
+            self.add_route(path, "get")
+            return original_get(path, *args, **kwargs)
+
+        def wrapped_post(path, *args, **kwargs):
+            self.add_route(path, "post")
+            return original_post(path, *args, **kwargs)
+
+        def wrapped_put(path, *args, **kwargs):
+            self.add_route(path, "put")
+            return original_put(path, *args, **kwargs)
+
+        def wrapped_delete(path, *args, **kwargs):
+            self.add_route(path, "delete")
+            return original_delete(path, *args, **kwargs)
+
+        def wrapped_patch(path, *args, **kwargs):
+            self.add_route(path, "patch")
+            return original_patch(path, *args, **kwargs)
+
+        def wrapped_head(path, *args, **kwargs):
+            self.add_route(path, "head")
+            return original_head(path, *args, **kwargs)
+
+        def wrapped_options(path, *args, **kwargs):
+            self.add_route(path, "options")
+            return original_options(path, *args, **kwargs)
+
+        self.app.get = wrapped_get
+        self.app.post = wrapped_post
+        self.app.put = wrapped_put
+        self.app.delete = wrapped_delete
+        self.app.patch = wrapped_patch
+        self.app.head = wrapped_head
+        self.app.options = wrapped_options
+
+    def add_route(self, path, method):
+        if path not in self.openapi_spec["paths"]:
+            self.openapi_spec["paths"][path] = {}
+        self.openapi_spec["paths"][path][method.lower()] = {
+            "summary": f"{method.upper()} {path}",
+            "responses": {
+                "200": {
+                    "description": "Successful response"
+                }
+            }
+        }
+
+    def update_info(self, **kwargs):
+        """Update the OpenAPI info section."""
+        for key, value in kwargs.items():
+            if hasattr(self.info, key):
+                setattr(self.info, key, value)
+            elif key in self.info.contact.__annotations__:
+                setattr(self.info.contact, key, value)
+            elif key in self.info.license.__annotations__:
+                setattr(self.info.license, key, value)
+            elif key in self.info.components.__annotations__:
+                setattr(self.info.components, key, value)
+            elif self.info.servers and key in self.info.servers[0].__annotations__:
+                for server in self.info.servers:
+                    setattr(server, key, value)
+            elif key in self.info.externalDocs.__annotations__:
+                setattr(self.info.externalDocs, key, value)
+        self.openapi_spec["info"] = asdict(self.info)
+        self.openapi_spec["components"] = asdict(self.info.components)
+        self.openapi_spec["servers"] = [asdict(server) for server in self.info.servers]
+        if self.info.externalDocs.url:
+            self.openapi_spec["externalDocs"] = asdict(self.info.externalDocs)
+
+    def _register_openapi_routes(self):
+        self.app.add_route("/openapi.json", self.openapi_spec_handler, methods=["GET"])
+        self.app.add_route("/docs", self.swagger_ui_handler, methods=["GET"])
+
+    async def openapi_spec_handler(self, request):
+        return json.dumps(self.openapi_spec), {"Content-Type": "application/json"}
+
+    async def swagger_ui_handler(self, request):
+        with open(os.path.join(os.path.dirname(__file__), "swagger.html"), "r") as f:
+            return f.read(), {"Content-Type": "text/html"}

--- a/robyn/swagger.html
+++ b/robyn/swagger.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css"
+        href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.52.3/swagger-ui.css">
+</head>
+
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.52.3/swagger-ui-bundle.js"></script>
+    <script>
+        window.onload = function () {
+            const ui = SwaggerUIBundle({
+                url: "/openapi.json",
+                dom_id: '#swagger-ui',
+            });
+        }
+    </script>
+</body>
+
+</html>

--- a/unit_tests/test_request_object.py
+++ b/unit_tests/test_request_object.py
@@ -1,15 +1,18 @@
 import pytest
-from robyn.openapi_middleware import OpenAPIMiddleware, OpenAPIInfo
+from robyn.openapi_middleware import OpenAPIMiddleware
 from robyn.robyn import Headers, QueryParams, Request, Url
+
 
 # Fixtures to set up the necessary objects
 @pytest.fixture
 def app():
-    return type('TestApp', (), {})()  # Mock app object
+    return type("TestApp", (), {})()  # Mock app object
+
 
 @pytest.fixture
 def middleware(app):
     return OpenAPIMiddleware(app)
+
 
 def test_update_info(middleware):
     # Initial assertions
@@ -30,15 +33,7 @@ def test_update_info(middleware):
         license_url="http://www.apache.org/licenses/LICENSE-2.0.html",
         servers=[{"url": "https://api.example.com", "description": "Production server"}],
         externalDocs={"description": "Find more info here", "url": "http://example.com/docs"},
-        component_schemas={
-            "Error": {
-                "type": "object",
-                "properties": {
-                    "message": {"type": "string"},
-                    "code": {"type": "integer"}
-                }
-            }
-        }
+        component_schemas={"Error": {"type": "object", "properties": {"message": {"type": "string"}, "code": {"type": "integer"}}}},
     )
 
     # Assertions after update
@@ -57,6 +52,7 @@ def test_update_info(middleware):
     assert middleware.info.externalDocs.description == "Find more info here"
     assert middleware.info.externalDocs.url == "http://example.com/docs"
     assert "Error" in middleware.info.components.schemas
+
 
 def test_request_object():
     url = Url(

--- a/unit_tests/test_request_object.py
+++ b/unit_tests/test_request_object.py
@@ -1,27 +1,89 @@
+import unittest
+from robyn.openapi_middleware import OpenAPIMiddleware, OpenAPIInfo
 from robyn.robyn import Headers, QueryParams, Request, Url
 
 
-def test_request_object():
-    url = Url(
-        scheme="https",
-        host="localhost",
-        path="/user",
-    )
-    request = Request(
-        query_params=QueryParams(),
-        headers=Headers({"Content-Type": "application/json"}),
-        path_params={},
-        body="",
-        method="GET",
-        url=url,
-        ip_addr=None,
-        identity=None,
-        form_data={},
-        files={},
-    )
+class TestOpenAPIMiddleware(unittest.TestCase):
 
-    assert request.url.scheme == "https"
-    assert request.url.host == "localhost"
-    print(request.headers.get("Content-Type"))
-    assert request.headers.get("Content-Type") == "application/json"
-    assert request.method == "GET"
+    def setUp(self):
+        self.app = type('TestApp', (), {})()  # Mock app object
+        self.middleware = OpenAPIMiddleware(self.app)
+
+    def test_update_info(self):
+        # Initial assertions
+        self.assertEqual(self.middleware.info.title, "Robyn API")
+        self.assertEqual(self.middleware.info.version, "1.0.0")
+        self.assertIsNone(self.middleware.info.description)
+
+        # Update the info
+        self.middleware.update_info(
+            title="My Custom API",
+            version="2.0.0",
+            description="This is a custom API",
+            termsOfService="http://example.com/terms/",
+            contact_name="API Support",
+            contact_url="http://www.example.com/support",
+            contact_email="support@example.com",
+            license_name="Apache 2.0",
+            license_url="http://www.apache.org/licenses/LICENSE-2.0.html",
+            servers=[{"url": "https://api.example.com", "description": "Production server"}],
+            externalDocs={"description": "Find more info here", "url": "http://example.com/docs"},
+            component_schemas={
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string"},
+                        "code": {"type": "integer"}
+                    }
+                }
+            }
+        )
+
+        # Assertions after update
+        self.assertEqual(self.middleware.info.title, "My Custom API")
+        self.assertEqual(self.middleware.info.version, "2.0.0")
+        self.assertEqual(self.middleware.info.description, "This is a custom API")
+        self.assertEqual(self.middleware.info.termsOfService, "http://example.com/terms/")
+        self.assertEqual(self.middleware.info.contact.name, "API Support")
+        self.assertEqual(self.middleware.info.contact.url, "http://www.example.com/support")
+        self.assertEqual(self.middleware.info.contact.email, "support@example.com")
+        self.assertEqual(self.middleware.info.license.name, "Apache 2.0")
+        self.assertEqual(self.middleware.info.license.url, "http://www.apache.org/licenses/LICENSE-2.0.html")
+        self.assertEqual(len(self.middleware.info.servers), 1)
+        self.assertEqual(self.middleware.info.servers[0].url, "https://api.example.com")
+        self.assertEqual(self.middleware.info.servers[0].description, "Production server")
+        self.assertEqual(self.middleware.info.externalDocs.description, "Find more info here")
+        self.assertEqual(self.middleware.info.externalDocs.url, "http://example.com/docs")
+        self.assertIn("Error", self.middleware.info.components.schemas)
+
+
+class TestRequestObject(unittest.TestCase):
+
+    def test_request_object(self):
+        url = Url(
+            scheme="https",
+            host="localhost",
+            path="/user",
+        )
+        request = Request(
+            query_params=QueryParams(),
+            headers=Headers({"Content-Type": "application/json"}),
+            path_params={},
+            body="",
+            method="GET",
+            url=url,
+            ip_addr=None,
+            identity=None,
+            form_data={},
+            files={},
+        )
+
+        self.assertEqual(request.url.scheme, "https")
+        self.assertEqual(request.url.host, "localhost")
+        print(request.headers.get("Content-Type"))
+        self.assertEqual(request.headers.get("Content-Type"), "application/json")
+        self.assertEqual(request.method, "GET")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_request_object.py
+++ b/unit_tests/test_request_object.py
@@ -1,89 +1,83 @@
-import unittest
+import pytest
 from robyn.openapi_middleware import OpenAPIMiddleware, OpenAPIInfo
 from robyn.robyn import Headers, QueryParams, Request, Url
 
+# Fixtures to set up the necessary objects
+@pytest.fixture
+def app():
+    return type('TestApp', (), {})()  # Mock app object
 
-class TestOpenAPIMiddleware(unittest.TestCase):
+@pytest.fixture
+def middleware(app):
+    return OpenAPIMiddleware(app)
 
-    def setUp(self):
-        self.app = type('TestApp', (), {})()  # Mock app object
-        self.middleware = OpenAPIMiddleware(self.app)
+def test_update_info(middleware):
+    # Initial assertions
+    assert middleware.info.title == "Robyn API"
+    assert middleware.info.version == "1.0.0"
+    assert middleware.info.description is None
 
-    def test_update_info(self):
-        # Initial assertions
-        self.assertEqual(self.middleware.info.title, "Robyn API")
-        self.assertEqual(self.middleware.info.version, "1.0.0")
-        self.assertIsNone(self.middleware.info.description)
-
-        # Update the info
-        self.middleware.update_info(
-            title="My Custom API",
-            version="2.0.0",
-            description="This is a custom API",
-            termsOfService="http://example.com/terms/",
-            contact_name="API Support",
-            contact_url="http://www.example.com/support",
-            contact_email="support@example.com",
-            license_name="Apache 2.0",
-            license_url="http://www.apache.org/licenses/LICENSE-2.0.html",
-            servers=[{"url": "https://api.example.com", "description": "Production server"}],
-            externalDocs={"description": "Find more info here", "url": "http://example.com/docs"},
-            component_schemas={
-                "Error": {
-                    "type": "object",
-                    "properties": {
-                        "message": {"type": "string"},
-                        "code": {"type": "integer"}
-                    }
+    # Update the info
+    middleware.update_info(
+        title="My Custom API",
+        version="2.0.0",
+        description="This is a custom API",
+        termsOfService="http://example.com/terms/",
+        contact_name="API Support",
+        contact_url="http://www.example.com/support",
+        contact_email="support@example.com",
+        license_name="Apache 2.0",
+        license_url="http://www.apache.org/licenses/LICENSE-2.0.html",
+        servers=[{"url": "https://api.example.com", "description": "Production server"}],
+        externalDocs={"description": "Find more info here", "url": "http://example.com/docs"},
+        component_schemas={
+            "Error": {
+                "type": "object",
+                "properties": {
+                    "message": {"type": "string"},
+                    "code": {"type": "integer"}
                 }
             }
-        )
+        }
+    )
 
-        # Assertions after update
-        self.assertEqual(self.middleware.info.title, "My Custom API")
-        self.assertEqual(self.middleware.info.version, "2.0.0")
-        self.assertEqual(self.middleware.info.description, "This is a custom API")
-        self.assertEqual(self.middleware.info.termsOfService, "http://example.com/terms/")
-        self.assertEqual(self.middleware.info.contact.name, "API Support")
-        self.assertEqual(self.middleware.info.contact.url, "http://www.example.com/support")
-        self.assertEqual(self.middleware.info.contact.email, "support@example.com")
-        self.assertEqual(self.middleware.info.license.name, "Apache 2.0")
-        self.assertEqual(self.middleware.info.license.url, "http://www.apache.org/licenses/LICENSE-2.0.html")
-        self.assertEqual(len(self.middleware.info.servers), 1)
-        self.assertEqual(self.middleware.info.servers[0].url, "https://api.example.com")
-        self.assertEqual(self.middleware.info.servers[0].description, "Production server")
-        self.assertEqual(self.middleware.info.externalDocs.description, "Find more info here")
-        self.assertEqual(self.middleware.info.externalDocs.url, "http://example.com/docs")
-        self.assertIn("Error", self.middleware.info.components.schemas)
+    # Assertions after update
+    assert middleware.info.title == "My Custom API"
+    assert middleware.info.version == "2.0.0"
+    assert middleware.info.description == "This is a custom API"
+    assert middleware.info.termsOfService == "http://example.com/terms/"
+    assert middleware.info.contact.name == "API Support"
+    assert middleware.info.contact.url == "http://www.example.com/support"
+    assert middleware.info.contact.email == "support@example.com"
+    assert middleware.info.license.name == "Apache 2.0"
+    assert middleware.info.license.url == "http://www.apache.org/licenses/LICENSE-2.0.html"
+    assert len(middleware.info.servers) == 1
+    assert middleware.info.servers[0].url == "https://api.example.com"
+    assert middleware.info.servers[0].description == "Production server"
+    assert middleware.info.externalDocs.description == "Find more info here"
+    assert middleware.info.externalDocs.url == "http://example.com/docs"
+    assert "Error" in middleware.info.components.schemas
 
+def test_request_object():
+    url = Url(
+        scheme="https",
+        host="localhost",
+        path="/user",
+    )
+    request = Request(
+        query_params=QueryParams(),
+        headers=Headers({"Content-Type": "application/json"}),
+        path_params={},
+        body="",
+        method="GET",
+        url=url,
+        ip_addr=None,
+        identity=None,
+        form_data={},
+        files={},
+    )
 
-class TestRequestObject(unittest.TestCase):
-
-    def test_request_object(self):
-        url = Url(
-            scheme="https",
-            host="localhost",
-            path="/user",
-        )
-        request = Request(
-            query_params=QueryParams(),
-            headers=Headers({"Content-Type": "application/json"}),
-            path_params={},
-            body="",
-            method="GET",
-            url=url,
-            ip_addr=None,
-            identity=None,
-            form_data={},
-            files={},
-        )
-
-        self.assertEqual(request.url.scheme, "https")
-        self.assertEqual(request.url.host, "localhost")
-        print(request.headers.get("Content-Type"))
-        self.assertEqual(request.headers.get("Content-Type"), "application/json")
-        self.assertEqual(request.method, "GET")
-
-
-if __name__ == '__main__':
-    unittest.main()
+    assert request.url.scheme == "https"
+    assert request.url.host == "localhost"
+    assert request.headers.get("Content-Type") == "application/json"
+    assert request.method == "GET"


### PR DESCRIPTION
### Summary
To solve #247 
This pull request introduces the OpenAPI middleware with a comprehensive `update_info` method that allows dynamic updates to the OpenAPI specification. It includes the following changes:

1. **OpenAPI Middleware**: A new `OpenAPIMiddleware` class that handles CRUD operations and dynamically updates the OpenAPI specification.
2. **Comprehensive OpenAPI Info**: Uses dataclasses to manage OpenAPI Info, Contact, License, Server, External Documentation, and Components.
3. **Unit Tests**: Adds unit tests for the `update_info` method to ensure that the OpenAPI info is updated correctly.

### Changes

- Added `openapi_middleware.py` to manage OpenAPI specifications.
- Updated `__init__.py` to include the middleware.
- Added `unit_tests/test_openapi_middleware.py` with unit tests for the middleware.

### Testing

Run the unit tests to ensure everything works correctly:

```sh
PYTHONPATH=.. python -m unittest unit_tests/test_openapi_middleware.py
