### PR TITLE
fix: set_response_header breaking openapi doc rendering

### DIFF
--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -491,12 +491,11 @@ Either, by using the `headers` field in the `Response` object:
 ### Global Response Headers
 
 <Row>
-<Col>
-Or setting the Headers globally *per* router.
-</Col>
-<Col>
 
+{' '}
+<Col>Or setting the Headers globally *per* router.</Col>
 
+  <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
     ```python {{ title: 'untyped' }}
@@ -507,16 +506,14 @@ Or setting the Headers globally *per* router.
     app.add_response_header("content-type", "application/json")
     ```
     </CodeGroup>
-  </Col>
-</Row>
 
-<Row>
+  </Col>
+
 <Col>
 `add_response_header` appends the header to the list of headers, while `set_response_header` replaces the header if it exists.
 </Col>
 <Col>
 
-
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
     ```python {{ title: 'untyped' }}
@@ -527,7 +524,25 @@ Or setting the Headers globally *per* router.
     app.set_response_header("content-type", "application/json")
     ```
     </CodeGroup>
+
   </Col>
+  
+<Col>
+You can disable some routes from the application of response with `exclude_response_headers`.
+</Col>
+<Col>
+    <CodeGroup title="Request" tag="GET" label="/hello_world">
+
+    ```python {{ title: 'untyped' }}
+    app.exclude_response_headers(["/login", "/signup"])
+    ```
+
+    ```python {{title: 'typed'}}
+    app.exclude_response_headers(["/login", "/signup"])
+    ```
+    </CodeGroup>
+
+</Col>
 </Row>
 
 ### Cookies

--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -594,17 +594,17 @@ Either, by using the `headers` field in the `Response` object:
   </Col>
   
 <Col>
-To prevent the headers from getting applied to certain endpoints, you can use the `response_headers_exclude` function.
+To prevent the headers from getting applied to certain endpoints, you can use the `exclude_response_headers_for` function.
 </Col>
 <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
     ```python {{ title: 'untyped' }}
-    app.response_headers_exclude(["/login", "/signup"])
+    app.exclude_response_headers_for(["/login", "/signup"])
     ```
 
     ```python {{title: 'typed'}}
-    app.response_headers_exclude(["/login", "/signup"])
+    app.exclude_response_headers_for(["/login", "/signup"])
     ```
     </CodeGroup>
 

--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -492,7 +492,6 @@ Either, by using the `headers` field in the `Response` object:
 
 <Row>
 
-{' '}
 <Col>Or setting the Headers globally *per* router.</Col>
 
   <Col>
@@ -528,7 +527,7 @@ Either, by using the `headers` field in the `Response` object:
   </Col>
   
 <Col>
-You can disable some routes from the application of response with `exclude_response_headers`.
+You can disable some routes from the application of response headers with `exclude_response_headers`.
 </Col>
 <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">

--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -594,7 +594,7 @@ Either, by using the `headers` field in the `Response` object:
   </Col>
   
 <Col>
-You can disable some routes from the application of response headers with `exclude_response_headers`.
+To prevent the headers from getting applied to certain endpoints, you can use the `exclude_response_headers` function.
 </Col>
 <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">

--- a/docs_src/src/pages/documentation/api_reference/getting_started.mdx
+++ b/docs_src/src/pages/documentation/api_reference/getting_started.mdx
@@ -594,17 +594,17 @@ Either, by using the `headers` field in the `Response` object:
   </Col>
   
 <Col>
-To prevent the headers from getting applied to certain endpoints, you can use the `exclude_response_headers` function.
+To prevent the headers from getting applied to certain endpoints, you can use the `response_headers_exclude` function.
 </Col>
 <Col>
     <CodeGroup title="Request" tag="GET" label="/hello_world">
 
     ```python {{ title: 'untyped' }}
-    app.exclude_response_headers(["/login", "/signup"])
+    app.response_headers_exclude(["/login", "/signup"])
     ```
 
     ```python {{title: 'typed'}}
-    app.exclude_response_headers(["/login", "/signup"])
+    app.response_headers_exclude(["/login", "/signup"])
     ```
     </CodeGroup>
 

--- a/integration_tests/test_openapi.py
+++ b/integration_tests/test_openapi.py
@@ -5,13 +5,20 @@ from integration_tests.helpers.http_methods_helpers import get
 
 @pytest.mark.benchmark
 def test_docs_handler():
+    # should_check_response = False because check_response raises a
+    # failure if the global headers are not present in the response
+    # provided we are excluding headers for /docs and /openapi.json
     html_response = get("/docs", should_check_response=False)
     assert html_response.status_code == 200
 
 
 @pytest.mark.benchmark
 def test_json_handler():
-    openapi_spec = get("/openapi.json").json()
+    openapi_response = get("/openapi.json", should_check_response=False)
+
+    assert openapi_response.status_code == 200
+
+    openapi_spec = openapi_response.json()
 
     assert isinstance(openapi_spec, dict)
     assert "openapi" in openapi_spec
@@ -24,7 +31,11 @@ def test_json_handler():
 
 @pytest.mark.benchmark
 def test_add_openapi_path():
-    openapi_spec = get("/openapi.json").json()
+    openapi_response = get("/openapi.json", should_check_response=False)
+
+    assert openapi_response.status_code == 200
+
+    openapi_spec = openapi_response.json()
 
     assert isinstance(openapi_spec, dict)
 
