### PR TITLE
refactor: revamp add OpenAPI route

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -224,6 +224,22 @@ class Robyn:
         except Exception:
             raise Exception(f"Invalid port number: {port}")
 
+    def _add_openapi_routes(self, auth_required: bool = False):
+        self.add_route(
+            route_type=HttpMethod.GET,
+            endpoint="/openapi.json",
+            handler=self.openapi.get_openapi_config,
+            is_const=True,
+            auth_required=auth_required,
+        )
+        self.add_route(
+            route_type=HttpMethod.GET,
+            endpoint="/docs",
+            handler=self.openapi.get_openapi_docs_page,
+            is_const=True,
+            auth_required=auth_required,
+        )
+
     def start(self, host: str = "127.0.0.1", port: int = 8080, _check_port: bool = True):
         """
         Starts the server
@@ -232,10 +248,6 @@ class Robyn:
         :param port int: represents the port number at which the server is listening
         :param _check_port bool: represents if the port should be checked if it is already in use
         """
-        if not self.config.disable_openapi:
-            self.add_route(route_type=HttpMethod.GET, endpoint="/openapi.json", handler=self.openapi.get_openapi_config, is_const=True)
-            self.add_route(route_type=HttpMethod.GET, endpoint="/docs", handler=self.openapi.get_openapi_docs_page, is_const=True)
-            logger.info("Docs hosted at http://%s:%s/docs", host, port)
 
         host = os.getenv("ROBYN_HOST", host)
         port = int(os.getenv("ROBYN_PORT", port))
@@ -249,6 +261,10 @@ class Robyn:
                 except Exception:
                     logger.error("Invalid port number. Please enter a valid port number.")
                     continue
+
+        if not self.config.disable_openapi:
+            self._add_openapi_routes()
+            logger.info("Docs hosted at http://%s:%s/docs", host, port)
 
         logger.info("Robyn version: %s", __version__)
         logger.info("Starting server at http://%s:%s", host, port)


### PR DESCRIPTION
## Description

This PR fixes 

- OpenAPI routes should be added after `_check_port`
- `logger.info("Docs hosted at http://%s:%s/docs", host, port)` was not correct. It just ignored `ROBYN_HOST` and `ROBYN_PORT`

## Summary

- Extract adding OpenAPI routes
- Add `auth_required` argument for future implementation
- Adjust the order to output the correct log

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

