### PR TITLE
fix for addroute differences

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from asyncio import iscoroutinefunction
 from functools import wraps
 from inspect import signature
@@ -38,8 +38,18 @@ class GlobalMiddleware(NamedTuple):
 
 
 class BaseRouter(ABC):
-    @abstractmethod
-    def add_route(*args) -> Union[Callable, CoroutineType, WebSocket]: ...
+    """
+    TODO Handle variable args and return types for an abstract method
+    Emptied Abstract class until we can figure out a way for each subclass to have different arguments and return types for add_route
+    currently nothing in Robyn itself relies on the abstract method of add_route and only the 3 classes in router.py mention BaseRouter
+    Router, MiddlewareRouter, WedSocketRouter
+    add_route is used widely in both rust and python code.
+    One option will be to use abstract classes for the arguments and the return value see
+    """
+
+    pass
+    # @abstractmethod
+    # def add_route(*args) -> Union[Callable, CoroutineType, WebSocket]: ...
 
 
 class Router(BaseRouter):


### PR DESCRIPTION
## Description

This PR fixes part of https://github.com/sparckles/Robyn/issues/1035

## Summary

This PR does the simplest thing to fix the mypy issues with the subclasses of BaseRouter having different arguments and return values for add_route

Currently, BaseRouter is not used anywhere except in Router.py so this change only affects future Routers. All tests still pass

I'm suggesting more refactoring of Router.py (see this comment on the issue https://github.com/sparckles/Robyn/issues/1035#issuecomment-2499225518 )

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [X ] The PR contains a descriptive title
- [X ] The PR contains a descriptive summary of the changes
- [X ] You build and test your changes before submitting a PR.
- [X ] You have added relevant documentation
- [X ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [X ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

