### PR TITLE
Two tiny corrections found by mypy 1.13

### DIFF
--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -188,8 +188,8 @@ def spawn_process(
     for middleware_type, middleware_function in global_middlewares:
         server.add_global_middleware(middleware_type, middleware_function)
 
-    for route_type, endpoint, function in route_middlewares:
-        server.add_middleware_route(route_type, endpoint, function)
+    for http_route_type, endpoint, function in route_middlewares:
+        server.add_middleware_route(http_route_type, endpoint, function)
 
     if Events.STARTUP in event_handlers:
         server.add_startup_handler(event_handlers[Events.STARTUP])

--- a/robyn/ws.py
+++ b/robyn/ws.py
@@ -23,7 +23,7 @@ class WebSocket:
     def __init__(self, robyn_object: "Robyn", endpoint: str, config: Config = Config(), dependencies: DependencyMap = DependencyMap()) -> None:
         self.robyn_object = robyn_object
         self.endpoint = endpoint
-        self.methods = {}
+        self.methods: dict = {}
         self.config = config
         self.dependencies = dependencies
 


### PR DESCRIPTION
## Description

This PR fixes two problems found by the mypy typechecker.

processpool.py reuse of route_trype local var for two different actual types
ws.py was missing dict type `self.methods: dict = {}`
## PR Checklist

Please ensure that:

- [X ] The PR contains a descriptive title
- [ X] The PR contains a descriptive summary of the changes
- [ X] You build and test your changes before submitting a PR.
- [ X] You have added relevant documentation
- [ X] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ X] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

