### PR TITLE
Fix mypy warnings in router.py

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -53,11 +53,10 @@ class Router(BaseRouter):
     ) -> Response:
         headers = Headers({"Content-Type": "text/plain"})
 
-        response = {}
         if isinstance(res, dict):
             # this should change
             headers = Headers({})
-            if "Content-Type" not in headers:
+            if not headers.contains("Content-Type"):
                 headers.set("Content-Type", "application/json")
 
             description = jsonify(res)
@@ -88,16 +87,16 @@ class Router(BaseRouter):
             if len(res) != 3:
                 raise ValueError("Tuple should have 3 elements")
             else:
-                description, headers, status_code = res
-                description = self._format_response(description).description
-                new_headers = Headers(headers)
-                if "Content-Type" in new_headers:
-                    headers.set("Content-Type", new_headers.get("Content-Type"))
+                description2, headers2, status_code2 = res
+                description2 = self._format_response(description2).description
+                new_headers: Headers = Headers(headers2)
+                if new_headers.contains("Content-Type"):
+                    headers2.set("Content-Type", new_headers.get("Content-Type"))
 
                 response = Response(
-                    status_code=status_code,
-                    headers=headers,
-                    description=description,
+                    status_code=status_code2,
+                    headers=headers2,
+                    description=description2,
                 )
         else:
             response = Response(
@@ -291,7 +290,7 @@ class MiddlewareRouter(BaseRouter):
         This method adds an authentication middleware to the specified endpoint.
         """
 
-        injected_dependencies = {}
+        injected_dependencies: dict = {}
 
         def decorator(handler):
             @wraps(handler)
@@ -320,7 +319,7 @@ class MiddlewareRouter(BaseRouter):
     # Arguments are returned as they could be modified by the middlewares.
     def add_middleware(self, middleware_type: MiddlewareType, endpoint: Optional[str]) -> Callable[..., None]:
         # no dependency injection here
-        injected_dependencies = {}
+        injected_dependencies: dict = {}
 
         def inner(handler):
             @wraps(handler)
@@ -383,7 +382,7 @@ class MiddlewareRouter(BaseRouter):
 class WebSocketRouter(BaseRouter):
     def __init__(self) -> None:
         super().__init__()
-        self.routes = {}
+        self.routes: dict = {}
 
     def add_route(self, endpoint: str, web_socket: WebSocket) -> None:
         self.routes[endpoint] = web_socket


### PR DESCRIPTION
## Description

This PR fixes most of the mypy warnings in router.py

## Summary

This PR does not fix https://github.com/sparckles/Robyn/issues/1035 where add_route is inconsistent between the BaseRouter(ABC) and it's subclasses.

The biggest changes were in Router. _format_response
- fixing re-use of local variable names but with a different type
- using `if "x" in headers` replaced with `if headers.contains("x")`
- missing type specifiers

Beyond that a few places with a missing dict type: for injected_dependencies x 2 and self.reoutes x 1

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x ] The PR contains a descriptive title
- [x ] The PR contains a descriptive summary of the changes
- [x ] You build and test your changes before submitting a PR.
- [x ] You have added relevant documentation
- [ x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

