### PR TITLE
chore: suppress clippy warnings

### DIFF
--- a/.github/workflows/rust-CI.yml
+++ b/.github/workflows/rust-CI.yml
@@ -39,4 +39,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy
+        # -- -D warnings
+


### PR DESCRIPTION
## Description

This PR fixes #1080

## Summary

This PR fixes warnings of clippy. Will need to revert this change when we update and support python 3.13

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

