### PR TITLE
ci: Upgrading deprecated actions in workflow

### DIFF
--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [macos, windows, linux, linux-cross, merge]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
       - name: Install uv


### PR DESCRIPTION
## Description

This PR fixes #1155 

## Summary

This PR does:
upgrade dependency of actions/download from v3 to v4 which stopped working currently in the actions

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