@@ -41,7 +52,11 @@ def test_add_openapi_path():
 
 @pytest.mark.benchmark
 def test_add_subrouter_paths():
-    openapi_spec = get("/openapi.json").json()
+    openapi_response = get("/openapi.json", should_check_response=False)
+
+    assert openapi_response.status_code == 200
+
+    openapi_spec = openapi_response.json()
 
     assert isinstance(openapi_spec, dict)
 
@@ -58,7 +73,11 @@ def test_add_subrouter_paths():
 
 @pytest.mark.benchmark
 def test_openapi_request_body():
-    openapi_spec = get("/openapi.json").json()
+    openapi_response = get("/openapi.json", should_check_response=False)
+
+    assert openapi_response.status_code == 200
+
+    openapi_spec = openapi_response.json()
 
     assert isinstance(openapi_spec, dict)
 
@@ -118,7 +137,11 @@ def test_openapi_request_body():
 
 @pytest.mark.benchmark
 def test_openapi_response_body():
-    openapi_spec = get("/openapi.json").json()
+    openapi_response = get("/openapi.json", should_check_response=False)
+
+    assert openapi_response.status_code == 200
+
+    openapi_spec = openapi_response.json()
 
     assert isinstance(openapi_spec, dict)
 

--- a/integration_tests/test_openapi.py
+++ b/integration_tests/test_openapi.py
@@ -176,7 +176,11 @@ def test_openapi_response_body():
 
 @pytest.mark.benchmark
 def test_openapi_query_params():
-    openapi_spec = get("/openapi.json").json()
+    openapi_response = get("/openapi.json", should_check_response=False)
+
+    assert openapi_response.status_code == 200
+
+    openapi_spec = openapi_response.json()
 
     assert isinstance(openapi_spec, dict)
 

--- a/integration_tests/test_openapi.py
+++ b/integration_tests/test_openapi.py
@@ -5,7 +5,7 @@ from integration_tests.helpers.http_methods_helpers import get
 
 @pytest.mark.benchmark
 def test_docs_handler():
-    html_response = get("/docs")
+    html_response = get("/docs", should_check_response=False)
     assert html_response.status_code == 200
 
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -200,6 +200,9 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
+    def exclude_response_headers(self, exclude_paths: Optional[list[str]]):
+        self.response_headers.set_exclude_paths(exclude_paths)
+
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:
         self.web_socket_router.add_route(endpoint, ws)
 
@@ -235,6 +238,7 @@ class Robyn:
         if not self.config.disable_openapi:
             self.add_route(route_type=HttpMethod.GET, endpoint="/openapi.json", handler=self.openapi.get_openapi_config, is_const=True)
             self.add_route(route_type=HttpMethod.GET, endpoint="/docs", handler=self.openapi.get_openapi_docs_page, is_const=True)
+            self.exclude_response_headers(["/docs"])
             logger.info("Docs hosted at http://%s:%s/docs", host, port)
 
         host = os.getenv("ROBYN_HOST", host)

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -201,6 +201,10 @@ class Robyn:
         self.response_headers.set(key, value)
 
     def exclude_response_headers(self, exclude_paths: Optional[List[str]]):
+        """
+        To disable certain routes from the application of response headers
+        @param exclude_paths: the paths to exclude response headers from
+        """
         self.response_headers.set_exclude_paths(exclude_paths)
 
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -242,6 +242,7 @@ class Robyn:
             is_const=True,
             auth_required=auth_required,
         )
+        self.exclude_response_headers(["/docs"])
 
     def start(self, host: str = "127.0.0.1", port: int = 8080, _check_port: bool = True):
         """
@@ -251,11 +252,6 @@ class Robyn:
         :param port int: represents the port number at which the server is listening
         :param _check_port bool: represents if the port should be checked if it is already in use
         """
-        if not self.config.disable_openapi:
-            self.add_route(route_type=HttpMethod.GET, endpoint="/openapi.json", handler=self.openapi.get_openapi_config, is_const=True)
-            self.add_route(route_type=HttpMethod.GET, endpoint="/docs", handler=self.openapi.get_openapi_docs_page, is_const=True)
-            self.exclude_response_headers(["/docs"])
-            logger.info("Docs hosted at http://%s:%s/docs", host, port)
 
         host = os.getenv("ROBYN_HOST", host)
         port = int(os.getenv("ROBYN_PORT", port))

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -201,7 +201,7 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def response_headers_exclude(self, exclude_paths: Optional[List[str]]):
+    def exclude_response_headers_for(self, exclude_paths: Optional[List[str]]):
         """
         To disable certain routes from the application of response headers
         @param exclude_paths: the paths to exclude response headers from
@@ -247,7 +247,7 @@ class Robyn:
             is_const=True,
             auth_required=auth_required,
         )
-        self.response_headers_exclude(["/docs", "/openapi.json"])
+        self.exclude_response_headers_for(["/docs", "/openapi.json"])
 
     def start(self, host: str = "127.0.0.1", port: int = 8080, _check_port: bool = True):
         """

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -200,7 +200,7 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def exclude_response_headers(self, exclude_paths: Optional[list[str]]):
+    def exclude_response_headers(self, exclude_paths: Optional[List[str]]):
         self.response_headers.set_exclude_paths(exclude_paths)
 
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -201,7 +201,7 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def exclude_response_headers(self, exclude_paths: Optional[List[str]]):
+    def response_headers_exclude(self, exclude_paths: Optional[List[str]]):
         """
         To disable certain routes from the application of response headers
         @param exclude_paths: the paths to exclude response headers from
@@ -247,7 +247,7 @@ class Robyn:
             is_const=True,
             auth_required=auth_required,
         )
-        self.exclude_response_headers(["/docs", "/openapi.json"])
+        self.response_headers_exclude(["/docs", "/openapi.json"])
 
     def start(self, host: str = "127.0.0.1", port: int = 8080, _check_port: bool = True):
         """

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -201,12 +201,12 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def exclude_response_headers_for(self, exclude_paths: Optional[List[str]]):
+    def exclude_response_headers_for(self, excluded_paths: Optional[List[str]]):
         """
         To exclude response headers from certain routes
         @param exclude_paths: the paths to exclude response headers from
         """
