### PR TITLE
docs: fix typo in 'organisation'

### DIFF
--- a/docs_src/src/pages/community.jsx
+++ b/docs_src/src/pages/community.jsx
@@ -83,7 +83,7 @@ export default function Community() {
             </h2>
             <p className="mt-6 text-lg leading-8 text-gray-300">
               Robyn is a community project and is housed under the sparckles
-              orgranisation.
+              organisation.
             </p>
           </div>
         </div>
@@ -136,7 +136,7 @@ export default function Community() {
               Our team
             </h2>
             <p className="mt-6 text-lg leading-8 text-gray-300">
-              Robyn is housed under an open source orgranisation called
+              Robyn is housed under an open source organisation called
               Sparckles. We are a group of developers passionate about the open
               source community. Come join us and help us empower the Python web
               ecosystem.


### PR DESCRIPTION
## Description

This PR fixes a minor typo in the docs.

## Summary

Quick fix - 'organisation' was misspelled as 'orgranisation' in two places.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

