### PR TITLE
feat: add security scheme config to openapi (#1122)

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -266,6 +266,16 @@ class BaseRobyn(ABC):
             logger.error("No openAPI")
             return
 
+        if self.authentication_handler:
+            # self.authentication_handler.token_getter
+            self.openapi.add_global_security_scheme(
+                name="bearerAuth",
+                scheme={
+                    "type": "http",
+                    "scheme": "bearer"
+                }
+            )
+
         self.router.prepare_routes_openapi(self.openapi, self.included_routers)
 
         self.add_route(

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -268,13 +268,7 @@ class BaseRobyn(ABC):
 
         if self.authentication_handler:
             # self.authentication_handler.token_getter
-            self.openapi.add_global_security_scheme(
-                name="bearerAuth",
-                scheme={
-                    "type": "http",
-                    "scheme": "bearer"
-                }
-            )
+            self.openapi.add_global_security_scheme(name="bearerAuth", scheme={"type": "http", "scheme": "bearer"})
 
         self.router.prepare_routes_openapi(self.openapi, self.included_routers)
 

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -161,7 +161,17 @@ class OpenAPI:
             "components": asdict(self.info.components),
             "servers": [asdict(server) for server in self.info.servers],
             "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
+            "security": [],
         }
+
+    def add_global_security_scheme(self, name: str, scheme: dict):
+        """
+        Adds a security scheme to the OpenAPI spec.
+        @param name: str The name of the security scheme.
+        @param scheme: dict The security scheme object to be added.
+        """
+        self.openapi_spec["components"]["securitySchemes"][name] = scheme
+        self.openapi_spec["security"].append({name: []})
 
     def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable):
         """


### PR DESCRIPTION
## Description

This PR fixes #1122 

## Summary

This PR adds support for configuring security schemes in the generated OpenAPI specification.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [ ] The PR contains a descriptive title
- [ ] The PR contains a descriptive summary of the changes
- [ ] You build and test your changes before submitting a PR.
- [ ] You have added relevant documentation
- [ ] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [ ] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