-        self.header_exclude_paths = exclude_paths
+        self.excluded_response_header_paths = exclude_paths
 
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:
         self.web_socket_router.add_route(endpoint, ws)

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -70,7 +70,7 @@ class Robyn:
         self.web_socket_router = WebSocketRouter()
         self.request_headers: Headers = Headers({})
         self.response_headers: Headers = Headers({})
-        self.excluded_response_header_paths: Optional[List[str]] = None
+        self.excluded_response_headers_paths: Optional[List[str]] = None
         self.directories: List[Directory] = []
         self.event_handlers = {}
         self.exception_handler: Optional[Callable] = None

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -203,7 +203,7 @@ class Robyn:
 
     def exclude_response_headers_for(self, exclude_paths: Optional[List[str]]):
         """
-        To disable certain routes from the application of response headers
+        To exclude response headers from certain routes
         @param exclude_paths: the paths to exclude response headers from
         """
         self.header_exclude_paths = exclude_paths

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -70,6 +70,7 @@ class Robyn:
         self.web_socket_router = WebSocketRouter()
         self.request_headers: Headers = Headers({})
         self.response_headers: Headers = Headers({})
+        self.header_exclude_paths: Optional[List[str]] = None
         self.directories: List[Directory] = []
         self.event_handlers = {}
         self.exception_handler: Optional[Callable] = None
@@ -205,7 +206,7 @@ class Robyn:
         To disable certain routes from the application of response headers
         @param exclude_paths: the paths to exclude response headers from
         """
-        self.response_headers.set_exclude_paths(exclude_paths)
+        self.header_exclude_paths = exclude_paths
 
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:
         self.web_socket_router.add_route(endpoint, ws)
@@ -292,6 +293,7 @@ class Robyn:
             self.config.workers,
             self.config.processes,
             self.response_headers,
+            self.header_exclude_paths,
             open_browser,
         )
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -246,7 +246,7 @@ class Robyn:
             is_const=True,
             auth_required=auth_required,
         )
-        self.exclude_response_headers(["/docs"])
+        self.exclude_response_headers(["/docs", "/openapi.json"])
 
     def start(self, host: str = "127.0.0.1", port: int = 8080, _check_port: bool = True):
         """

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -70,7 +70,7 @@ class Robyn:
         self.web_socket_router = WebSocketRouter()
         self.request_headers: Headers = Headers({})
         self.response_headers: Headers = Headers({})
-        self.header_exclude_paths: Optional[List[str]] = None
+        self.excluded_response_header_paths: Optional[List[str]] = None
         self.directories: List[Directory] = []
         self.event_handlers = {}
         self.exception_handler: Optional[Callable] = None
@@ -201,12 +201,12 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def exclude_response_headers_for(self, excluded_paths: Optional[List[str]]):
+    def exclude_response_headers_for(self, excluded_response_header_paths: Optional[List[str]]):
         """
         To exclude response headers from certain routes
         @param exclude_paths: the paths to exclude response headers from
         """
-        self.excluded_response_header_paths = exclude_paths
+        self.excluded_response_header_paths = excluded_response_header_paths
 
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:
         self.web_socket_router.add_route(endpoint, ws)
@@ -293,7 +293,7 @@ class Robyn:
             self.config.workers,
             self.config.processes,
             self.response_headers,
-            self.header_exclude_paths,
+            self.excluded_response_header_paths,
             open_browser,
         )
 

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -27,7 +27,7 @@ def run_processes(
     workers: int,
     processes: int,
     response_headers: Headers,
-    response_header_exclude_paths: Optional[List[str]],
+    excluded_response_header_paths: Optional[List[str]],
     open_browser: bool,
 ) -> List[Process]:
     socket = SocketHeld(url, port)
@@ -44,7 +44,7 @@ def run_processes(
         workers,
         processes,
         response_headers,
-        response_header_exclude_paths,
+        excluded_response_header_paths,
     )
 
     def terminating_signal_handler(_sig, _frame):
@@ -78,7 +78,7 @@ def init_processpool(
     workers: int,
     processes: int,
     response_headers: Headers,
-    response_header_exclude_paths: Optional[List[str]],
+    excluded_response_header_paths: Optional[List[str]],
 ) -> List[Process]:
     process_pool = []
     if sys.platform.startswith("win32") or processes == 1:
