### PR TITLE
chore: ci update ubuntu to ubuntu-latest EXCEPT for linux-cross

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -43,4 +43,3 @@ jobs:
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest integration_tests --codspeed
-

--- a/.github/workflows/preview-deployments.yml
+++ b/.github/workflows/preview-deployments.yml
@@ -101,7 +101,7 @@ jobs:
           cd ~ && python -c 'import robyn'
 
   linux-cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +127,7 @@ jobs:
         name: Install build wheel
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           # Mount the dist directory as /artifacts in the container
           dockerRunArgs: |
@@ -149,4 +149,3 @@ jobs:
             pip install --upgrade pip setuptools wheel
             pip install --force-reinstall dist/robyn*.whl
             cd ~ && python -c 'import robyn'
-

--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -105,7 +105,7 @@ jobs:
           name: wheels
           path: dist
   linux-cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python:
@@ -130,7 +130,7 @@ jobs:
         name: Install build wheel
         with:
           arch: ${{ matrix.target }}
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           # Mount the dist directory as /artifacts in the container
           dockerRunArgs: |


### PR DESCRIPTION
chore: ci update ubuntu to ubuntu-latest EXCEPT for linux-cross which is fixed at 22.04 because uraimo/run-on-arch-action@v2 does not yet support ubuntu-24.04 (and therefore we can't use ubuntu-latest in these 4 places)

## Description

This PR fixes #

## Summary

This PR does....

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [ ] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

