### PR TITLE
refactor: openApi made lazy. 

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -51,10 +51,9 @@ class Robyn:
         self.directory_path = directory_path
         self.config = config
         self.dependencies = dependencies
-        self.openapi_file_path = openapi_file_path
         self.openapi = openapi
 
-        self.init_openapi()
+        self.init_openapi(openapi_file_path)
 
         if not bool(os.environ.get("ROBYN_CLI", False)):
             # the env variables are already set when are running through the cli
@@ -82,15 +81,15 @@ class Robyn:
         self.authentication_handler: Optional[AuthenticationHandler] = None
         self.included_routers: List[Router] = []
 
-    def init_openapi(self) -> None:
+    def init_openapi(self, openapi_file_path: Optional[str]) -> None:
         if self.config.disable_openapi:
             return
 
         if self.openapi is None:
             self.openapi = OpenAPI()
 
-        if self.openapi_file_path:
-            self.openapi.override_openapi(Path(self.directory_path).joinpath(self.openapi_file_path))
+        if openapi_file_path:
+            self.openapi.override_openapi(Path(self.directory_path).joinpath(openapi_file_path))
         elif Path(self.directory_path).joinpath("openapi.json").exists():
             self.openapi.override_openapi(Path(self.directory_path).joinpath("openapi.json"))
         # TODO! what about when the elif fails?

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -131,9 +131,7 @@ class Robyn:
         """
         injected_dependencies = self.dependencies.get_dependency_map(self)
 
-        list_openapi_tags: List[str] = []
-        if not self.config.disable_openapi and openapi_tags is not None:
-            list_openapi_tags = openapi_tags
+        list_openapi_tags: List[str] = openapi_tags if openapi_tags else []
 
         if auth_required:
             self.middleware_router.add_auth_middleware(endpoint)(handler)

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -182,7 +182,7 @@ def spawn_process(
     server.set_response_headers_exclude_paths(excluded_response_headers_paths)
 
     for route in routes:
-        route_type, endpoint, function, is_const = route
+        route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags = route
         server.add_route(route_type, endpoint, function, is_const)
 
     for middleware_type, middleware_function in global_middlewares:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger(__name__)
 
 
 def lower_http_method(method: HttpMethod):
-    return str(method).lower()[11:]
+    return (str(method))[11:].lower()
 
 
 class Route(NamedTuple):

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -11,6 +11,7 @@ from robyn import status_codes
 from robyn.authentication import AuthenticationHandler, AuthenticationNotConfiguredError
 from robyn.dependency_injection import DependencyMap
 from robyn.jsonify import jsonify
+from robyn.openapi import OpenAPI
 from robyn.responses import FileResponse
 from robyn.robyn import FunctionInfo, Headers, HttpMethod, Identity, MiddlewareType, QueryParams, Request, Response, Url
 from robyn.types import Body, Files, FormData, IPAddress, Method, PathParams
@@ -19,11 +20,18 @@ from robyn.ws import WebSocket
 _logger = logging.getLogger(__name__)
 
 
+def lower_http_method(method: HttpMethod):
+    return str(method).lower()[11:]
+
+
 class Route(NamedTuple):
     route_type: HttpMethod
     route: str
     function: FunctionInfo
     is_const: bool
+    auth_required: bool
+    openapi_name: str
+    openapi_tags: List[str]
 
 
 class RouteMiddleware(NamedTuple):
@@ -108,6 +116,9 @@ class Router(BaseRouter):
         endpoint: str,
         handler: Callable,
         is_const: bool,
+        auth_required: bool,
+        openapi_name: str,
+        openapi_tags: List[str],
         exception_handler: Optional[Callable],
         injected_dependencies: dict,
     ) -> Union[Callable, CoroutineType]:
@@ -226,7 +237,7 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
             return async_inner_handler
         else:
             function = FunctionInfo(
@@ -236,8 +247,17 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
             return inner_handler
+
+    def prepare_routes_openapi(self, openapi: OpenAPI, included_routers: List) -> None:
+        for route in self.routes:
+            openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler)
+
+        # TODO! after include_routes does not immediatelly merge all the routes
+        # for router in included_routers:
+        #    for route in router:
+        #        openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler)
 
     def get_routes(self) -> List[Route]:
         return self.routes


### PR DESCRIPTION
Makes openAPI lazy (only created if enabled, all methods only called if enabled). 

Fixes a potential issue in __init__ where the default argument creates a shared object at parse time rather than a separate one for each instance. As only one instance, not normally an issue but not good practice.

One FIXME is an edge case in init_openapi where neither if clause evaluates to True for openapi_file_path (should we log an error or what?)

## Description

This PR is progressing towards the larger refactor to simplify the processing of add_route. See https://github.com/sparckles/Robyn/issues/1059

## Summary

This PR does make it so that 
1. the openApi instance variable is only created if needed
2. the openApi is created if needed (and not passed as argument) at Robyn.__init__ not at parse time
3. all the calls to add_openapi_path_obj are made in app.start so after all the routes have been fully sorted (only if openApi is enabled)

Please look carefully at the TODO We should cover this edge case
```
        if self.openapi_file_path:
            self.openapi.override_openapi(Path(self.directory_path).joinpath(self.openapi_file_path))
        elif Path(self.directory_path).joinpath("openapi.json").exists():
            self.openapi.override_openapi(Path(self.directory_path).joinpath("openapi.json"))
        # TODO! what about when the elif fails?

```

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [X] The PR contains a descriptive title
- [X] The PR contains a descriptive summary of the changes
- [X] You build and test your changes before submitting a PR.
- [X] You have added relevant documentation {No API changes}
- [X] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [X] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

