### PR TITLE
feat: expose the openapi object params

### DIFF
--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -97,6 +97,37 @@ class Components:
 
 
 @dataclass
+class Parameter:
+    def __post_init__(self):
+        self.__setattr__("in", self._in)
+        self.__delattr__("_in")
+
+    name: str = (None,)
+    _in: str = (None,)
+    description: Optional[str] = (None,)
+    required: Optional[bool] = (False,)
+    deprecated: Optional[bool] = (False,)
+    allowEmptyValue: Optional[bool] = (False,)
+
+
+@dataclass
+class Operation:
+    tags: Optional[List[str]] = (field(default_factory=list),)
+    summary: Optional[str] = (None,)
+    description: Optional[str] = (None,)
+    externalDocs: Optional[ExternalDocumentation] = (field(default_factory=ExternalDocumentation),)
+    operationId: Optional[str] = (None,)
+
+    parameters = (field(default_factory=dict),)
+    requestBody = (field(default_factory=dict),)
+    responses = (field(default_factory=dict),)
+    callbacks = (field(default_factory=dict),)
+    deprecated = (field(default_factory=dict),)
+    security = (field(default_factory=dict),)
+    servers = (field(default_factory=dict),)
+
+
+@dataclass
 class OpenAPIInfo:
     """
     Provides metadata about the API. The metadata MAY be used by tooling as required.
@@ -251,6 +282,20 @@ class OpenAPI:
             "description": description,
             "tags": tags,
             "parameters": openapi_parameter_object,
+            "requestBody": {
+                "content": {
+                    "application/x-www-form-urlencoded": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"description": "Updated name of the pet", "type": "string"},
+                                "status": {"description": "Updated status of the pet", "type": "string"},
+                            },
+                            "required": ["status"],
+                        }
+                    }
+                }
+            },
             "responses": {"200": {"description": "Successful Response", "content": {return_type: {"schema": {}}}}},
         }
 


### PR DESCRIPTION
## Description

This PR fixes #935

## Summary

This PR exposes the operator object params to the user in openapi spec.

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

