### PR TITLE
Fix datetime object handling in OpenAPI schema generation

### DIFF
--- a/unit_tests/test_openapi.py
+++ b/unit_tests/test_openapi.py
@@ -1,0 +1,69 @@
+import datetime
+from dataclasses import dataclass
+from typing import Optional
+
+
+from robyn.openapi import OpenAPI, OpenAPIInfo
+from robyn.types import JSONResponse
+
+
+@dataclass
+class DateResponseModel(JSONResponse):
+    date: datetime.datetime
+    optional_date: Optional[datetime.date] = None
+
+
+def test_datetime_schema_object():
+    """Test the schema generation for datetime types"""
+    openapi = OpenAPI(info=OpenAPIInfo())
+
+    schema = openapi.get_schema_object("test", datetime.datetime)
+    assert schema["type"] == "string"
+    assert schema["format"] == "date-time"
+
+    schema = openapi.get_schema_object("test", datetime.date)
+    assert schema["type"] == "string"
+    assert schema["format"] == "date"
+
+
+def test_datetime_response_object():
+    """Test the schema generation for response objects containing datetime fields"""
+    openapi = OpenAPI(info=OpenAPIInfo())
+
+    schema = openapi.get_schema_object("test", DateResponseModel)
+    assert schema["type"] == "object"
+    assert "properties" in schema
+    assert schema["properties"]["date"]["type"] == "string"
+    assert schema["properties"]["date"]["format"] == "date-time"
+    assert schema["properties"]["optional_date"]["anyOf"] == [{"type": "string", "format": "date"}, {"type": "null"}]
+
+
+def test_datetime_path_object():
+    """Test the OpenAPI path object generation for datetime return types"""
+    openapi = OpenAPI(info=OpenAPIInfo())
+
+    _, path_obj = openapi.get_path_obj(
+        endpoint="/test",
+        name="Test Endpoint",
+        description="Test description",
+        tags=["test"],
+        query_params=None,
+        request_body=None,
+        return_annotation=datetime.datetime,
+    )
+
+    assert path_obj["responses"]["200"]["content"]["application/json"]["schema"]["type"] == "string"
+    assert path_obj["responses"]["200"]["content"]["application/json"]["schema"]["format"] == "date-time"
+
+    _, path_obj = openapi.get_path_obj(
+        endpoint="/test",
+        name="Test Endpoint",
+        description="Test description",
+        tags=["test"],
+        query_params=None,
+        request_body=None,
+        return_annotation=datetime.date,
+    )
+
+    assert path_obj["responses"]["200"]["content"]["application/json"]["schema"]["type"] == "string"
+    assert path_obj["responses"]["200"]["content"]["application/json"]["schema"]["format"] == "date"


### PR DESCRIPTION
## Description

This PR fixes #1124

## Summary

This PR fixes the OpenAPI schema generation for endpoints that return datetime objects. Previously, the application would fail to start with an AttributeError when attempting to generate OpenAPI documentation for endpoints returning datetime.datetime or datetime.date objects.

Changes made:
- Added special handling for `datetime.datetime` and `datetime.date` types in schema generation
- Added proper OpenAPI schema type ("string") and format ("date-time"/"date") for datetime objects
- Added unit tests for datetime schema generation

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.
