### PR TITLE
fix: crashes on ctrl + c

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::{Arc, RwLock};
 
-use std::process::abort;
+use std::process::exit;
 use std::{env, thread};
 
 use actix_files::Files;
@@ -230,7 +230,7 @@ impl Server {
                     Ok(())
                 })
             })?;
-            abort();
+           exit(0);
         }
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -230,7 +230,7 @@ impl Server {
                     Ok(())
                 })
             })?;
-           exit(0);
+            exit(0);
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

This PR fixes Ctrl + C causing crashes on mac.

## Summary

This PR fixes Ctrl + C causing crashes on mac.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