@@ -149,7 +149,7 @@ def spawn_process(
     socket: SocketHeld,
     workers: int,
     response_headers: Headers,
-    response_header_exclude_paths: Optional[List[str]],
+    excluded_response_header_paths: Optional[List[str]],
 ):
     """
     This function is called by the main process handler to create a server runtime.

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -93,7 +93,7 @@ def init_processpool(
             socket,
             workers,
             response_headers,
-            response_header_exclude_paths,
+            excluded_response_header_paths,
         )
 
         return process_pool
@@ -113,7 +113,7 @@ def init_processpool(
                 copied_socket,
                 workers,
                 response_headers,
-                response_header_exclude_paths,
+                excluded_response_header_paths,
             ),
         )
         process.start()
@@ -179,7 +179,7 @@ def spawn_process(
 
     server.apply_response_headers(response_headers)
 
-    server.set_response_header_exclude_paths(response_header_exclude_paths)
+    server.set_response_header_exclude_paths(excluded_response_header_paths)
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -27,7 +27,7 @@ def run_processes(
     workers: int,
     processes: int,
     response_headers: Headers,
-    header_exclude_paths: Optional[List[str]],
+    response_header_exclude_paths: Optional[List[str]],
     open_browser: bool,
 ) -> List[Process]:
     socket = SocketHeld(url, port)
@@ -44,7 +44,7 @@ def run_processes(
         workers,
         processes,
         response_headers,
-        header_exclude_paths,
+        response_header_exclude_paths,
     )
 
     def terminating_signal_handler(_sig, _frame):
@@ -78,7 +78,7 @@ def init_processpool(
     workers: int,
     processes: int,
     response_headers: Headers,
-    header_exclude_paths: Optional[List[str]],
+    response_header_exclude_paths: Optional[List[str]],
 ) -> List[Process]:
     process_pool = []
     if sys.platform.startswith("win32") or processes == 1:
@@ -93,7 +93,7 @@ def init_processpool(
             socket,
             workers,
             response_headers,
-            header_exclude_paths,
+            response_header_exclude_paths,
         )
 
         return process_pool
@@ -113,7 +113,7 @@ def init_processpool(
                 copied_socket,
                 workers,
                 response_headers,
-                header_exclude_paths,
+                response_header_exclude_paths,
             ),
         )
         process.start()
@@ -149,7 +149,7 @@ def spawn_process(
     socket: SocketHeld,
     workers: int,
     response_headers: Headers,
-    header_exclude_paths: Optional[List[str]],
+    response_header_exclude_paths: Optional[List[str]],
 ):
     """
     This function is called by the main process handler to create a server runtime.
@@ -179,7 +179,7 @@ def spawn_process(
 
     server.apply_response_headers(response_headers)
 
-    server.set_response_header_exclude_paths(header_exclude_paths)
+    server.set_response_header_exclude_paths(response_header_exclude_paths)
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -2,7 +2,7 @@ import asyncio
 import signal
 import sys
 import webbrowser
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from multiprocess import Process
 
@@ -27,6 +27,7 @@ def run_processes(
     workers: int,
     processes: int,
     response_headers: Headers,
+    header_exclude_paths: Optional[List[str]],
     open_browser: bool,
 ) -> List[Process]:
     socket = SocketHeld(url, port)
@@ -43,6 +44,7 @@ def run_processes(
         workers,
         processes,
         response_headers,
+        header_exclude_paths,
     )
 
     def terminating_signal_handler(_sig, _frame):
@@ -76,6 +78,7 @@ def init_processpool(
     workers: int,
     processes: int,
     response_headers: Headers,
+    header_exclude_paths: Optional[List[str]],
 ) -> List[Process]:
     process_pool = []
     if sys.platform.startswith("win32") or processes == 1:
@@ -90,6 +93,7 @@ def init_processpool(
             socket,
             workers,
             response_headers,
+            header_exclude_paths,
         )
 
         return process_pool
@@ -109,6 +113,7 @@ def init_processpool(
                 copied_socket,
                 workers,
                 response_headers,
+                header_exclude_paths,
             ),
         )
         process.start()
