### PR TITLE
chore: git workflow update macos to macos-latest no other changes

### DIFF
--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
@@ -149,4 +149,3 @@ jobs:
             pip install --upgrade pip setuptools wheel
             pip install --force-reinstall dist/robyn*.whl
             cd ~ && python -c 'import robyn'
-

--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -8,7 +8,7 @@ env:
   UV_SYSTEM_PYTHON: 1
 jobs:
   macos:
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
## Description

This PR updates the github workflow from macos-12 (deprecated) to macos-latest

Only affects preview-deployments.yml and release-CI.yml

## Summary

This PR does....

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [ ] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

