### PR TITLE
fix: request body parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0.109"
 once_cell = "1.8.0"
 actix-multipart = "0.6.1"
 parking_lot = "0.12.3"
+serde_urlencoded = "0.7"
 
 [features]
 io-uring = ["actix-web/experimental-io-uring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0.109"
 once_cell = "1.8.0"
 actix-multipart = "0.6.1"
 parking_lot = "0.12.3"
-serde_urlencoded = "0.7"
+percent-encoding = "2.3"
 
 [features]
 io-uring = ["actix-web/experimental-io-uring"]

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -586,7 +586,7 @@ def sync_form_data(request: Request):
 
 @app.post("/sync/simple_form_data")
 def sync_simple_form_data(request: Request):
-    return request.headers["Content-Type"]
+    return request.form_data["list_field"]
 
 
 # JSON Request
@@ -612,6 +612,12 @@ async def async_json_post(request: Request):
 async def request_json(request: Request):
     json = request.json()
     return json["key"]
+
+
+@app.post("/sync/request_json/list")
+async def request_json_list(request: Request):
+    json = request.json()
+    return json["field"]
 
 
 # --- PUT ---

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -482,6 +482,13 @@ def sync_multipart_file(request: Request):
     return {"file_names": list(file_names)}
 
 
+@app.post("/sync/multipart-file-form")
+def sync_multipart_file_form(request: Request):
+    files = request.files
+    file_names = files.keys()
+    return {"form_data": request.form_data, "file_names": list(file_names)}
+
+
 # Queries
 
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -584,6 +584,11 @@ def sync_form_data(request: Request):
     return request.headers["Content-Type"]
 
 
+@app.post("/sync/simple_form_data")
+def sync_simple_form_data(request: Request):
+    return request.headers["Content-Type"]
+
+
 # JSON Request
 
 

--- a/integration_tests/helpers/http_methods_helpers.py
+++ b/integration_tests/helpers/http_methods_helpers.py
@@ -63,6 +63,7 @@ def post(
 
 def multipart_post(
     endpoint: str,
+    form_data: Optional[dict] = None,
     files: Optional[dict] = None,
     expected_status_code: int = 200,
     should_check_response: bool = True,
@@ -77,7 +78,7 @@ def multipart_post(
     """
 
     endpoint = endpoint.strip("/")
-    response = requests.post(f"{BASE_URL}/{endpoint}", files=files)
+    response = requests.post(f"{BASE_URL}/{endpoint}", files=files, data=form_data)
     if should_check_response:
         check_response(response, expected_status_code)
     return response

--- a/integration_tests/test_multipart_data.py
+++ b/integration_tests/test_multipart_data.py
@@ -19,5 +19,6 @@ def test_multipart_file(function_type: str, session):
 @pytest.mark.benchmark
 @pytest.mark.parametrize("function_type", ["sync"])
 def test_simple_form_data(function_type: str, session):
-    res = post(f"/{function_type}/simple_form_data", data={"hello": "world"})
-    assert "x-www-form-urlencoded" in res.text
+    data = {"hello": "world", "list_field": ["a=", "b"]}
+    res = post(f"/{function_type}/simple_form_data", data=data)
+    assert str(data["list_field"]) == res.text

--- a/integration_tests/test_multipart_data.py
+++ b/integration_tests/test_multipart_data.py
@@ -1,5 +1,5 @@
 import pytest
-from integration_tests.helpers.http_methods_helpers import multipart_post
+from integration_tests.helpers.http_methods_helpers import multipart_post, post
 
 
 @pytest.mark.benchmark
@@ -14,3 +14,10 @@ def test_form_data(function_type: str, session):
 def test_multipart_file(function_type: str, session):
     res = multipart_post(f"/{function_type}/multipart-file", files={"hello": "world"})
     assert "hello" in res.text
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync"])
+def test_simple_form_data(function_type: str, session):
+    res = post(f"/{function_type}/simple_form_data", data={"hello": "world"})
+    assert "x-www-form-urlencoded" in res.text

--- a/integration_tests/test_multipart_data.py
+++ b/integration_tests/test_multipart_data.py
@@ -18,6 +18,13 @@ def test_multipart_file(function_type: str, session):
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("function_type", ["sync"])
+def test_multipart_file_and_form_data(function_type: str, session):
+    res = multipart_post(f"/{function_type}/multipart-file-form", files={"hello": "world"}, form_data={"list_field": ["a=", "b"]})
+    assert "hello" in res.text and '["a=","b"]' in res.text
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("function_type", ["sync"])
 def test_simple_form_data(function_type: str, session):
     data = {"hello": "world", "list_field": ["a=", "b"]}
     res = post(f"/{function_type}/simple_form_data", data=data)

--- a/integration_tests/test_request_json.py
+++ b/integration_tests/test_request_json.py
@@ -11,6 +11,7 @@ from integration_tests.helpers.http_methods_helpers import post
         ("/sync/request_json", '{"hello": "world"', "None"),
         ("/async/request_json", '{"hello": "world"}', "<class 'dict'>"),
         ("/async/request_json", '{"hello": "world"', "None"),
+        ("/sync/request_json/list", '{"hello": "world", "field": ["a=", "b"]}', "['a=', 'b']"),
     ],
 )
 def test_request(route, body, expected_result):

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use log::debug;
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
-    types::{PyBytes, PyString},
+    types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple},
 };
+use serde_json::Value;
 
 pub mod function_info;
 pub mod headers;
@@ -81,6 +83,58 @@ pub fn get_body_from_pyobject(body: &PyAny) -> PyResult<Vec<u8>> {
     } else {
         debug!("Could not convert specified body to bytes");
         Ok(vec![])
+    }
+}
+
+pub fn get_form_data_from_pyobject(form_data: &PyAny) -> PyResult<Option<HashMap<String, Value>>> {
+    if let Ok(py_dict) = form_data.downcast::<PyDict>() {
+        let mut map = HashMap::new();
+        for (key, value) in py_dict.iter() {
+            let key_str: String = key.extract()?;
+            let json_value: Value = pyany_to_value(value)?;
+            map.insert(key_str, json_value);
+        }
+        Ok(Some(map))
+    } else {
+        debug!("Could not convert specified form data");
+        Ok(None)
+    }
+}
+
+fn pyany_to_value(obj: &PyAny) -> PyResult<Value> {
+    if obj.is_none() {
+        Ok(Value::Null)
+    } else if let Ok(val) = obj.downcast::<PyBool>() {
+        Ok(Value::Bool(val.is_true()))
+    } else if let Ok(val) = obj.downcast::<PyInt>() {
+        let int_val: i64 = val.extract()?;
+        Ok(Value::Number(int_val.into()))
+    } else if let Ok(val) = obj.downcast::<PyFloat>() {
+        let float_val: f64 = val.extract()?;
+        Ok(Value::Number(serde_json::Number::from_f64(float_val).ok_or_else(|| {
+            PyValueError::new_err("Failed to convert float")
+        })?))
+    } else if let Ok(val) = obj.downcast::<PyString>() {
+        let str_val: String = val.extract()?;
+        Ok(Value::String(str_val))
+    } else if let Ok(dict) = obj.downcast::<PyDict>() {
+        let mut map = serde_json::Map::new();
+        for (key, value) in dict.iter() {
+            let key_str: String = key.extract()?;
+            let json_value = pyany_to_value(value)?;
+            map.insert(key_str, json_value);
+        }
+        Ok(Value::Object(map))
+    } else if let Ok(list) = obj.downcast::<PyList>() {
+        let vec = list.iter().map(pyany_to_value).collect::<Result<Vec<_>, _>>()?;
+        Ok(Value::Array(vec))
+    } else if let Ok(tuple) = obj.downcast::<PyTuple>() {
+        let vec = tuple.iter().map(pyany_to_value).collect::<Result<Vec<_>, _>>()?;
+        Ok(Value::Array(vec))
+    } else {
+        Err(PyValueError::new_err(
+            "Unsupported Python type for conversion to JSON",
+        ))
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -117,6 +117,9 @@ fn pyany_to_value(obj: &PyAny) -> PyResult<Value> {
     } else if let Ok(val) = obj.downcast::<PyString>() {
         let str_val: String = val.extract()?;
         Ok(Value::String(str_val))
+    } else if let Ok(val) = obj.downcast::<PyBytes>() {
+        let bytes_val = val.extract::<Vec<u8>>()?.into_iter().map(|c| Value::Number(c.into())).collect();
+        Ok(Value::Array(bytes_val))
     } else if let Ok(dict) = obj.downcast::<PyDict>() {
         let mut map = serde_json::Map::new();
         for (key, value) in dict.iter() {

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -5,11 +5,15 @@ use actix_web::{
 };
 use futures_util::StreamExt as _;
 use log::debug;
+use percent_encoding::percent_decode;
 use pyo3::types::{PyBytes, PyDict, PyString};
-use pyo3::{exceptions::PyValueError, prelude::*, types::{PyList, PyAny}};
+use pyo3::{
+    exceptions::PyValueError,
+    prelude::*,
+    types::{PyAny, PyList},
+};
 use serde_json::Value;
 use std::collections::HashMap;
-use percent_encoding::percent_decode;
 
 use crate::types::{check_body_type, get_body_from_pyobject, get_form_data_from_pyobject, Url};
 
@@ -29,7 +33,8 @@ pub struct Request {
     pub identity: Option<Identity>,
     #[pyo3(from_py_with = "get_form_data_from_pyobject")]
     pub form_data: Option<HashMap<String, Value>>,
-    pub files: Option<HashMap<String, Vec<u8>>>,
+    #[pyo3(from_py_with = "get_form_data_from_pyobject")]
+    pub files: Option<HashMap<String, Value>>,
 }
 
 impl ToPyObject for Request {
@@ -45,19 +50,68 @@ impl ToPyObject for Request {
             Some(data) => {
                 let dict = PyDict::new(py);
                 for (key, value) in data.iter() {
-                    dict.set_item(key, value_to_pyany(py, value).unwrap()).unwrap();
+                    dict.set_item(key, value_to_pyany(py, value).unwrap())
+                        .unwrap();
                 }
                 dict.into_py(py)
             }
             None => PyDict::new(py).into_py(py),
         };
-
         let files: Py<PyDict> = match &self.files {
             Some(data) => {
                 let dict = PyDict::new(py);
-                for (key, value) in data.iter() {
-                    let bytes = PyBytes::new(py, value);
-                    dict.set_item(key, bytes).unwrap();
+                for (field, value) in data.iter() {
+                    let mut _dict = PyDict::new(py);
+                    match value {
+                        Value::Object(file_dict) => {
+                            for (file_name, val) in file_dict {
+                                if let Value::Array(file_content) = val {
+                                    let mut single = true;
+                                    let files = PyList::empty(py);
+                                    let mut file_bytes: Vec<u8> = Vec::new();
+                                    for file_data in file_content.into_iter() {
+                                        if let Value::Array(_files) = file_data {
+                                            // file list
+                                            single = false;
+                                            let mut _file_bytes: Vec<u8> = Vec::new();
+                                            for _file in _files.into_iter() {
+                                                if let Value::Number(content) = _file {
+                                                    if let Some(i) = content.as_u64() {
+                                                        if i <= u8::MAX as u64 {
+                                                            let num_u8 = i as u8;
+                                                            _file_bytes.push(num_u8);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            files.append(PyBytes::new(py, &_file_bytes)).unwrap();
+                                        } else if let Value::Number(content) = file_data {
+                                            // file char
+                                            if let Some(i) = content.as_u64() {
+                                                if i <= u8::MAX as u64 {
+                                                    let num_u8 = i as u8;
+                                                    file_bytes.push(num_u8);
+                                                }
+                                            }
+                                        } else {
+                                            _dict.set_item(file_name, py.None()).unwrap();
+                                        }
+                                    }
+                                    if single {
+                                        _dict.set_item(file_name, PyBytes::new(py, &file_bytes)).unwrap();
+                                    } else {
+                                        _dict.set_item(file_name, files).unwrap();
+                                    }
+                                } else {
+                                    _dict.set_item(file_name, py.None()).unwrap();
+                                }
+                            }
+                        }
+                        _ => {
+                            _dict = PyDict::new(py);
+                        }
+                    }
+                    dict.set_item(field, _dict).unwrap();
                 }
                 dict.into_py(py)
             }
@@ -82,7 +136,7 @@ impl ToPyObject for Request {
 
 async fn handle_multipart(
     mut payload: Multipart,
-    files: &mut HashMap<String, Vec<u8>>,
+    files: &mut HashMap<String, Value>,
     form_data: &mut HashMap<String, Value>,
     body: &mut Vec<u8>,
 ) -> Result<(), Error> {
@@ -106,7 +160,30 @@ async fn handle_multipart(
         body.extend_from_slice(&data.clone());
 
         if let Some(name) = file_name {
-            files.insert(name, data);
+            match files.get(field_name) {
+                Some(f) => match f {
+                    Value::Array(f) => {
+                        let mut _f = f.clone();
+                        let mut file_map = serde_json::Map::new();
+                        file_map.insert(name, data.into());
+                        _f.push(serde_json::Value::Object(file_map));
+                        files.insert(field_name.to_owned(), serde_json::Value::Array(_f));
+                    }
+                    _ => {
+                        let mut file_map = serde_json::Map::new();
+                        file_map.insert(name, data.into());
+                        files.insert(
+                            field_name.to_owned(),
+                            vec![f.clone(), serde_json::Value::Object(file_map)].into(),
+                        );
+                    }
+                },
+                None => {
+                    let mut file_map = serde_json::Map::new();
+                    file_map.insert(name, data.into());
+                    files.insert(field_name.to_owned(), serde_json::Value::Object(file_map));
+                }
+            };
         } else if let Ok(value) = String::from_utf8(data) {
             form_data_handler(form_data, field_name, &value)?;
         }
@@ -303,7 +380,6 @@ impl PyRequest {
             // let parsed_json = fun.call1((python_string,))?;
 
             // Ok(parsed_json.into_py(py))
-
             Ok(python_string) => match serde_json::from_str(python_string.extract()?) {
                 Ok(map) => {
                     let dict = value_to_pydict(py, &map)?;
@@ -346,8 +422,7 @@ fn value_to_pyany(py: Python, val: &Value) -> PyResult<Py<PyAny>> {
         }
         Value::String(s) => s.into_py(py),
         Value::Array(arr) => {
-            let py_list =
-                PyList::new(py, arr.iter().map(|v| value_to_pyany(py, v).unwrap()));
+            let py_list = PyList::new(py, arr.iter().map(|v| value_to_pyany(py, v).unwrap()));
             py_list.into_py(py)
         }
         Value::Object(_) => value_to_pydict(py, val)?.into_py(py),
@@ -355,24 +430,40 @@ fn value_to_pyany(py: Python, val: &Value) -> PyResult<Py<PyAny>> {
     Ok(object)
 }
 
-fn form_data_handler(form_data: &mut HashMap<String, Value>, key: &str, value: &str) -> Result<(), Error> {
+fn form_data_handler(
+    form_data: &mut HashMap<String, Value>,
+    key: &str,
+    value: &str,
+) -> Result<(), Error> {
     match form_data.get(key) {
-        Some(v) => {
-            match v {
-                Value::Array(vs) => {
-                    let mut _vs = vs.clone();
-                    _vs.push(serde_json::Value::String(percent_decode(value.as_bytes()).decode_utf8()?.into_owned()));
-                    form_data.insert(key.to_owned(), serde_json::Value::Array(_vs));
-                },
-                _ => {
-                    form_data.insert(key.to_owned(), vec![v.clone(), serde_json::Value::String(percent_decode(value.as_bytes()).decode_utf8()?.into_owned())].into());
-                },
+        Some(v) => match v {
+            Value::Array(vs) => {
+                let mut _vs = vs.clone();
+                _vs.push(serde_json::Value::String(
+                    percent_decode(value.as_bytes()).decode_utf8()?.into_owned(),
+                ));
+                form_data.insert(key.to_owned(), serde_json::Value::Array(_vs));
+            }
+            _ => {
+                form_data.insert(
+                    key.to_owned(),
+                    vec![
+                        v.clone(),
+                        serde_json::Value::String(
+                            percent_decode(value.as_bytes()).decode_utf8()?.into_owned(),
+                        ),
+                    ]
+                    .into(),
+                );
             }
         },
         None => {
             form_data.insert(
                 key.to_owned(),
-                percent_decode(value.as_bytes()).decode_utf8()?.into_owned().into(),
+                percent_decode(value.as_bytes())
+                    .decode_utf8()?
+                    .into_owned()
+                    .into(),
             );
         }
     };


### PR DESCRIPTION
## Description

This PR fixes #954

## Summary

1. Add serde_urlencoded dependencies to parse simple form data
2. Update `request.form_data` for parsing of simple form data
3. Add simple form data case
4. Use Value to PyDict instead of the default turn String
5. Replace the form_data type
6. Add form_data transformation logic
7. Replace the files type
8. Use Value to restore the original structure of files
9. Add files transformation logic

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [ ] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sansyrox/robyn#%EF%B8%8F-to-develop-locally) on your PR.

