### PR TITLE
Fix mypy issues in openapi.py with missing dict and use of typedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ poetry run test_server
 ```
 - Run tests
 ```
+pytest
+```
+For just integration tests use
+```
 pytest integration_tests
 ```
 - Test (refer to `integration_tests/base_routes.py` for more endpoints)

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, dataclass, field
 from importlib import resources
 from inspect import Signature
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from robyn.responses import html
 from robyn.robyn import QueryParams, Response
@@ -236,9 +236,9 @@ class OpenAPI:
         name: str,
         description: str,
         tags: List[str],
-        query_params: Optional[TypedDict],
-        request_body: Optional[TypedDict],
-        return_annotation: Optional[TypedDict],
+        query_params: Optional[Dict],
+        request_body: Optional[Dict],
+        return_annotation: Optional[Dict],
     ) -> Tuple[str, dict]:
         """
         Get the "path" openapi object according to spec
@@ -258,7 +258,7 @@ class OpenAPI:
         if not description:
             description = "No description provided"
 
-        openapi_path_object = {
+        openapi_path_object: dict = {
             "summary": name,
             "description": description,
             "parameters": [],
@@ -293,7 +293,7 @@ class OpenAPI:
                 endpoint_with_path_params_wrapped_in_braces += "/{" + path_param_name + "}"
 
         if query_params:
-            query_param_annotations = query_params.__annotations__ if query_params is TypedDict else typing.get_type_hints(query_params)
+            query_param_annotations = query_params.__annotations__ if query_params is Dict else typing.get_type_hints(query_params)
 
             for query_param in query_param_annotations:
                 query_param_type = self.get_openapi_type(query_param_annotations[query_param])
@@ -310,7 +310,7 @@ class OpenAPI:
         if request_body:
             properties = {}
 
-            request_body_annotations = request_body.__annotations__ if request_body is TypedDict else typing.get_type_hints(request_body)
+            request_body_annotations = request_body.__annotations__ if request_body is Dict else typing.get_type_hints(request_body)
 
             for body_item in request_body_annotations:
                 properties[body_item] = self.get_schema_object(body_item, request_body_annotations[body_item])
@@ -339,7 +339,7 @@ class OpenAPI:
 
         return endpoint_with_path_params_wrapped_in_braces, openapi_path_object
 
-    def get_openapi_type(self, typed_dict: TypedDict) -> str:
+    def get_openapi_type(self, typed_dict: Dict) -> str:
         """
         Get actual type from the TypedDict annotations
 
@@ -371,7 +371,7 @@ class OpenAPI:
         @return: dict the properties object
         """
 
-        properties = {
+        properties: dict = {
             "title": parameter.capitalize(),
         }
 


### PR DESCRIPTION
## Description

This PR fixes mypy issues in  openapi.py 

## Summary

This PR fixes the following

### TypedDict

all `TypedDict` replaced with `dict`
the python docs don't include any examples of using TypedDict for a variable, only as a class. 
mypy 1.13.0 complains about examples like this `query_params: Optional[TypedDict],` so I have changed them all to be like `query_params: Optional[Dict],` All tests still pass

MyPy error: `Variable "typing.TypedDict" is not valid as a type` 

This meant  changing a few tests from
```
query_param_annotations = query_params.__annotations__ if query_params is TypedDict else typing.get_type_hints(query_params)
```
to 
```
query_param_annotations = query_params.__annotations__ if query_params is Dict else typing.get_type_hints(query_params)
```

While the tests all pass I'm not sure if the logic of typing.get_type_hints still works for Dict vs TypedDict


### missing dict type

#### def get_path_obj variable openapi_path_object

This wasn't given a type which was causing multiple mypy errors:
```
openapi_path_object = {
...
                openapi_path_object["parameters"].append(
"Sequence[str]" has no attribute "append"
...
            openapi_path_object["requestBody"] = request_body_object
Incompatible types in assignment (expression has type "dict[str, dict[str, dict[str, dict[str, Collection[str]]]]]", target has type "Sequence[str]")
...
        openapi_path_object["responses"] = {"200": {"description": "Successful Response", "content": {response_type: {"schema": response_schema}}}}
Incompatible types in assignment (expression has type "dict[str, dict[str, Collection[str]]]", target has type "Sequence[str]")
```
all fixed by changing the declaration to:
```
        openapi_path_object: dict = {
```

####     def get_schema_object local variable properties

same as above. Change declaration to
```
        properties: dict = {
```
all the similar warnings are gone


# my results

These changes mean that mypy 1.13 finds no warnings in openapi.py

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [ ] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