@@ -144,6 +149,7 @@ def spawn_process(
     socket: SocketHeld,
     workers: int,
     response_headers: Headers,
+    header_exclude_paths: Optional[List[str]],
 ):
     """
     This function is called by the main process handler to create a server runtime.
@@ -172,6 +178,8 @@ def spawn_process(
     server.apply_request_headers(request_headers)
 
     server.apply_response_headers(response_headers)
+
+    server.set_exclude_paths(header_exclude_paths)
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -179,7 +179,7 @@ def spawn_process(
 
     server.apply_response_headers(response_headers)
 
-    server.set_exclude_paths(header_exclude_paths)
+    server.set_response_header_exclude_paths(header_exclude_paths)
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -179,7 +179,7 @@ def spawn_process(
 
     server.apply_response_headers(response_headers)
 
-    server.set_response_headers_exclude_paths(excluded_response_header_paths)
+    server.set_response_headers_exclude_paths(excluded_response_headers_paths)
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -27,7 +27,7 @@ def run_processes(
     workers: int,
     processes: int,
     response_headers: Headers,
-    excluded_response_header_paths: Optional[List[str]],
+    excluded_response_headers_paths: Optional[List[str]],
     open_browser: bool,
 ) -> List[Process]:
     socket = SocketHeld(url, port)
@@ -44,7 +44,7 @@ def run_processes(
         workers,
         processes,
         response_headers,
-        excluded_response_header_paths,
+        excluded_response_headers_paths,
     )
 
     def terminating_signal_handler(_sig, _frame):
@@ -78,7 +78,7 @@ def init_processpool(
     workers: int,
     processes: int,
     response_headers: Headers,
-    excluded_response_header_paths: Optional[List[str]],
+    excluded_response_headers_paths: Optional[List[str]],
 ) -> List[Process]:
     process_pool = []
     if sys.platform.startswith("win32") or processes == 1:
@@ -93,7 +93,7 @@ def init_processpool(
             socket,
             workers,
             response_headers,
-            excluded_response_header_paths,
+            excluded_response_headers_paths,
         )
 
         return process_pool
@@ -113,7 +113,7 @@ def init_processpool(
                 copied_socket,
                 workers,
                 response_headers,
-                excluded_response_header_paths,
+                excluded_response_headers_paths,
             ),
         )
         process.start()
@@ -149,7 +149,7 @@ def spawn_process(
     socket: SocketHeld,
     workers: int,
     response_headers: Headers,
-    excluded_response_header_paths: Optional[List[str]],
+    excluded_response_headers_paths: Optional[List[str]],
 ):
     """
     This function is called by the main process handler to create a server runtime.
