### PR TITLE
Router refactor

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -53,11 +53,10 @@ class Router(BaseRouter):
     ) -> Response:
         headers = Headers({"Content-Type": "text/plain"})
 
-        response = {}
         if isinstance(res, dict):
             # this should change
             headers = Headers({})
-            if "Content-Type" not in headers:
+            if not headers.contains("Content-Type"):
                 headers.set("Content-Type", "application/json")
 
             description = jsonify(res)
@@ -88,16 +87,16 @@ class Router(BaseRouter):
             if len(res) != 3:
                 raise ValueError("Tuple should have 3 elements")
             else:
-                description, headers, status_code = res
-                description = self._format_response(description).description
-                new_headers = Headers(headers)
-                if "Content-Type" in new_headers:
-                    headers.set("Content-Type", new_headers.get("Content-Type"))
+                description2, headers2, status_code2 = res
+                description2 = self._format_response(description2).description
+                new_headers: Headers = Headers(headers2)
+                if new_headers.contains("Content-Type"):
+                    headers2.set("Content-Type", new_headers.get("Content-Type"))
 
                 response = Response(
-                    status_code=status_code,
-                    headers=headers,
-                    description=description,
+                    status_code=status_code2,
+                    headers=headers2,
+                    description=description2,
                 )
         else:
             response = Response(
@@ -291,7 +290,7 @@ class MiddlewareRouter(BaseRouter):
         This method adds an authentication middleware to the specified endpoint.
         """
 
-        injected_dependencies = {}
+        injected_dependencies: dict = {}
 
         def decorator(handler):
             @wraps(handler)
@@ -320,7 +319,7 @@ class MiddlewareRouter(BaseRouter):
     # Arguments are returned as they could be modified by the middlewares.
     def add_middleware(self, middleware_type: MiddlewareType, endpoint: Optional[str]) -> Callable[..., None]:
         # no dependency injection here
-        injected_dependencies = {}
+        injected_dependencies: dict = {}
 
         def inner(handler):
             @wraps(handler)
@@ -383,7 +382,7 @@ class MiddlewareRouter(BaseRouter):
 class WebSocketRouter(BaseRouter):
     def __init__(self) -> None:
         super().__init__()
-        self.routes = {}
+        self.routes: dict = {}
 
     def add_route(self, endpoint: str, web_socket: WebSocket) -> None:
         self.routes[endpoint] = web_socket

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -47,13 +47,6 @@ class Router(BaseRouter):
         super().__init__()
         self.routes: List[Route] = []
 
-    def _format_dict_response(self, res: Dict) -> Response:
-        return Response(
-            status_code=status_codes.HTTP_200_OK,
-            headers=Headers({"Content-Type": "application/json"}),
-            description=jsonify(res),
-        )
-
     def _format_tuple_response(self, res: tuple) -> Response:
         if len(res) != 3:
             raise ValueError("Tuple should have 3 elements")
@@ -78,7 +71,11 @@ class Router(BaseRouter):
             return res
 
         if isinstance(res, dict):
-            return self._format_dict_response(dict(res))
+            return Response(
+                status_code=status_codes.HTTP_200_OK,
+                headers=Headers({"Content-Type": "application/json"}),
+                description=jsonify(res),
+            )
 
         if isinstance(res, FileResponse):
             response: Response = Response(


### PR DESCRIPTION
## Description

This PR fixes #1044 builds on the earlier "Fix mypy warnings in router.py" https://github.com/sparckles/Robyn/pull/1038

## Summary

This PR refactors `def _format_response(self, res: Union[Dict, Response, bytes, tuple, str]) -> Response` to reduce nesting and remove the two complicated formats to other functions `_format_dict_response` and `_format_tuple_response`

All tests pass (but I want to add unit tests to confirm more examples without needing a running server).

This should resolve these comments from @sansyrox : https://github.com/sparckles/Robyn/pull/1038#discussion_r1851799397 and https://github.com/sparckles/Robyn/pull/1038#discussion_r1851189193

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [X] The PR contains a descriptive title
- [X] The PR contains a descriptive summary of the changes
- [X] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [X] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [X] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

