### PR TITLE
Feat: add async support for auth handler

### DIFF
--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Coroutine, Optional, Union
 
 from robyn.robyn import Headers, Identity, Request, Response
 from robyn.status_codes import HTTP_401_UNAUTHORIZED
@@ -64,7 +64,7 @@ class AuthenticationHandler(ABC):
         )
 
     @abstractmethod
-    def authenticate(self, request: Request) -> Optional[Identity]:
+    def authenticate(self, request: Request) -> Union[Optional[Identity], Coroutine[Any, Any, Optional[Identity]]]:
         """
         Authenticates the user.
         :param request: The request object.

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -289,21 +289,32 @@ class MiddlewareRouter(BaseRouter):
         injected_dependencies: dict = {}
 
         def decorator(handler):
-            @wraps(handler)
-            async def inner_handler(request: Request, *args):
-                if not self.authentication_handler:
-                    raise AuthenticationNotConfiguredError()
+            if inspect.iscoroutinefunction(self.authentication_handler.authenticate):
 
-                if inspect.iscoroutinefunction(self.authentication_handler.authenticate):
+                @wraps(handler)
+                async def inner_handler(request: Request, *args):
+                    if not self.authentication_handler:
+                        raise AuthenticationNotConfiguredError()
+
                     identity = await self.authentication_handler.authenticate(request)
-                else:
+                    if identity is None:
+                        return self.authentication_handler.unauthorized_response
+                    request.identity = identity
+
+                    return request
+            else:
+
+                @wraps(handler)
+                def inner_handler(request: Request, *args):
+                    if not self.authentication_handler:
+                        raise AuthenticationNotConfiguredError()
+
                     identity = self.authentication_handler.authenticate(request)
+                    if identity is None:
+                        return self.authentication_handler.unauthorized_response
+                    request.identity = identity
 
-                if identity is None:
-                    return self.authentication_handler.unauthorized_response
-                request.identity = identity
-
-                return request
+                    return request
 
             self.add_route(
                 MiddlewareType.BEFORE_REQUEST,

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -290,10 +290,15 @@ class MiddlewareRouter(BaseRouter):
 
         def decorator(handler):
             @wraps(handler)
-            def inner_handler(request: Request, *args):
+            async def inner_handler(request: Request, *args):
                 if not self.authentication_handler:
                     raise AuthenticationNotConfiguredError()
-                identity = self.authentication_handler.authenticate(request)
+
+                if inspect.iscoroutinefunction(self.authentication_handler.authenticate):
+                    identity = await self.authentication_handler.authenticate(request)
+                else:
+                    identity = self.authentication_handler.authenticate(request)
+
                 if identity is None:
                     return self.authentication_handler.unauthorized_response
                 request.identity = identity


### PR DESCRIPTION
## Description

This PR add the possibility to run async authenticate on AuthenticationHandler.

## Summary

This PR changes adds the typing hints for Authentication handler in order to return an Identity that comes from a Sync process or a Coroutine (Async). Also, it modifies the add_auth_middleware function to run this authenticate using async.

FYI: This allows AuthenticationHandler to support async sessions on cache (on memory db like redis).
```python
class RedisAuthHandler(AuthenticationHandler):
    """Redis Robyn auth handler using async Redis."""

    # Inheritance on abstract method allows both async and sync child methods.
    async def authenticate(self, request: Request) -> Identity | None: # Python 3.10 typing syntax
        """Authenticate Handler in Redis."""
        token = self.token_getter.get_token(request)
        if not token:
            return None

        user_id = await RedisClient.get_user_from_token(token) # <-- Important part. To the user this is just straightforward
        if user_id:
            return Identity(claims={"user_id": str(user_id)})
        return None
```

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [X] The PR contains a descriptive title
- [X] The PR contains a descriptive summary of the changes
- [X] You build and test your changes before submitting a PR.
- [ ] ~~You have added relevant documentation~~ Minor feature, so current API Reference explains the usage.
- [ ] ~~You have added relevant tests. We prefer integration tests wherever possible~~ Minor feature, so current auth testing worked for both scenarios (sync and async).

## Pre-Commit Instructions:

- [X] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.


**EDIT: Add some code context**