### PR TITLE
docs: fix typos in API Reference documentation

### DIFF
--- a/docs_src/src/pages/documentation/api_reference/using_rust_directly.mdx
+++ b/docs_src/src/pages/documentation/api_reference/using_rust_directly.mdx
@@ -44,7 +44,7 @@ The first thing you need to is to create a Rust file. Let's call it `hello_world
 
       #[pyfunction]
       fn square(n: i32) -> i32 {
-          n * n * n
+          n * n
           // this is another comment
       }
 

--- a/docs_src/src/pages/documentation/api_reference/views.mdx
+++ b/docs_src/src/pages/documentation/api_reference/views.mdx
@@ -84,7 +84,7 @@ You can serve views in two ways:
 
 <Row>
   <Col>
-  Using an `@app.view` decorator.
+  Using the `app.add_view` method.
   </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/hello_world">


### PR DESCRIPTION
## Description

This PR fixes a mistake found in the documentation for views. (I tried to match the terminology and style of surrounding documentation, but feel free to change the wording if you need to.)

## Summary

This PR changes:
> Using the `@app.view` decorator.

to:

> Using the `app.add_view` method.

to more accurately describe the following code sample:

```py
 from .views import sample_view

 ...
 ...

 app.add_view("/", sample_view)
```

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.