### PR TITLE
ci: fix Codspeed benchmark ci

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.5"
 
       - uses: actions/setup-python@v5
         with:
@@ -27,19 +29,31 @@ jobs:
 
       - name: Install dependencies with uv
         run: |
-          uv pip install poetry
-          uv run poetry export --with test --with dev --without-hashes --output requirements.txt
-          uv pip install -r requirements.txt
+          echo "# Installing Dependencies"
+          uv pip install -r pyproject.toml --group dev --group test
+          echo "# Installing Project"
           uv pip install -e .
+
       - name: Add macos target
         if: matrix.os == 'macos'
         run: rustup target add aarch64-apple-darwin
+
       - name: Setup Rust part of the project
         run: |
+          echo "::group::Checking dependencies"
+          echo "# Checking dependencies, If not found any then it will stop the job."
+          which uv python pip maturin pytest
+          echo "# Checking pip list"
+          pip list
+          echo "::endgroup::"
+          
+          echo "::group::Running & Installing build"
           maturin build -i python --universal2 --out dist
           uv pip install --no-index --find-links=dist/ robyn
+          echo "::endgroup::"
+
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v2
+        uses: CodSpeedHQ/action@v3.5.0
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: pytest integration_tests --codspeed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,14 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  'watchdog == 4.0.1',
-  'multiprocess == 0.70.14',
-  'inquirerpy == 0.3.4',
-  'rustimport == 1.3.4',
-  'orjson == 3.9.15',
-# conditional
-  "uvloop~=0.19.0; sys_platform != 'win32' and platform_python_implementation == 'CPython' and platform_machine != 'armv7l'"
-  ]
-
-[project.scripts]
-robyn = "robyn.cli:run"
+  "inquirerpy == 0.3.4",
+  "multiprocess == 0.70.14",
+  "orjson == 3.9.15",
+  "rustimport == 1.3.4",
+  # conditional
+  "uvloop~=0.19.0; sys_platform != 'win32' and platform_python_implementation == 'CPython' and platform_machine != 'armv7l'",
+  "watchdog == 4.0.1",
+]
 
 [project.optional-dependencies]
 "templating" = ["jinja2 == 3.0.1"]
@@ -42,6 +39,27 @@ Documentation = "https://robyn.tech/"
 Repository = "https://github.com/sparckles/robyn"
 Issues = "https://github.com/sparckles/robyn/issues"
 Changelog = "https://github.com/sparckles/robyn/blob/main/CHANGELOG.md"
+
+[project.scripts]
+robyn = "robyn.cli:run"
+test_server = "integration_tests.base_routes:main"
+
+[dependency-groups]
+dev = [
+  "black==23.1",
+  "commitizen==2.40",
+  "isort==5.11.5",
+  "maturin==0.14.12",
+  "pre-commit==2.21.0",
+  "ruff==0.1.3",
+]
+test = [
+  "nox==2023.4.22",
+  "pytest==7.2.1",
+  "pytest-codspeed==1.2.2",
+  "requests==2.28.2",
+  "websocket-client==1.5.0",
+]
 
 
 [tool.poetry]
@@ -57,7 +75,6 @@ inquirerpy = "0.3.4"
 maturin = "0.14.12"
 watchdog = "4.0.1"
 multiprocess = "0.70.14"
-nestd = "0.3.1"
 uvloop = { version = "0.19.0", markers = "sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')" }
 jinja2 = { version = "3.0.1", optional = true }
 rustimport = "^1.3.4"


### PR DESCRIPTION
## Description
Fixes Codspeed Benchmark ci

## Summary
+ Fixing codspeed benchmark ci, happened due to of using poetry export command
+ To fix above, we tried to complete shift to uv and removed poetry use just only from this ci only
+ To use uv instead of poetry, pyproject.toml file needs some additions to make it compatible with PEP & UV standards.

<!--
Thank you for contributing to Robyn!
-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

