### PR TITLE
ci: Fixing artifact conflict issue in ci

### DIFF
--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
+  
 env:
   UV_SYSTEM_PYTHON: 1
 jobs:
@@ -42,7 +44,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-universal-${{ matrix.python-version }}
           path: dist
   windows:
     runs-on: windows-latest
@@ -72,7 +74,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ matrix.target }}-${{ matrix.python-version }}
           path: dist
   linux:
     runs-on: ubuntu-latest
@@ -102,7 +104,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ matrix.target }}-${{ matrix.python-version }}
           path: dist
   linux-cross:
     runs-on: ubuntu-latest
@@ -151,12 +153,32 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ matrix.target }}-${{ matrix.python.version }}-${{ matrix.python.abi }}
           path: dist
+  merge:
+    name: Building Single Artifact
+    runs-on: ubuntu-latest
+    needs: [macos, windows, linux, linux-cross]
+    steps:
+      - name: Downloading all Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: wheels-*
+          merge-multiple: true
+      - run: |
+          echo "Listing directories"
+          ls -R
+      - name: Uploading Artifact's Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: artifacts
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [macos, windows, linux, linux-cross]
+    needs: [macos, windows, linux, linux-cross, merge]
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Description

This PR fixes #1152

## Summary
1. Same name artifact conflict issue in ci
2. This happened due to upgradation of dependency (actions/upload-artifact) from v3 to v4 which have some breaking changes.
3. This PR solve the issue, by having unique artifact name initially and after building the wheel files. 
    It then combines them in a single artifact file, to avoid clutter.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

