### PR TITLE
fix: disable openapi path

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -208,12 +208,12 @@ class Robyn:
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def exclude_response_headers_for(self, excluded_response_header_paths: Optional[List[str]]):
+    def exclude_response_headers_for(self, excluded_response_headers_paths: Optional[List[str]]):
         """
         To exclude response headers from certain routes
         @param exclude_paths: the paths to exclude response headers from
         """
-        self.excluded_response_header_paths = excluded_response_header_paths
+        self.excluded_response_headers_paths = excluded_response_headers_paths
 
     def add_web_socket(self, endpoint: str, ws: WebSocket) -> None:
         self.web_socket_router.add_route(endpoint, ws)
@@ -300,7 +300,7 @@ class Robyn:
             self.config.workers,
             self.config.processes,
             self.response_headers,
-            self.excluded_response_header_paths,
+            self.excluded_response_headers_paths,
             open_browser,
         )
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -327,7 +327,7 @@ class Server:
         pass
     def apply_response_headers(self, headers: Headers) -> None:
         pass
-    def set_response_headers_exclude_paths(self, excluded_response_header_paths: Optional[list[str]] = None):
+    def set_response_headers_exclude_paths(self, excluded_response_headers_paths: Optional[list[str]] = None):
         pass
 
     def add_route(


### PR DESCRIPTION
## Description

This PR fixes #1021

## Summary

This PR fixes `excluded_header_path` error

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

