### PR TITLE
Initial static text url_for implementation

### DIFF
--- a/integration_tests/templates/test.html
+++ b/integration_tests/templates/test.html
@@ -8,6 +8,6 @@
 </head>
 
 <body>
-  <h1>{{framework}} 🤝 {{templating_engine}}</h1>
+  <h1>{{framework}} 🤝 {{templating_engine}} {{url_for()}} </h1>
 </body>
 </html>

--- a/integration_tests/test_get_requests.py
+++ b/integration_tests/test_get_requests.py
@@ -40,6 +40,7 @@ def test_template(function_type: str, session):
         assert r.text.startswith("\n\n<!DOCTYPE html>")
         assert "Jinja2" in r.text
         assert "Robyn" in r.text
+        assert "called new url_for" in r.text
 
     check_response(get(f"/{function_type}/template"))
 

--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -6,6 +6,16 @@ from robyn import status_codes
 
 from .robyn import Headers, Response
 
+def url_for() -> str:
+    """Creates a link to an endpoint function name
+
+    NOT YET IMPLEMENTED
+    #TODO
+    #FIXME
+    Returns:
+        str: the url for the function
+    """
+    return "called new url_for"
 
 class TemplateInterface(ABC):
     def __init__(self): ...
@@ -17,6 +27,7 @@ class TemplateInterface(ABC):
 class JinjaTemplate(TemplateInterface):
     def __init__(self, directory, encoding="utf-8", followlinks=False):
         self.env = Environment(loader=FileSystemLoader(searchpath=directory, encoding=encoding, followlinks=followlinks))
+        self.env.globals['url_for'] = url_for
 
     def render_template(self, template_name, **kwargs) -> Response:
         rendered_template = self.env.get_template(template_name).render(**kwargs)


### PR DESCRIPTION
## Description

This PR starts the process of implementing url_for so that Jinja templates can reference Robyn endpoints by function name rather than path see https://github.com/sparckles/Robyn/issues/996

## Summary

This PR adds a url_for that returns a fixed string and a test for this.

Changes are limited to 3 files
- templating.py (define the url_for function and add it to the global Jinja environment)
- template.html (display the output of url_for
- test_get_requests.py (add an assert to check the fixed string)

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [X ] The PR contains a descriptive title
- [ X] The PR contains a descriptive summary of the changes
- [ X] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation (I've added a docstring, until we get to the point where it can be used in a functional way I've not added it to the main documentation)
- [ X] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.
I think I've done that. I'm running the tests from a separate clone which I have had to modify to work with Python 3.12.7 (updated dependencies are the only changes)
