### PR TITLE
add_route refactoring

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -102,7 +102,7 @@ class Router(BaseRouter):
             description=str(res).encode("utf-8"),
         )
 
-    def add_route(
+    def add_route(  # type: ignore
         self,
         route_type: HttpMethod,
         endpoint: str,
@@ -254,7 +254,7 @@ class MiddlewareRouter(BaseRouter):
     def set_authentication_handler(self, authentication_handler: AuthenticationHandler):
         self.authentication_handler = authentication_handler
 
-    def add_route(
+    def add_route(  # type: ignore
         self,
         middleware_type: MiddlewareType,
         endpoint: str,
@@ -380,7 +380,7 @@ class WebSocketRouter(BaseRouter):
         super().__init__()
         self.routes: dict = {}
 
-    def add_route(self, endpoint: str, web_socket: WebSocket) -> None:
+    def add_route(self, endpoint: str, web_socket: WebSocket) -> None:  # type: ignore
         self.routes[endpoint] = web_socket
 
     def get_routes(self) -> Dict[str, WebSocket]:


### PR DESCRIPTION
## Description

This PR fixes https://github.com/sparckles/Robyn/issues/1059

## Summary

This PR does the following

1. use `# type: ignore` on the add_route of Router, MiddlewareRouter and WebSocketRouter to suppress mypy complaining about BaseRouter.add_route having different arguments and return values

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [X] The PR contains a descriptive title
- [X] The PR contains a descriptive summary of the changes
- [X] You build and test your changes before submitting a PR.
- [X] You have added relevant documentation
- [X] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [X] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