@@ -179,7 +179,7 @@ def spawn_process(
 
     server.apply_response_headers(response_headers)
 
-    server.set_response_header_exclude_paths(excluded_response_header_paths)
+    server.set_response_headers_exclude_paths(excluded_response_header_paths)
 
     for route in routes:
         route_type, endpoint, function, is_const = route

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -327,7 +327,7 @@ class Server:
         pass
     def apply_response_headers(self, headers: Headers) -> None:
         pass
-    def set_response_header_exclude_paths(self, response_header_exclude_paths: Optional[list[str]] = None):
+    def set_response_header_exclude_paths(self, excluded_response_header_paths: Optional[list[str]] = None):
         pass
 
     def add_route(

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -327,7 +327,7 @@ class Server:
         pass
     def apply_response_headers(self, headers: Headers) -> None:
         pass
-    def set_response_header_exclude_paths(self, excluded_response_header_paths: Optional[list[str]] = None):
+    def set_response_headers_exclude_paths(self, excluded_response_header_paths: Optional[list[str]] = None):
         pass
 
     def add_route(

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -177,8 +177,6 @@ class QueryParams:
         pass
 
 class Headers:
-    exclude_paths: Optional[list[str]] = None
-
     def __init__(self, default_headers: Optional[dict]) -> None:
         pass
 
@@ -242,9 +240,6 @@ class Headers:
         Returns:
             True if the headers are empty, False otherwise
         """
-        pass
-
-    def set_exclude_paths(self, exclude_paths: Optional[list[str]] = None):
         pass
 
 @dataclass
@@ -331,6 +326,8 @@ class Server:
     def apply_request_headers(self, headers: Headers) -> None:
         pass
     def apply_response_headers(self, headers: Headers) -> None:
+        pass
+    def set_exclude_paths(self, exclude_paths: Optional[list[str]] = None):
         pass
 
     def add_route(

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -327,7 +327,7 @@ class Server:
         pass
     def apply_response_headers(self, headers: Headers) -> None:
         pass
-    def set_exclude_paths(self, exclude_paths: Optional[list[str]] = None):
+    def set_response_header_exclude_paths(self, response_header_exclude_paths: Optional[list[str]] = None):
         pass
 
     def add_route(

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -177,6 +177,8 @@ class QueryParams:
         pass
 
 class Headers:
+    exclude_paths: Optional[list[str]] = None
+
     def __init__(self, default_headers: Optional[dict]) -> None:
         pass
 
@@ -240,6 +242,9 @@ class Headers:
         Returns:
             True if the headers are empty, False otherwise
         """
+        pass
+
+    def set_exclude_paths(self, exclude_paths: Optional[list[str]] = None):
         pass
 
 @dataclass

--- a/src/server.rs
+++ b/src/server.rs
@@ -73,7 +73,7 @@ impl Server {
             directories: Arc::new(RwLock::new(Vec::new())),
             startup_handler: None,
             shutdown_handler: None,
-            response_header_exclude_paths: None,
+            excluded_response_header_paths: None,
         }
     }
 
@@ -110,7 +110,7 @@ impl Server {
         let startup_handler = self.startup_handler.clone();
         let shutdown_handler = self.shutdown_handler.clone();
 
-        let response_header_exclude_paths = self.response_header_exclude_paths.clone();
+        let excluded_response_header_paths = self.excluded_response_header_paths.clone();
 
         let task_locals = pyo3_asyncio::TaskLocals::new(event_loop).copy_context(py)?;
         let task_locals_copy = task_locals.clone();
@@ -167,7 +167,7 @@ impl Server {
                         .app_data(web::Data::new(middleware_router.clone()))
                         .app_data(web::Data::new(global_request_headers.clone()))
                         .app_data(web::Data::new(global_response_headers.clone()))
-                        .app_data(web::Data::new(response_header_exclude_paths.clone()));
+                        .app_data(web::Data::new(excluded_response_header_paths.clone()));
 
                     let web_socket_map = web_socket_router.get_web_socket_map();
                     for (elem, value) in (web_socket_map.read()).iter() {
@@ -308,7 +308,7 @@ impl Server {
         &mut self,
         excluded_response_header_paths: Option<Vec<String>>,
     ) {
-        self.response_header_exclude_paths = response_header_exclude_paths;
+        self.excluded_response_header_paths = excluded_response_header_paths;
     }
 
     /// Add a new route to the routing tables
@@ -428,7 +428,7 @@ async fn index(
     const_router: web::Data<Arc<ConstRouter>>,
     middleware_router: web::Data<Arc<MiddlewareRouter>>,
     global_request_response_headers: (web::Data<Arc<Headers>>, web::Data<Arc<Headers>>),
-    response_header_exclude_paths: web::Data<Option<Vec<String>>>,
+    excluded_response_header_paths: web::Data<Option<Vec<String>>>,
     req: HttpRequest,
 ) -> impl Responder {
     let mut request = Request::from_actix_request(&req, payload, &global_request_response_headers.0).await;

--- a/src/server.rs
+++ b/src/server.rs
@@ -452,6 +452,10 @@ async fn index(
 
     response.headers.extend(&global_response_headers);
 
+    if req.uri().path().eq("/docs") {
+        response.headers.append("Content-Type".to_string(), "text/html".to_string());
+    }
+
     debug!("Extended Response : {:?}", response);
 
     // After middleware

--- a/src/server.rs
+++ b/src/server.rs
@@ -452,10 +452,15 @@ async fn index(
 
     response.headers.extend(&global_response_headers);
 
-    if req.uri().path().eq("/docs") {
-        response
-            .headers
-            .append("Content-Type".to_string(), "text/html".to_string());
+    match &global_response_headers.exclude_paths {
+        None => {},
+        Some(exclude_paths) => {
+            if exclude_paths.contains(&req.uri().path().to_owned()) {
+                response
+                    .headers
+                    .remove_all();
+            }
+        },
     }
 
     debug!("Extended Response : {:?}", response);

--- a/src/server.rs
+++ b/src/server.rs
@@ -497,7 +497,7 @@ async fn index(
         None => {}
         Some(exclude_paths) => {
             if exclude_paths.contains(&req.uri().path().to_owned()) {
-                response.headers.remove_all();
+                response.headers.clear();
             }
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -453,7 +453,9 @@ async fn index(
     response.headers.extend(&global_response_headers);
 
     if req.uri().path().eq("/docs") {
-        response.headers.append("Content-Type".to_string(), "text/html".to_string());
+        response
+            .headers
+            .append("Content-Type".to_string(), "text/html".to_string());
     }
 
     debug!("Extended Response : {:?}", response);

--- a/src/server.rs
+++ b/src/server.rs
@@ -304,7 +304,10 @@ impl Server {
         self.global_response_headers = Arc::new(headers.clone());
     }
 
-    pub fn set_response_header_exclude_paths(&mut self, response_header_exclude_paths: Option<Vec<String>>) {
+    pub fn set_response_header_exclude_paths(
+        &mut self,
+        response_header_exclude_paths: Option<Vec<String>>,
+    ) {
         self.response_header_exclude_paths = response_header_exclude_paths;
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -205,8 +205,7 @@ impl Server {
                                         payload,
                                         const_router,
                                         middleware_router,
-                                        global_request_headers,
-                                        global_response_headers,
+                                        (global_request_headers,global_response_headers),
                                         exclude_paths,
                                         req,
                                     )
@@ -397,12 +396,11 @@ async fn index(
     payload: web::Payload,
     const_router: web::Data<Arc<ConstRouter>>,
     middleware_router: web::Data<Arc<MiddlewareRouter>>,
-    global_request_headers: web::Data<Arc<Headers>>,
-    global_response_headers: web::Data<Arc<Headers>>,
+    global_headers: (web::Data<Arc<Headers>>, web::Data<Arc<Headers>>),
     exclude_paths: web::Data<Option<Vec<String>>>,
     req: HttpRequest,
 ) -> impl Responder {
-    let mut request = Request::from_actix_request(&req, payload, &global_request_headers).await;
+    let mut request = Request::from_actix_request(&req, payload, &global_headers.0).await;
 
     // Before middleware
     // Global
@@ -462,7 +460,7 @@ async fn index(
 
     debug!("OG Response : {:?}", response);
 
-    response.headers.extend(&global_response_headers);
+    response.headers.extend(&global_headers.1);
 
     match &exclude_paths.get_ref() {
         None => {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -205,7 +205,7 @@ impl Server {
                                         payload,
                                         const_router,
                                         middleware_router,
-                                        (global_request_headers,global_response_headers),
+                                        (global_request_headers, global_response_headers),
                                         exclude_paths,
                                         req,
                                     )

--- a/src/server.rs
+++ b/src/server.rs
@@ -110,7 +110,7 @@ impl Server {
         let startup_handler = self.startup_handler.clone();
         let shutdown_handler = self.shutdown_handler.clone();
 
-        let excluded_response_header_paths = self.excluded_response_header_paths.clone();
+        let excluded_response_headers_paths = self.excluded_response_headers_paths.clone();
 
         let task_locals = pyo3_asyncio::TaskLocals::new(event_loop).copy_context(py)?;
         let task_locals_copy = task_locals.clone();

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,11 +427,11 @@ async fn index(
     payload: web::Payload,
     const_router: web::Data<Arc<ConstRouter>>,
     middleware_router: web::Data<Arc<MiddlewareRouter>>,
-    global_headers: (web::Data<Arc<Headers>>, web::Data<Arc<Headers>>),
+    global_request_response_headers: (web::Data<Arc<Headers>>, web::Data<Arc<Headers>>),
     response_header_exclude_paths: web::Data<Option<Vec<String>>>,
     req: HttpRequest,
 ) -> impl Responder {
-    let mut request = Request::from_actix_request(&req, payload, &global_headers.0).await;
+    let mut request = Request::from_actix_request(&req, payload, &global_request_response_headers.0).await;
 
     // Before middleware
     // Global
@@ -491,7 +491,7 @@ async fn index(
 
     debug!("OG Response : {:?}", response);
 
-    response.headers.extend(&global_headers.1);
+    response.headers.extend(&global_request_response_headers.1);
 
     match &response_header_exclude_paths.get_ref() {
         None => {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,7 +56,7 @@ pub struct Server {
     directories: Arc<RwLock<Vec<Directory>>>,
     startup_handler: Option<Arc<FunctionInfo>>,
     shutdown_handler: Option<Arc<FunctionInfo>>,
-    exclude_paths: Option<Vec<String>>,
+    response_header_exclude_paths: Option<Vec<String>>,
 }
 
 #[pymethods]
@@ -73,7 +73,7 @@ impl Server {
             directories: Arc::new(RwLock::new(Vec::new())),
             startup_handler: None,
             shutdown_handler: None,
-            exclude_paths: None,
+            response_header_exclude_paths: None,
         }
     }
 
@@ -110,7 +110,7 @@ impl Server {
         let startup_handler = self.startup_handler.clone();
         let shutdown_handler = self.shutdown_handler.clone();
 
-        let exclude_paths = self.exclude_paths.clone();
+        let response_header_exclude_paths = self.response_header_exclude_paths.clone();
 
         let task_locals = pyo3_asyncio::TaskLocals::new(event_loop).copy_context(py)?;
         let task_locals_copy = task_locals.clone();
@@ -167,7 +167,7 @@ impl Server {
                         .app_data(web::Data::new(middleware_router.clone()))
                         .app_data(web::Data::new(global_request_headers.clone()))
                         .app_data(web::Data::new(global_response_headers.clone()))
-                        .app_data(web::Data::new(exclude_paths.clone()));
+                        .app_data(web::Data::new(response_header_exclude_paths.clone()));
 
                     let web_socket_map = web_socket_router.get_web_socket_map();
                     for (elem, value) in (web_socket_map.read()).iter() {
@@ -199,7 +199,7 @@ impl Server {
                                   payload: web::Payload,
                                   global_request_headers,
                                   global_response_headers,
-                                  exclude_paths,
+                                  response_header_exclude_paths,
                                   req| {
                                 pyo3_asyncio::tokio::scope_local(task_locals.clone(), async move {
                                     index(
@@ -208,7 +208,7 @@ impl Server {
                                         const_router,
                                         middleware_router,
                                         (global_request_headers, global_response_headers),
-                                        exclude_paths,
+                                        response_header_exclude_paths,
                                         req,
                                     )
                                     .await
@@ -304,8 +304,8 @@ impl Server {
         self.global_response_headers = Arc::new(headers.clone());
     }
 
-    pub fn set_exclude_paths(&mut self, exclude_paths: Option<Vec<String>>) {
-        self.exclude_paths = exclude_paths;
+    pub fn set_response_header_exclude_paths(&mut self, response_header_exclude_paths: Option<Vec<String>>) {
+        self.response_header_exclude_paths = response_header_exclude_paths;
     }
 
     /// Add a new route to the routing tables
@@ -425,7 +425,7 @@ async fn index(
     const_router: web::Data<Arc<ConstRouter>>,
     middleware_router: web::Data<Arc<MiddlewareRouter>>,
     global_headers: (web::Data<Arc<Headers>>, web::Data<Arc<Headers>>),
-    exclude_paths: web::Data<Option<Vec<String>>>,
+    response_header_exclude_paths: web::Data<Option<Vec<String>>>,
     req: HttpRequest,
 ) -> impl Responder {
     let mut request = Request::from_actix_request(&req, payload, &global_headers.0).await;
@@ -490,7 +490,7 @@ async fn index(
 
     response.headers.extend(&global_headers.1);
 
-    match &exclude_paths.get_ref() {
+    match &response_header_exclude_paths.get_ref() {
         None => {}
         Some(exclude_paths) => {
             if exclude_paths.contains(&req.uri().path().to_owned()) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -453,14 +453,12 @@ async fn index(
     response.headers.extend(&global_response_headers);
 
     match &global_response_headers.exclude_paths {
-        None => {},
+        None => {}
         Some(exclude_paths) => {
             if exclude_paths.contains(&req.uri().path().to_owned()) {
-                response
-                    .headers
-                    .remove_all();
+                response.headers.remove_all();
             }
-        },
+        }
     }
 
     debug!("Extended Response : {:?}", response);

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,7 +56,7 @@ pub struct Server {
     directories: Arc<RwLock<Vec<Directory>>>,
     startup_handler: Option<Arc<FunctionInfo>>,
     shutdown_handler: Option<Arc<FunctionInfo>>,
-    response_header_exclude_paths: Option<Vec<String>>,
+    excluded_response_header_paths: Option<Vec<String>>,
 }
 
 #[pymethods]
@@ -306,7 +306,7 @@ impl Server {
 
     pub fn set_response_header_exclude_paths(
         &mut self,
-        response_header_exclude_paths: Option<Vec<String>>,
+        excluded_response_header_paths: Option<Vec<String>>,
     ) {
         self.response_header_exclude_paths = response_header_exclude_paths;
     }
@@ -493,7 +493,7 @@ async fn index(
 
     response.headers.extend(&global_request_response_headers.1);
 
-    match &response_header_exclude_paths.get_ref() {
+    match &excluded_response_header_paths.get_ref() {
         None => {}
         Some(exclude_paths) => {
             if exclude_paths.contains(&req.uri().path().to_owned()) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -498,8 +498,8 @@ async fn index(
 
     match &excluded_response_header_paths.get_ref() {
         None => {}
-        Some(exclude_paths) => {
-            if exclude_paths.contains(&req.uri().path().to_owned()) {
+        Some(excluded_response_header_paths) => {
+            if excluded_response_header_paths.contains(&req.uri().path().to_owned()) {
                 response.headers.clear();
             }
         }

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -9,7 +9,7 @@ use pyo3::types::{PyDict, PyList};
 #[derive(Clone, Debug, Default)]
 pub struct Headers {
     pub headers: DashMap<String, Vec<String>>,
-    pub exclude_paths: Option<Vec<String>>
+    pub exclude_paths: Option<Vec<String>>,
 }
 
 #[pymethods]
@@ -32,11 +32,14 @@ impl Headers {
                         headers.entry(key).or_insert_with(Vec::new).push(value);
                     }
                 }
-                Headers { headers: headers, exclude_paths: None }
+                Headers {
+                    headers,
+                    exclude_paths: None,
+                }
             }
             None => Headers {
                 headers: DashMap::new(),
-                exclude_paths: None
+                exclude_paths: None,
             },
         }
     }

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -9,7 +9,6 @@ use pyo3::types::{PyDict, PyList};
 #[derive(Clone, Debug, Default)]
 pub struct Headers {
     pub headers: DashMap<String, Vec<String>>,
-    pub exclude_paths: Option<Vec<String>>,
 }
 
 #[pymethods]
@@ -32,14 +31,10 @@ impl Headers {
                         headers.entry(key).or_insert_with(Vec::new).push(value);
                     }
                 }
-                Headers {
-                    headers,
-                    exclude_paths: None,
-                }
+                Headers { headers }
             }
             None => Headers {
                 headers: DashMap::new(),
-                exclude_paths: None,
             },
         }
     }
@@ -113,10 +108,6 @@ impl Headers {
 
     pub fn is_empty(&self) -> bool {
         self.headers.is_empty()
-    }
-
-    pub fn set_exclude_paths(&mut self, exclude_paths: Option<Vec<String>>) {
-        self.exclude_paths = exclude_paths;
     }
 
     fn __eq__(&self, other: &Headers) -> bool {

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -158,7 +158,7 @@ impl Headers {
         self.headers.remove(&key.to_lowercase());
     }
 
-    pub fn remove_all(&mut self) {
+    pub fn clear(&mut self) {
         self.headers.clear();
     }
 

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -9,6 +9,7 @@ use pyo3::types::{PyDict, PyList};
 #[derive(Clone, Debug, Default)]
 pub struct Headers {
     pub headers: DashMap<String, Vec<String>>,
+    pub exclude_paths: Option<Vec<String>>
 }
 
 #[pymethods]
@@ -31,10 +32,11 @@ impl Headers {
                         headers.entry(key).or_insert_with(Vec::new).push(value);
                     }
                 }
-                Headers { headers }
+                Headers { headers: headers, exclude_paths: None }
             }
             None => Headers {
                 headers: DashMap::new(),
+                exclude_paths: None
             },
         }
     }
@@ -110,6 +112,10 @@ impl Headers {
         self.headers.is_empty()
     }
 
+    pub fn set_exclude_paths(&mut self, exclude_paths: Option<Vec<String>>) {
+        self.exclude_paths = exclude_paths;
+    }
+
     fn __eq__(&self, other: &Headers) -> bool {
         if self.headers.is_empty() && other.headers.is_empty() {
             return true;
@@ -156,6 +162,10 @@ impl Headers {
 impl Headers {
     pub fn remove(&mut self, key: &str) {
         self.headers.remove(&key.to_lowercase());
+    }
+
+    pub fn remove_all(&mut self) {
+        self.headers.clear();
     }
 
     pub fn extend(&mut self, headers: &Headers) {


### PR DESCRIPTION
## Description

This PR fixes #976

## Summary

This PR fixes `set_response_header` breaking openapi doc rendering

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.