### PR TITLE
refactor: modernize typing and defaults across core API

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import time
 from collections import defaultdict
-from typing import List, Optional, TypedDict
+from typing import TypedDict
 
 from integration_tests.subroutes import di_subrouter, static_router, sub_router
 from robyn import Headers, Request, Response, Robyn, SSEMessage, SSEResponse, WebSocketDisconnect, jsonify, serve_file, serve_html
@@ -1223,7 +1223,7 @@ def sample_openapi_endpoint():
 
 class Initial(Body):
     is_present: bool
-    letter: Optional[str]
+    letter: str | None
 
 
 class FullName(Body):
@@ -1451,22 +1451,22 @@ async def easy_access_async(id: int, q: str, page: int = 1):
 
 
 @app.get("/easy/sync/optional")
-def easy_access_optional_sync(name: str, age: Optional[int] = None):
+def easy_access_optional_sync(name: str, age: int | None = None):
     return {"name": name, "age": age}
 
 
 @app.get("/easy/async/optional")
-async def easy_access_optional_async(name: str, age: Optional[int] = None):
+async def easy_access_optional_async(name: str, age: int | None = None):
     return {"name": name, "age": age}
 
 
 @app.get("/easy/sync/list")
-def easy_access_list_sync(tag: List[str]):
+def easy_access_list_sync(tag: list[str]):
     return {"tags": tag}
 
 
 @app.get("/easy/async/list")
-async def easy_access_list_async(tag: List[str]):
+async def easy_access_list_async(tag: list[str]):
     return {"tags": tag}
 
 
@@ -1665,7 +1665,7 @@ def main():
     app.include_router(static_router)
 
     class BasicAuthHandler(AuthenticationHandler):
-        def authenticate(self, request: Request) -> Optional[Identity]:
+        def authenticate(self, request: Request) -> Identity | None:
             token = self.token_getter.get_token(request)
             if token is not None:
                 # Useless but we call the set_token method for testing purposes

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1273,7 +1273,7 @@ class FullName(Body):
 
 
 class TestTypedBody(Body):
-    items: List[str]
+    items: list[str]
     numbers: list[int]
 
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -3,8 +3,9 @@ import logging
 import os
 import socket
 from abc import ABC
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import cast
 
 import multiprocess as mp  # type: ignore
 
@@ -28,8 +29,7 @@ from robyn.ws import WebSocketAdapter, WebSocketDisconnect, create_websocket_dec
 
 __version__ = get_version()
 
-
-def _normalize_endpoint(endpoint: Optional[str], treat_empty_as_root: bool = False) -> Optional[str]:
+def _normalize_endpoint(endpoint: str | None, treat_empty_as_root: bool = False) -> str | None:
     """
     Normalize an endpoint to ensure consistent routing.
 
@@ -65,13 +65,11 @@ def _normalize_endpoint(endpoint: Optional[str], treat_empty_as_root: bool = Fal
 
     return endpoint
 
-
 config = Config()
 
 if (compile_path := config.compile_rust_path) is not None:
     compile_rust_files(compile_path)
     print("Compiled rust files")
-
 
 class BaseRobyn(ABC):
     """This is the python wrapper for the Robyn binaries."""
@@ -79,11 +77,15 @@ class BaseRobyn(ABC):
     def __init__(
         self,
         file_object: str,
-        config: Config = Config(),
-        openapi_file_path: Optional[str] = None,
-        openapi: Optional[OpenAPI] = None,
-        dependencies: DependencyMap = DependencyMap(),
+        config: Config | None = None,
+        openapi_file_path: str | None = None,
+        openapi: OpenAPI | None = None,
+        dependencies: DependencyMap | None = None,
     ) -> None:
+        if config is None:
+            config = Config()
+        if dependencies is None:
+            dependencies = DependencyMap()
         directory_path = os.path.dirname(os.path.abspath(file_object))
         self.file_path = file_object
         self.directory_path = directory_path
@@ -112,15 +114,16 @@ class BaseRobyn(ABC):
         self.web_socket_router = WebSocketRouter()
         self.request_headers: Headers = Headers({})
         self.response_headers: Headers = Headers({})
-        self.excluded_response_headers_paths: Optional[List[str]] = None
-        self.directories: List[Directory] = []
+        self.excluded_response_headers_paths: list[str] | None = None
+        self.directories: list[Directory] = []
         self.event_handlers: dict = {}
-        self.exception_handler: Optional[Callable] = None
-        self.authentication_handler: Optional[AuthenticationHandler] = None
-        self.included_routers: List[Router] = []
-        self._mcp_app: Optional[MCPApp] = None
+        self.exception_handler: Callable | None = None
+        self.authentication_handler: AuthenticationHandler | None = None
+        self.included_routers: list[SubRouter] = []
+        self._mcp_app: MCPApp | None = None
+        self._added_routes: set[str] = set()
 
-    def init_openapi(self, openapi_file_path: Optional[str]) -> None:
+    def init_openapi(self, openapi_file_path: str | None) -> None:
         if self.config.disable_openapi:
             return
 
@@ -148,13 +151,13 @@ class BaseRobyn(ABC):
 
     def add_route(
         self,
-        route_type: Union[HttpMethod, str],
+        route_type: HttpMethod | str,
         endpoint: str,
         handler: Callable,
         is_const: bool = False,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: Union[List[str], None] = None,
+        openapi_tags: list[str] | None = None,
     ):
         """
         Connect a URI to a handler
@@ -170,7 +173,7 @@ class BaseRobyn(ABC):
         """
         injected_dependencies = self.dependencies.get_dependency_map(self)
 
-        list_openapi_tags: List[str] = openapi_tags if openapi_tags else []
+        list_openapi_tags: list[str] = openapi_tags if openapi_tags else []
 
         if isinstance(route_type, str):
             http_methods = {
@@ -195,9 +198,6 @@ class BaseRobyn(ABC):
 
         # Check if this exact route (method + normalized_endpoint) already exists
         route_key = f"{route_type}:{normalized_endpoint}"
-        if not hasattr(self, "_added_routes"):
-            self._added_routes = set()
-
         if route_key in self._added_routes:
             # Route already exists, raise an error
             raise ValueError(f"Route {route_type} {normalized_endpoint} already exists")
@@ -238,7 +238,7 @@ class BaseRobyn(ABC):
         """
         self.dependencies.add_global_dependency(**kwargs)
 
-    def before_request(self, endpoint: Optional[str] = None) -> Callable[..., None]:
+    def before_request(self, endpoint: str | None = None) -> Callable[..., None]:
         """
         You can use the @app.before_request decorator to call a method before routing to the specified endpoint
 
@@ -246,7 +246,7 @@ class BaseRobyn(ABC):
         """
         return self.middleware_router.add_middleware(MiddlewareType.BEFORE_REQUEST, _normalize_endpoint(endpoint))
 
-    def after_request(self, endpoint: Optional[str] = None) -> Callable[..., None]:
+    def after_request(self, endpoint: str | None = None) -> Callable[..., None]:
         """
         You can use the @app.after_request decorator to call a method after routing to the specified endpoint
 
@@ -258,7 +258,7 @@ class BaseRobyn(ABC):
         self,
         route: str,
         directory_path: str,
-        index_file: Optional[str] = None,
+        index_file: str | None = None,
         show_files_listing: bool = False,
     ):
         """
@@ -283,7 +283,7 @@ class BaseRobyn(ABC):
     def set_response_header(self, key: str, value: str) -> None:
         self.response_headers.set(key, value)
 
-    def exclude_response_headers_for(self, excluded_response_headers_paths: Optional[List[str]]):
+    def exclude_response_headers_for(self, excluded_response_headers_paths: list[str] | None):
         """
         To exclude response headers from certain routes
         @param exclude_paths: the paths to exclude response headers from
@@ -370,7 +370,7 @@ class BaseRobyn(ABC):
         const: bool = False,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["get"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.get decorator to add a route with the GET method
@@ -379,8 +379,11 @@ class BaseRobyn(ABC):
         :param const bool: represents if the handler is a const function or not
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
+
+        if openapi_tags is None:
+            openapi_tags = ["get"]
 
         def inner(handler):
             return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags)
@@ -392,7 +395,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["post"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.post decorator to add a route with POST method
@@ -400,11 +403,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["post"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.POST,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -413,7 +426,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["put"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.put decorator to add a get route with PUT method
@@ -421,11 +434,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["put"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.PUT,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -434,7 +457,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["delete"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.delete decorator to add a route with DELETE method
@@ -442,11 +465,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["delete"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.DELETE,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -455,7 +488,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["patch"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.patch decorator to add a route with PATCH method
@@ -463,11 +496,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["patch"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.PATCH,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -476,7 +519,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["head"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.head decorator to add a route with HEAD method
@@ -484,11 +527,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["head"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.HEAD,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -497,7 +550,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["options"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.options decorator to add a route with OPTIONS method
@@ -505,11 +558,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["options"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.OPTIONS,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -518,7 +581,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["connect"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.connect decorator to add a route with CONNECT method
@@ -526,11 +589,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["connect"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.CONNECT,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -539,7 +612,7 @@ class BaseRobyn(ABC):
         endpoint: str,
         auth_required: bool = False,
         openapi_name: str = "",
-        openapi_tags: List[str] = ["trace"],
+        openapi_tags: list[str] | None = None,
     ):
         """
         The @app.trace decorator to add a route with TRACE method
@@ -547,11 +620,21 @@ class BaseRobyn(ABC):
         :param endpoint str: endpoint for the route added
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
-        :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param openapi_tags: list[str] -- for grouping of endpoints in the openapi spec
         """
 
+        if openapi_tags is None:
+            openapi_tags = ["trace"]
+
         def inner(handler):
-            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(
+                HttpMethod.TRACE,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+            )
 
         return inner
 
@@ -624,9 +707,15 @@ class BaseRobyn(ABC):
             self._mcp_app = MCPApp(self)
         return self._mcp_app
 
-
 class Robyn(BaseRobyn):
-    def start(self, host: str = "127.0.0.1", port: int = 8080, _check_port: bool = True, client_timeout: int = 30, keep_alive_timeout: int = 20):
+    def start(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+        _check_port: bool = True,
+        client_timeout: int = 30,
+        keep_alive_timeout: int = 20,
+    ):
         """
         Starts the server
 
@@ -659,7 +748,9 @@ class Robyn(BaseRobyn):
         logger.info("Robyn version: %s", __version__)
         logger.info("Starting server at http://%s:%s", host, port)
 
-        mp.allow_connection_pickling()
+        allow_connection_pickling = getattr(mp, "allow_connection_pickling", None)
+        if callable(allow_connection_pickling):
+            allow_connection_pickling()
 
         run_processes(
             host,
@@ -680,9 +771,14 @@ class Robyn(BaseRobyn):
             keep_alive_timeout,
         )
 
-
 class SubRouter(BaseRobyn):
-    def __init__(self, file_object: str, prefix: str = "", config: Config = Config(), openapi: OpenAPI = OpenAPI()) -> None:
+    def __init__(
+        self,
+        file_object: str,
+        prefix: str = "",
+        config: Config | None = None,
+        openapi: OpenAPI | None = None,
+    ) -> None:
         super().__init__(file_object=file_object, config=config, openapi=openapi)
         self.prefix = prefix
 
@@ -705,29 +801,135 @@ class SubRouter(BaseRobyn):
 
         return f"{normalized_prefix}{normalized_endpoint}"
 
-    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"]):
-        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def get(
+        self,
+        endpoint: str,
+        const: bool = False,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["get"]
+        return super().get(
+            endpoint=self.__add_prefix(endpoint),
+            const=const,
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"]):
-        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def post(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["post"]
+        return super().post(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"]):
-        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def put(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["put"]
+        return super().put(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"]):
-        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def delete(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["delete"]
+        return super().delete(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"]):
-        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def patch(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["patch"]
+        return super().patch(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"]):
-        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def head(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["head"]
+        return super().head(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"]):
-        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def trace(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["trace"]
+        return super().trace(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
-    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"]):
-        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def options(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: list[str] | None = None,
+    ):
+        if openapi_tags is None:
+            openapi_tags = ["options"]
+        return super().options(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+        )
 
     def websocket(self, endpoint: str):
         """
@@ -735,8 +937,7 @@ class SubRouter(BaseRobyn):
         """
         return create_websocket_decorator(self)(endpoint)
 
-
-def ALLOW_CORS(app: Robyn, origins: Union[List[str], str], headers: Union[List[str], str] = None):
+def ALLOW_CORS(app: Robyn, origins: list[str] | str, headers: list[str] | str | None = None):
     """
     Configure CORS headers for the application.
 
@@ -788,7 +989,6 @@ def ALLOW_CORS(app: Robyn, origins: Union[List[str], str], headers: Union[List[s
     app.set_response_header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS")
     app.set_response_header("Access-Control-Allow-Headers", str(headers) if headers else "Content-Type, Authorization")
     app.set_response_header("Access-Control-Allow-Credentials", "true")
-
 
 __all__ = [
     "Robyn",

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -80,15 +80,11 @@ class BaseRobyn(ABC):
     def __init__(
         self,
         file_object: str,
-        config: Config | None = None,
+        config: Config = Config(),
         openapi_file_path: str | None = None,
         openapi: OpenAPI | None = None,
-        dependencies: DependencyMap | None = None,
+        dependencies: DependencyMap = DependencyMap(),
     ) -> None:
-        if config is None:
-            config = Config()
-        if dependencies is None:
-            dependencies = DependencyMap()
         directory_path = os.path.dirname(os.path.abspath(file_object))
         self.file_path = file_object
         self.directory_path = directory_path
@@ -750,13 +746,7 @@ class Robyn(BaseRobyn):
 
 
 class SubRouter(BaseRobyn):
-    def __init__(
-        self,
-        file_object: str,
-        prefix: str = "",
-        config: Config | None = None,
-        openapi: OpenAPI | None = None,
-    ) -> None:
+    def __init__(self, file_object: str, prefix: str = "", config: Config = Config(), openapi: OpenAPI = OpenAPI()) -> None:
         super().__init__(file_object=file_object, config=config, openapi=openapi)
         self.prefix = prefix
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -29,6 +29,7 @@ from robyn.ws import WebSocketAdapter, WebSocketDisconnect, create_websocket_dec
 
 __version__ = get_version()
 
+
 def _normalize_endpoint(endpoint: str | None, treat_empty_as_root: bool = False) -> str | None:
     """
     Normalize an endpoint to ensure consistent routing.
@@ -65,11 +66,13 @@ def _normalize_endpoint(endpoint: str | None, treat_empty_as_root: bool = False)
 
     return endpoint
 
+
 config = Config()
 
 if (compile_path := config.compile_rust_path) is not None:
     compile_rust_files(compile_path)
     print("Compiled rust files")
+
 
 class BaseRobyn(ABC):
     """This is the python wrapper for the Robyn binaries."""
@@ -680,6 +683,7 @@ class BaseRobyn(ABC):
             self._mcp_app = MCPApp(self)
         return self._mcp_app
 
+
 class Robyn(BaseRobyn):
     def start(
         self,
@@ -743,6 +747,7 @@ class Robyn(BaseRobyn):
             client_timeout,
             keep_alive_timeout,
         )
+
 
 class SubRouter(BaseRobyn):
     def __init__(
@@ -894,6 +899,7 @@ class SubRouter(BaseRobyn):
         """
         return create_websocket_decorator(self)(endpoint)
 
+
 def ALLOW_CORS(app: Robyn, origins: list[str] | str, headers: list[str] | str | None = None):
     """
     Configure CORS headers for the application.
@@ -946,6 +952,7 @@ def ALLOW_CORS(app: Robyn, origins: list[str] | str, headers: list[str] | str | 
     app.set_response_header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS")
     app.set_response_header("Access-Control-Allow-Headers", str(headers) if headers else "Content-Type, Authorization")
     app.set_response_header("Access-Control-Allow-Credentials", "true")
+
 
 __all__ = [
     "Robyn",

--- a/robyn/_param_utils.py
+++ b/robyn/_param_utils.py
@@ -7,7 +7,8 @@ Used by both robyn/router.py (HTTP handlers) and robyn/ws.py (WebSocket handlers
 
 import inspect
 import logging
-from typing import Any, Dict, Optional, Set, Tuple, Union
+import types
+from typing import Any, Dict, Optional, Set, Tuple, Union, get_args, get_origin
 
 _logger = logging.getLogger(__name__)
 
@@ -37,12 +38,13 @@ class QueryParamValidationError(Exception):
 
 def unwrap_optional(annotation) -> Tuple[Any, bool]:
     """
-    If annotation is Optional[T] (i.e. Union[T, None]), return (T, True).
+    If annotation is Optional[T] (i.e. T | None / Union[T, None]), return (T, True).
+    Handles both typing.Union and PEP 604 union syntax (X | Y).
     Otherwise return (annotation, False).
     """
-    origin = getattr(annotation, "__origin__", None)
-    if origin is Union:
-        args = annotation.__args__
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        args = get_args(annotation)
         non_none_args = [a for a in args if a is not type(None)]
         if len(non_none_args) == 1 and type(None) in args:
             return non_none_args[0], True
@@ -51,8 +53,7 @@ def unwrap_optional(annotation) -> Tuple[Any, bool]:
 
 def is_list_type(annotation) -> bool:
     """Check if annotation is List[T] or list[T]."""
-    origin = getattr(annotation, "__origin__", None)
-    return origin is list
+    return get_origin(annotation) is list
 
 
 def get_list_element_type(annotation) -> type:

--- a/robyn/ai.py
+++ b/robyn/ai.py
@@ -9,10 +9,9 @@ Provides agent and memory functionality for building AI-powered applications for
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
-
 
 class AIConfig:
     """Configuration class for AI providers and settings"""
@@ -55,21 +54,20 @@ class AIConfig:
         """Update configuration with new values"""
         self.config.update(kwargs)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Get configuration as dictionary"""
         return self.config.copy()
-
 
 class MemoryProvider(ABC):
     """Abstract base class for memory providers"""
 
     @abstractmethod
-    async def store(self, user_id: str, data: Dict[str, Any]) -> None:
+    async def store(self, user_id: str, data: dict[str, Any]) -> None:
         """Store data in memory"""
         pass
 
     @abstractmethod
-    async def retrieve(self, user_id: str, query: Optional[str] = None) -> List[Dict[str, Any]]:
+    async def retrieve(self, user_id: str, query: str | None = None) -> list[dict[str, Any]]:
         """Retrieve data from memory"""
         pass
 
@@ -78,30 +76,28 @@ class MemoryProvider(ABC):
         """Clear memory for a user"""
         pass
 
-
 class InMemoryProvider(MemoryProvider):
     """Simple in-memory storage provider"""
 
     def __init__(self):
-        self._storage: Dict[str, List[Dict[str, Any]]] = {}
+        self._storage: dict[str, list[dict[str, Any]]] = {}
 
-    async def store(self, user_id: str, data: Dict[str, Any]) -> None:
+    async def store(self, user_id: str, data: dict[str, Any]) -> None:
         if user_id not in self._storage:
             self._storage[user_id] = []
         self._storage[user_id].append(data)
 
-    async def retrieve(self, user_id: str, query: Optional[str] = None) -> List[Dict[str, Any]]:
+    async def retrieve(self, user_id: str, query: str | None = None) -> list[dict[str, Any]]:
         return self._storage.get(user_id, [])
 
     async def clear(self, user_id: str) -> None:
         if user_id in self._storage:
             del self._storage[user_id]
 
-
 class Memory:
     """Memory interface for storing and retrieving conversation history and context"""
 
-    def __init__(self, provider: Union[str, MemoryProvider], user_id: str, **kwargs):
+    def __init__(self, provider: str | MemoryProvider, user_id: str, **kwargs):
         self.user_id = user_id
 
         if isinstance(provider, str):
@@ -112,12 +108,12 @@ class Memory:
         else:
             self.provider = provider
 
-    async def add(self, message: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def add(self, message: str, metadata: dict[str, Any] | None = None) -> None:
         """Add a message to memory"""
         data = {"message": message, "metadata": metadata or {}}
         await self.provider.store(self.user_id, data)
 
-    async def get(self, query: Optional[str] = None) -> List[Dict[str, Any]]:
+    async def get(self, query: str | None = None) -> list[dict[str, Any]]:
         """Get messages from memory"""
         return await self.provider.retrieve(self.user_id, query)
 
@@ -125,15 +121,13 @@ class Memory:
         """Clear all memory for this user"""
         await self.provider.clear(self.user_id)
 
-
 class AgentRunner(ABC):
     """Abstract base class for agent runners"""
 
     @abstractmethod
-    async def run(self, query: str, **kwargs) -> Dict[str, Any]:
+    async def run(self, query: str, **kwargs) -> dict[str, Any]:
         """Execute the agent with the given query"""
         pass
-
 
 class SimpleRunner(AgentRunner):
     """Simple runner with OpenAI integration and fallback responses"""
@@ -153,7 +147,7 @@ class SimpleRunner(AgentRunner):
                 raise ImportError("openai package not installed. Install with: pip install openai")
         return self._client
 
-    async def run(self, query: str, **kwargs) -> Dict[str, Any]:
+    async def run(self, query: str, **kwargs) -> dict[str, Any]:
         """Execute with OpenAI (requires API key)"""
         client = self._get_client()
 
@@ -203,11 +197,10 @@ class SimpleRunner(AgentRunner):
             logger.error(f"Error in SimpleRunner: {e}")
             raise e
 
-
 class Agent:
     """AI Agent interface for handling queries with memory and execution"""
 
-    def __init__(self, runner: Union[str, AgentRunner], memory: Optional[Memory] = None, **kwargs):
+    def __init__(self, runner: str | AgentRunner, memory: Memory | None = None, **kwargs):
         self.memory = memory
 
         if isinstance(runner, str):
@@ -218,7 +211,7 @@ class Agent:
         else:
             self.runner = runner
 
-    async def run(self, query: str, history: bool = False, **kwargs) -> Dict[str, Any]:
+    async def run(self, query: str, history: bool = False, **kwargs) -> dict[str, Any]:
         """Run the agent with the given query"""
         context = {}
 
@@ -240,7 +233,6 @@ class Agent:
 
         return result
 
-
 def memory(provider: str = "inmemory", user_id: str = "default", **kwargs) -> Memory:
     """
     Create a memory instance with the specified provider
@@ -254,7 +246,6 @@ def memory(provider: str = "inmemory", user_id: str = "default", **kwargs) -> Me
         Memory instance
     """
     return Memory(provider=provider, user_id=user_id, **kwargs)
-
 
 def configure(**kwargs) -> AIConfig:
     """
@@ -275,8 +266,7 @@ def configure(**kwargs) -> AIConfig:
     """
     return AIConfig(**kwargs)
 
-
-def agent(runner: str = "simple", memory: Optional[Memory] = None, config: Optional[AIConfig] = None, **kwargs) -> Agent:
+def agent(runner: str = "simple", memory: Memory | None = None, config: AIConfig | None = None, **kwargs) -> Agent:
     """
     Create an agent instance with the specified runner
 

--- a/robyn/ai.py
+++ b/robyn/ai.py
@@ -9,9 +9,10 @@ Provides agent and memory functionality for building AI-powered applications for
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
 
 class AIConfig:
     """Configuration class for AI providers and settings"""
@@ -58,6 +59,7 @@ class AIConfig:
         """Get configuration as dictionary"""
         return self.config.copy()
 
+
 class MemoryProvider(ABC):
     """Abstract base class for memory providers"""
 
@@ -76,6 +78,7 @@ class MemoryProvider(ABC):
         """Clear memory for a user"""
         pass
 
+
 class InMemoryProvider(MemoryProvider):
     """Simple in-memory storage provider"""
 
@@ -93,6 +96,7 @@ class InMemoryProvider(MemoryProvider):
     async def clear(self, user_id: str) -> None:
         if user_id in self._storage:
             del self._storage[user_id]
+
 
 class Memory:
     """Memory interface for storing and retrieving conversation history and context"""
@@ -121,6 +125,7 @@ class Memory:
         """Clear all memory for this user"""
         await self.provider.clear(self.user_id)
 
+
 class AgentRunner(ABC):
     """Abstract base class for agent runners"""
 
@@ -128,6 +133,7 @@ class AgentRunner(ABC):
     async def run(self, query: str, **kwargs) -> dict[str, Any]:
         """Execute the agent with the given query"""
         pass
+
 
 class SimpleRunner(AgentRunner):
     """Simple runner with OpenAI integration and fallback responses"""
@@ -197,6 +203,7 @@ class SimpleRunner(AgentRunner):
             logger.error(f"Error in SimpleRunner: {e}")
             raise e
 
+
 class Agent:
     """AI Agent interface for handling queries with memory and execution"""
 
@@ -233,6 +240,7 @@ class Agent:
 
         return result
 
+
 def memory(provider: str = "inmemory", user_id: str = "default", **kwargs) -> Memory:
     """
     Create a memory instance with the specified provider
@@ -246,6 +254,7 @@ def memory(provider: str = "inmemory", user_id: str = "default", **kwargs) -> Me
         Memory instance
     """
     return Memory(provider=provider, user_id=user_id, **kwargs)
+
 
 def configure(**kwargs) -> AIConfig:
     """
@@ -265,6 +274,7 @@ def configure(**kwargs) -> AIConfig:
         )
     """
     return AIConfig(**kwargs)
+
 
 def agent(runner: str = "simple", memory: Memory | None = None, config: AIConfig | None = None, **kwargs) -> Agent:
     """

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from robyn.robyn import Headers, Identity, Request, Response
 from robyn.status_codes import HTTP_401_UNAUTHORIZED
-
 
 class AuthenticationNotConfiguredError(Exception):
     """
@@ -12,7 +10,6 @@ class AuthenticationNotConfiguredError(Exception):
 
     def __str__(self):
         return "Authentication is not configured. Use app.configure_authentication() to configure it."
-
 
 class TokenGetter(ABC):
     @property
@@ -25,7 +22,7 @@ class TokenGetter(ABC):
 
     @classmethod
     @abstractmethod
-    def get_token(cls, request: Request) -> Optional[str]:
+    def get_token(cls, request: Request) -> str | None:
         """
         Gets the token from the request.
         This method should not decode the token. Decoding is the role of the authentication handler.
@@ -45,7 +42,6 @@ class TokenGetter(ABC):
         """
         raise NotImplementedError()
 
-
 class AuthenticationHandler(ABC):
     def __init__(self, token_getter: TokenGetter):
         """
@@ -64,14 +60,13 @@ class AuthenticationHandler(ABC):
         )
 
     @abstractmethod
-    def authenticate(self, request: Request) -> Optional[Identity]:
+    def authenticate(self, request: Request) -> Identity | None:
         """
         Authenticates the user.
         :param request: The request object.
         :return: The identity of the user.
         """
         raise NotImplementedError()
-
 
 class BearerGetter(TokenGetter):
     """
@@ -80,7 +75,7 @@ class BearerGetter(TokenGetter):
     """
 
     @classmethod
-    def get_token(cls, request: Request) -> Optional[str]:
+    def get_token(cls, request: Request) -> str | None:
         if request.headers.contains("authorization"):
             authorization_header = request.headers.get("authorization")
         else:

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from robyn.robyn import Headers, Identity, Request, Response
 from robyn.status_codes import HTTP_401_UNAUTHORIZED
 
+
 class AuthenticationNotConfiguredError(Exception):
     """
     This exception is raised when the authentication is not configured.
@@ -10,6 +11,7 @@ class AuthenticationNotConfiguredError(Exception):
 
     def __str__(self):
         return "Authentication is not configured. Use app.configure_authentication() to configure it."
+
 
 class TokenGetter(ABC):
     @property
@@ -42,6 +44,7 @@ class TokenGetter(ABC):
         """
         raise NotImplementedError()
 
+
 class AuthenticationHandler(ABC):
     def __init__(self, token_getter: TokenGetter):
         """
@@ -67,6 +70,7 @@ class AuthenticationHandler(ABC):
         :return: The identity of the user.
         """
         raise NotImplementedError()
+
 
 class BearerGetter(TokenGetter):
     """

--- a/robyn/cli.py
+++ b/robyn/cli.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 import webbrowser
 from pathlib import Path
-from typing import Optional
 
 from InquirerPy.base.control import Choice
 from InquirerPy.resolver import prompt
@@ -17,7 +16,6 @@ from .reloader import create_rust_file, setup_reloader
 
 SCAFFOLD_DIR = Path(__file__).parent / "scaffold"
 CURRENT_WORKING_DIR = Path.cwd()
-
 
 def create_robyn_app():
     questions = [
@@ -73,13 +71,11 @@ def create_robyn_app():
 
     print(f"New Robyn project created in '{final_project_dir_path}' ")
 
-
 def docs():
     print("Opening Robyn documentation... | Offline docs coming soon!")
     webbrowser.open("https://robyn.tech")
 
-
-def start_dev_server(config: Config, file_path: Optional[str] = None):
+def start_dev_server(config: Config, file_path: str | None = None):
     if file_path is None:
         return
 
@@ -90,7 +86,6 @@ def start_dev_server(config: Config, file_path: Optional[str] = None):
         setup_reloader(str(directory_path), str(absolute_file_path))
         return
 
-
 def start_app_normally(config: Config):
     command = [sys.executable]
 
@@ -99,7 +94,6 @@ def start_app_normally(config: Config):
 
     # Run the subprocess
     subprocess.run(command, start_new_session=False)
-
 
 def run():
     config = Config()

--- a/robyn/cli.py
+++ b/robyn/cli.py
@@ -17,6 +17,7 @@ from .reloader import create_rust_file, setup_reloader
 SCAFFOLD_DIR = Path(__file__).parent / "scaffold"
 CURRENT_WORKING_DIR = Path.cwd()
 
+
 def create_robyn_app():
     questions = [
         {
@@ -71,9 +72,11 @@ def create_robyn_app():
 
     print(f"New Robyn project created in '{final_project_dir_path}' ")
 
+
 def docs():
     print("Opening Robyn documentation... | Offline docs coming soon!")
     webbrowser.open("https://robyn.tech")
+
 
 def start_dev_server(config: Config, file_path: str | None = None):
     if file_path is None:
@@ -86,6 +89,7 @@ def start_dev_server(config: Config, file_path: str | None = None):
         setup_reloader(str(directory_path), str(absolute_file_path))
         return
 
+
 def start_app_normally(config: Config):
     command = [sys.executable]
 
@@ -94,6 +98,7 @@ def start_app_normally(config: Config):
 
     # Run the subprocess
     subprocess.run(command, start_new_session=False)
+
 
 def run():
     config = Config()

--- a/robyn/logger.py
+++ b/robyn/logger.py
@@ -1,7 +1,5 @@
 import logging
 from enum import Enum
-from typing import Optional
-
 
 class Colors(Enum):
     BLUE = "\033[94m"
@@ -9,7 +7,6 @@ class Colors(Enum):
     GREEN = "\033[92m"
     YELLOW = "\033[93m"
     RED = "\033[91m"
-
 
 class Logger:
     HEADER = "\033[95m"
@@ -23,7 +20,7 @@ class Logger:
     def _format_msg(
         self,
         msg: str,
-        color: Optional[Colors],
+        color: Colors | None,
         bold: bool,
         underline: bool,
     ):
@@ -40,7 +37,7 @@ class Logger:
         self,
         msg: str,
         *args,
-        color: Optional[Colors] = Colors.RED,
+        color: Colors | None = Colors.RED,
         bold: bool = False,
         underline: bool = False,
     ):
@@ -50,7 +47,7 @@ class Logger:
         self,
         msg: str,
         *args,
-        color: Optional[Colors] = Colors.YELLOW,
+        color: Colors | None = Colors.YELLOW,
         bold: bool = False,
         underline: bool = False,
     ):
@@ -60,7 +57,7 @@ class Logger:
         self,
         msg: str,
         *args,
-        color: Optional[Colors] = Colors.GREEN,
+        color: Colors | None = Colors.GREEN,
         bold: bool = False,
         underline: bool = False,
     ):
@@ -75,6 +72,5 @@ class Logger:
         underline: bool = False,
     ):
         self.logger.debug(self._format_msg(msg, color, bold, underline), *args)
-
 
 logger = Logger()

--- a/robyn/logger.py
+++ b/robyn/logger.py
@@ -1,12 +1,14 @@
 import logging
 from enum import Enum
 
+
 class Colors(Enum):
     BLUE = "\033[94m"
     CYAN = "\033[96m"
     GREEN = "\033[92m"
     YELLOW = "\033[93m"
     RED = "\033[91m"
+
 
 class Logger:
     HEADER = "\033[95m"
@@ -72,5 +74,6 @@ class Logger:
         underline: bool = False,
     ):
         self.logger.debug(self._format_msg(msg, color, bold, underline), *args)
+
 
 logger = Logger()

--- a/robyn/mcp.py
+++ b/robyn/mcp.py
@@ -11,17 +11,15 @@ import json
 import logging
 import re
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-
-def _extract_uri_params(uri: str) -> List[str]:
+def _extract_uri_params(uri: str) -> list[str]:
     """Extract parameter names from URI template like 'echo://{message}'"""
     return re.findall(r"\{(\w+)\}", uri)
 
-
-def _generate_schema_from_function(func: Callable) -> Dict[str, Any]:
+def _generate_schema_from_function(func: Callable) -> dict[str, Any]:
     """Generate JSON schema from function signature"""
     sig = inspect.signature(func)
     properties = {}
@@ -56,8 +54,7 @@ def _generate_schema_from_function(func: Callable) -> Dict[str, Any]:
 
     return {"type": "object", "properties": properties, "required": required}
 
-
-def _generate_prompt_args_from_function(func: Callable) -> List[Dict[str, Any]]:
+def _generate_prompt_args_from_function(func: Callable) -> list[dict[str, Any]]:
     """Generate prompt arguments from function signature"""
     sig = inspect.signature(func)
     arguments = []
@@ -71,16 +68,14 @@ def _generate_prompt_args_from_function(func: Callable) -> List[Dict[str, Any]]:
 
     return arguments
 
-
 @dataclass
 class MCPResource:
     """Represents an MCP resource"""
 
     uri: str
     name: str
-    description: Optional[str] = None
-    mimeType: Optional[str] = None
-
+    description: str | None = None
+    mimeType: str | None = None
 
 @dataclass
 class MCPTool:
@@ -88,8 +83,7 @@ class MCPTool:
 
     name: str
     description: str
-    inputSchema: Dict[str, Any]
-
+    inputSchema: dict[str, Any]
 
 @dataclass
 class MCPPrompt:
@@ -97,59 +91,56 @@ class MCPPrompt:
 
     name: str
     description: str
-    arguments: Optional[List[Dict[str, Any]]] = None
-
+    arguments: Optional[list[dict[str, Any]]] = None
 
 @dataclass
 class MCPMessage:
     """JSON-RPC 2.0 message structure"""
 
     jsonrpc: str = "2.0"
-    id: Optional[Union[str, int]] = None
-    method: Optional[str] = None
-    params: Optional[Dict[str, Any]] = None
-    result: Optional[Any] = None
-    error: Optional[Dict[str, Any]] = None
-
+    id: str | int | None = None
+    method: str | None = None
+    params: dict[str, Any] | None = None
+    result: Any | None = None
+    error: dict[str, Any] | None = None
 
 class MCPError(Exception):
     """MCP-specific error"""
 
-    def __init__(self, code: int, message: str, data: Optional[Any] = None):
+    def __init__(self, code: int, message: str, data: Any | None = None):
         self.code = code
         self.message = message
         self.data = data
         super().__init__(message)
 
-
 class MCPHandler:
     """Handles MCP protocol requests and responses"""
 
     def __init__(self):
-        self.resources: Dict[str, Callable] = {}
-        self.tools: Dict[str, Callable] = {}
-        self.prompts: Dict[str, Callable] = {}
-        self.resource_metadata: Dict[str, MCPResource] = {}
-        self.tool_metadata: Dict[str, MCPTool] = {}
-        self.prompt_metadata: Dict[str, MCPPrompt] = {}
+        self.resources: dict[str, Callable] = {}
+        self.tools: dict[str, Callable] = {}
+        self.prompts: dict[str, Callable] = {}
+        self.resource_metadata: dict[str, MCPResource] = {}
+        self.tool_metadata: dict[str, MCPTool] = {}
+        self.prompt_metadata: dict[str, MCPPrompt] = {}
         self.server_info = {"name": "robyn-mcp-server", "version": "1.0.0"}
 
-    def register_resource(self, uri: str, name: str, handler: Callable, description: Optional[str] = None, mime_type: Optional[str] = None):
+    def register_resource(self, uri: str, name: str, handler: Callable, description: str | None = None, mime_type: str | None = None):
         """Register a resource handler"""
         self.resources[uri] = handler
         self.resource_metadata[uri] = MCPResource(uri=uri, name=name, description=description, mimeType=mime_type)
 
-    def register_tool(self, name: str, handler: Callable, description: str, input_schema: Dict[str, Any]):
+    def register_tool(self, name: str, handler: Callable, description: str, input_schema: dict[str, Any]):
         """Register a tool handler"""
         self.tools[name] = handler
         self.tool_metadata[name] = MCPTool(name=name, description=description, inputSchema=input_schema)
 
-    def register_prompt(self, name: str, handler: Callable, description: str, arguments: Optional[List[Dict[str, Any]]] = None):
+    def register_prompt(self, name: str, handler: Callable, description: str, arguments: Optional[list[dict[str, Any]]] = None):
         """Register a prompt handler"""
         self.prompts[name] = handler
         self.prompt_metadata[name] = MCPPrompt(name=name, description=description, arguments=arguments)
 
-    async def handle_request(self, request_data: Dict[str, Any]) -> Dict[str, Any]:
+    async def handle_request(self, request_data: dict[str, Any]) -> dict[str, Any]:
         """Handle an MCP JSON-RPC request"""
         try:
             # Parse the request
@@ -184,7 +175,7 @@ class MCPHandler:
             logger.exception("Error handling MCP request")
             return {"jsonrpc": "2.0", "id": request_data.get("id"), "error": {"code": -32603, "message": "Internal error", "data": str(e)}}
 
-    async def _handle_initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_initialize(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle MCP initialize request"""
         return {
             "protocolVersion": "2024-11-05",
@@ -192,14 +183,14 @@ class MCPHandler:
             "serverInfo": self.server_info,
         }
 
-    async def _handle_list_resources(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_list_resources(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle resources/list request"""
         resources = []
         for uri, metadata in self.resource_metadata.items():
             resources.append(asdict(metadata))
         return {"resources": resources}
 
-    def _match_uri_template(self, requested_uri: str) -> Optional[Tuple[str, Dict[str, str]]]:
+    def _match_uri_template(self, requested_uri: str) -> Optional[tuple[str, dict[str, str]]]:
         """Match requested URI against registered URI templates"""
         for template_uri in self.resources.keys():
             # Extract parameter names from template
@@ -231,7 +222,7 @@ class MCPHandler:
 
         return None
 
-    async def _handle_read_resource(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_read_resource(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle resources/read request"""
         uri = params.get("uri")
         if not uri:
@@ -280,14 +271,14 @@ class MCPHandler:
 
         return {"contents": [{"uri": uri, "mimeType": mime_type, "text": str(content)}]}
 
-    async def _handle_list_tools(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_list_tools(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle tools/list request"""
         tools = []
         for name, metadata in self.tool_metadata.items():
             tools.append(asdict(metadata))
         return {"tools": tools}
 
-    async def _handle_call_tool(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_call_tool(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle tools/call request"""
         name = params.get("name")
         arguments = params.get("arguments", {})
@@ -305,14 +296,14 @@ class MCPHandler:
 
         return {"content": [{"type": "text", "text": str(result)}]}
 
-    async def _handle_list_prompts(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_list_prompts(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle prompts/list request"""
         prompts = []
         for name, metadata in self.prompt_metadata.items():
             prompts.append(asdict(metadata))
         return {"prompts": prompts}
 
-    async def _handle_get_prompt(self, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_get_prompt(self, params: dict[str, Any]) -> dict[str, Any]:
         """Handle prompts/get request"""
         name = params.get("name")
         arguments = params.get("arguments", {})
@@ -337,7 +328,6 @@ class MCPHandler:
             messages = [{"role": "user", "content": {"type": "text", "text": str(result)}}]
 
         return {"description": self.prompt_metadata[name].description, "messages": messages}
-
 
 class MCPApp:
     """MCP application wrapper for Robyn"""
@@ -380,7 +370,7 @@ class MCPApp:
                 logger.exception("Error in MCP request handler")
                 return {"jsonrpc": "2.0", "id": None, "error": {"code": -32603, "message": "Internal error", "data": str(e)}}
 
-    def resource(self, uri: str = None, name: str = None, description: Optional[str] = None, mime_type: Optional[str] = None):
+    def resource(self, uri: str = None, name: str = None, description: str | None = None, mime_type: str | None = None):
         """
         Decorator to register an MCP resource
 
@@ -408,7 +398,7 @@ class MCPApp:
 
         return decorator
 
-    def tool(self, name: str = None, description: str = None, input_schema: Dict[str, Any] = None):
+    def tool(self, name: str = None, description: str = None, input_schema: dict[str, Any] = None):
         """
         Decorator to register an MCP tool
 
@@ -434,7 +424,7 @@ class MCPApp:
 
         return decorator
 
-    def prompt(self, name: str = None, description: str = None, arguments: Optional[List[Dict[str, Any]]] = None):
+    def prompt(self, name: str = None, description: str = None, arguments: Optional[list[dict[str, Any]]] = None):
         """
         Decorator to register an MCP prompt
 

--- a/robyn/mcp.py
+++ b/robyn/mcp.py
@@ -11,13 +11,15 @@ import json
 import logging
 import re
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
 
 def _extract_uri_params(uri: str) -> list[str]:
     """Extract parameter names from URI template like 'echo://{message}'"""
     return re.findall(r"\{(\w+)\}", uri)
+
 
 def _generate_schema_from_function(func: Callable) -> dict[str, Any]:
     """Generate JSON schema from function signature"""
@@ -54,6 +56,7 @@ def _generate_schema_from_function(func: Callable) -> dict[str, Any]:
 
     return {"type": "object", "properties": properties, "required": required}
 
+
 def _generate_prompt_args_from_function(func: Callable) -> list[dict[str, Any]]:
     """Generate prompt arguments from function signature"""
     sig = inspect.signature(func)
@@ -68,6 +71,7 @@ def _generate_prompt_args_from_function(func: Callable) -> list[dict[str, Any]]:
 
     return arguments
 
+
 @dataclass
 class MCPResource:
     """Represents an MCP resource"""
@@ -77,6 +81,7 @@ class MCPResource:
     description: str | None = None
     mimeType: str | None = None
 
+
 @dataclass
 class MCPTool:
     """Represents an MCP tool"""
@@ -85,6 +90,7 @@ class MCPTool:
     description: str
     inputSchema: dict[str, Any]
 
+
 @dataclass
 class MCPPrompt:
     """Represents an MCP prompt template"""
@@ -92,6 +98,7 @@ class MCPPrompt:
     name: str
     description: str
     arguments: Optional[list[dict[str, Any]]] = None
+
 
 @dataclass
 class MCPMessage:
@@ -104,6 +111,7 @@ class MCPMessage:
     result: Any | None = None
     error: dict[str, Any] | None = None
 
+
 class MCPError(Exception):
     """MCP-specific error"""
 
@@ -112,6 +120,7 @@ class MCPError(Exception):
         self.message = message
         self.data = data
         super().__init__(message)
+
 
 class MCPHandler:
     """Handles MCP protocol requests and responses"""
@@ -328,6 +337,7 @@ class MCPHandler:
             messages = [{"role": "user", "content": {"type": "text", "text": str(result)}}]
 
         return {"description": self.prompt_metadata[name].description, "messages": messages}
+
 
 class MCPApp:
     """MCP application wrapper for Robyn"""

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -2,12 +2,14 @@ import inspect
 import json
 import logging
 import re
+import types
 import typing
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from importlib import resources
 from inspect import Signature
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, is_typeddict
+from typing import Any, Protocol, TypeAlias, TypedDict, get_args, get_origin, is_typeddict
 
 from robyn.pydantic_support import get_pydantic_openapi_schema, is_pydantic_model
 from robyn.responses import html
@@ -28,14 +30,14 @@ class Contact:
     The contact information for the exposed API.
     (https://swagger.io/specification/#contact-object)
 
-    @param name: Optional[str] The identifying name of the contact person/organization.
-    @param url: Optional[str] The URL pointing to the contact information. This MUST be in the form of a URL.
-    @param email: Optional[str] The email address of the contact person/organization. This MUST be in the form of an email address.
+    @param name: str | None The identifying name of the contact person/organization.
+    @param url: str | None The URL pointing to the contact information. This MUST be in the form of a URL.
+    @param email: str | None The email address of the contact person/organization. This MUST be in the form of an email address.
     """
 
-    name: Optional[str] = None
-    url: Optional[str] = None
-    email: Optional[str] = None
+    name: str | None = None
+    url: str | None = None
+    email: str | None = None
 
 
 @dataclass
@@ -44,12 +46,12 @@ class License:
     The license information for the exposed API.
     (https://swagger.io/specification/#license-object)
 
-    @param name: Optional[str] The license name used for the API.
-    @param url: Optional[str] A URL to the license used for the API. This MUST be in the form of a URL.
+    @param name: str | None The license name used for the API.
+    @param url: str | None A URL to the license used for the API. This MUST be in the form of a URL.
     """
 
-    name: Optional[str] = None
-    url: Optional[str] = None
+    name: str | None = None
+    url: str | None = None
 
 
 @dataclass
@@ -62,11 +64,11 @@ class Server:
     @param url: str A URL to the target host. This URL supports Server Variables and MAY be relative,
     to indicate that the host location is relative to the location where the OpenAPI document is being served.
     Variable substitutions will be made when a variable is named in {brackets}.
-    @param description: Optional[str] An optional string describing the host designated by the URL.
+    @param description: str | None An optional string describing the host designated by the URL.
     """
 
     url: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 @dataclass
@@ -75,12 +77,12 @@ class ExternalDocumentation:
     Additional external documentation for this operation.
     (https://swagger.io/specification/#external-documentation-object)
 
-    @param description: Optional[str] A description of the target documentation.
-    @param url: Optional[str] The URL for the target documentation.
+    @param description: str | None A description of the target documentation.
+    @param url: str | None The URL for the target documentation.
     """
 
-    description: Optional[str] = None
-    url: Optional[str] = None
+    description: str | None = None
+    url: str | None = None
 
 
 @dataclass
@@ -89,26 +91,26 @@ class Components:
     Additional external documentation for this operation.
     (https://swagger.io/specification/#components-object)
 
-    @param schemas: Optional[Dict[str, Dict]] An object to hold reusable Schema Objects.
-    @param responses: Optional[Dict[str, Dict]] An object to hold reusable Response Objects.
-    @param parameters: Optional[Dict[str, Dict]] An object to hold reusable Parameter Objects.
-    @param examples: Optional[Dict[str, Dict]] An object to hold reusable Example Objects.
-    @param requestBodies: Optional[Dict[str, Dict]] An object to hold reusable Request Body Objects.
-    @param securitySchemes: Optional[Dict[str, Dict]] An object to hold reusable Security Scheme Objects.
-    @param links: Optional[Dict[str, Dict]] An object to hold reusable Link Objects.
-    @param callbacks: Optional[Dict[str, Dict]] An object to hold reusable Callback Objects.
-    @param pathItems: Optional[Dict[str, Dict]] An object to hold reusable Callback Objects.
+    @param schemas: dict[str, Dict] | None An object to hold reusable Schema Objects.
+    @param responses: dict[str, Dict] | None An object to hold reusable Response Objects.
+    @param parameters: dict[str, Dict] | None An object to hold reusable Parameter Objects.
+    @param examples: dict[str, Dict] | None An object to hold reusable Example Objects.
+    @param requestBodies: dict[str, Dict] | None An object to hold reusable Request Body Objects.
+    @param securitySchemes: dict[str, Dict] | None An object to hold reusable Security Scheme Objects.
+    @param links: dict[str, Dict] | None An object to hold reusable Link Objects.
+    @param callbacks: dict[str, Dict] | None An object to hold reusable Callback Objects.
+    @param pathItems: dict[str, Dict] | None An object to hold reusable Callback Objects.
     """
 
-    schemas: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    responses: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    parameters: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    examples: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    requestBodies: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    securitySchemes: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    links: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    callbacks: Optional[Dict[str, Dict]] = field(default_factory=dict)
-    pathItems: Optional[Dict[str, Dict]] = field(default_factory=dict)
+    schemas: dict[str, Dict] | None = field(default_factory=dict)
+    responses: dict[str, Dict] | None = field(default_factory=dict)
+    parameters: dict[str, Dict] | None = field(default_factory=dict)
+    examples: dict[str, Dict] | None = field(default_factory=dict)
+    requestBodies: dict[str, Dict] | None = field(default_factory=dict)
+    securitySchemes: dict[str, Dict] | None = field(default_factory=dict)
+    links: dict[str, Dict] | None = field(default_factory=dict)
+    callbacks: dict[str, Dict] | None = field(default_factory=dict)
+    pathItems: dict[str, Dict] | None = field(default_factory=dict)
 
 
 @dataclass
@@ -119,23 +121,23 @@ class OpenAPIInfo:
 
     @param title: str The title of the API.
     @param version: str The version of the API.
-    @param description: Optional[str] A description of the API.
-    @param termsOfService: Optional[str] A URL to the Terms of Service for the API.
+    @param description: str | None A description of the API.
+    @param termsOfService: str | None A URL to the Terms of Service for the API.
     @param contact: Contact The contact information for the exposed API.
     @param license: License The license information for the exposed API.
     @param servers: list[Server] An list of Server objects representing the servers.
-    @param externalDocs: Optional[ExternalDocumentation] Additional external documentation.
+    @param externalDocs: ExternalDocumentation | None Additional external documentation.
     @param components: Components An element to hold various schemas for the document.
     """
 
     title: str = "Robyn API"
     version: str = "1.0.0"
-    description: Optional[str] = None
-    termsOfService: Optional[str] = None
+    description: str | None = None
+    termsOfService: str | None = None
     contact: Contact = field(default_factory=Contact)
     license: License = field(default_factory=License)
-    servers: List[Server] = field(default_factory=list)
-    externalDocs: Optional[ExternalDocumentation] = field(default_factory=ExternalDocumentation)
+    servers: list[Server] = field(default_factory=list)
+    externalDocs: ExternalDocumentation | None = field(default_factory=ExternalDocumentation)
     components: Components = field(default_factory=Components)
 
 
@@ -168,14 +170,14 @@ class OpenAPI:
             "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
         }
 
-    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable):
+    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: list[str], handler: Callable):
         """
         Adds the given path to openapi spec
 
         @param route_type: str the http method as string (get, post ...)
         @param endpoint: str the endpoint to be added
         @param openapi_name: str the name of the endpoint
-        @param openapi_tags: List[str] for grouping of endpoints
+        @param openapi_tags: list[str] for grouping of endpoints
         @param handler: Callable the handler function for the endpoint
         """
 
@@ -270,21 +272,21 @@ class OpenAPI:
         endpoint: str,
         name: str,
         description: str,
-        tags: List[str],
-        query_params: Optional[str_typed_dict],
-        request_body: Optional[str_typed_dict],
-        return_annotation: Optional[str_typed_dict],
-    ) -> Tuple[str, dict]:
+        tags: list[str],
+        query_params: str_typed_dict | None,
+        request_body: str_typed_dict | None,
+        return_annotation: str_typed_dict | None,
+    ) -> tuple[str, dict]:
         """
         Get the "path" openapi object according to spec
 
         @param endpoint: str the endpoint to be added
         @param name: str the name of the endpoint
-        @param description: Optional[str] short description of the endpoint (to be fetched from the endpoint definition by default)
-        @param tags: List[str] for grouping of endpoints
-        @param query_params: Optional[TypedDict] query params for the function
-        @param request_body: Optional[TypedDict] request body for the function
-        @param return_annotation: Optional[TypedDict] return type of the endpoint handler
+        @param description: str | None short description of the endpoint (to be fetched from the endpoint definition by default)
+        @param tags: list[str] for grouping of endpoints
+        @param query_params: TypedDict | None query params for the function
+        @param request_body: TypedDict | None request body for the function
+        @param return_annotation: TypedDict | None return type of the endpoint handler
 
         @return: (str, dict) a tuple containing the endpoint with path params wrapped in braces and the "path" openapi object
         according to spec
@@ -423,15 +425,16 @@ class OpenAPI:
                 properties["type"] = type_mapping[type_name]
                 return properties
 
-        # Check if it's a generic type (like List[Object])
-        if hasattr(param_type, "__origin__"):
-            if param_type.__origin__ is list or param_type.__origin__ is List:
-                properties["type"] = "array"
-                # Handle the element type in the list
-                if hasattr(param_type, "__args__") and param_type.__args__:
-                    item_type = param_type.__args__[0]
-                    properties["items"] = self.get_schema_object(f"{parameter}_item", item_type)
-                return properties
+        origin = get_origin(param_type)
+        args = get_args(param_type)
+
+        # Check if it's a generic type (like list[Object])
+        if origin is list:
+            properties["type"] = "array"
+            if args:
+                item_type = args[0]
+                properties["items"] = self.get_schema_object(f"{parameter}_item", item_type)
+            return properties
 
         # check for Pydantic models
         if is_pydantic_model(param_type):
@@ -440,9 +443,15 @@ class OpenAPI:
                 self._merge_component_schemas(component_schemas)
             return schema
 
-        # check for Optional type
-        if param_type.__module__ == "typing":
-            properties["anyOf"] = [{"type": self.get_openapi_type(param_type.__args__[0])}, {"type": "null"}]
+        # check for Optional/Union types
+        if origin in (typing.Union, types.UnionType):
+            any_of: list[dict] = []
+            for arg in args:
+                if arg is type(None):
+                    any_of.append({"type": "null"})
+                else:
+                    any_of.append(self.get_schema_object(parameter, arg))
+            properties["anyOf"] = any_of
             return properties
         # check for custom classes and TypedDicts
         elif inspect.isclass(param_type):

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -9,7 +9,7 @@ from dataclasses import asdict, dataclass, field
 from importlib import resources
 from inspect import Signature
 from pathlib import Path
-from typing import Any, Protocol, TypeAlias, TypedDict, get_args, get_origin, is_typeddict
+from typing import Any, TypedDict, get_args, get_origin, is_typeddict
 
 from robyn.pydantic_support import get_pydantic_openapi_schema, is_pydantic_model
 from robyn.responses import html

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -2,7 +2,6 @@ import asyncio
 import signal
 import sys
 import webbrowser
-from typing import Dict, List, Optional
 
 from multiprocess import Process  # type: ignore
 
@@ -12,25 +11,24 @@ from robyn.robyn import FunctionInfo, Headers, Server, SocketHeld
 from robyn.router import GlobalMiddleware, Route, RouteMiddleware
 from robyn.types import Directory
 
-
 def run_processes(
     url: str,
     port: int,
-    directories: List[Directory],
+    directories: list[Directory],
     request_headers: Headers,
-    routes: List[Route],
-    global_middlewares: List[GlobalMiddleware],
-    route_middlewares: List[RouteMiddleware],
-    web_sockets: Dict[str, dict],
-    event_handlers: Dict[Events, FunctionInfo],
+    routes: list[Route],
+    global_middlewares: list[GlobalMiddleware],
+    route_middlewares: list[RouteMiddleware],
+    web_sockets: dict[str, dict],
+    event_handlers: dict[Events, FunctionInfo],
     workers: int,
     processes: int,
     response_headers: Headers,
-    excluded_response_headers_paths: Optional[List[str]],
+    excluded_response_headers_paths: list[str] | None,
     open_browser: bool,
     client_timeout: int = 30,
     keep_alive_timeout: int = 20,
-) -> List[Process]:
+) -> list[Process]:
     socket = SocketHeld(url, port)
 
     process_pool = init_processpool(
@@ -68,23 +66,22 @@ def run_processes(
 
     return process_pool
 
-
 def init_processpool(
-    directories: List[Directory],
+    directories: list[Directory],
     request_headers: Headers,
-    routes: List[Route],
-    global_middlewares: List[GlobalMiddleware],
-    route_middlewares: List[RouteMiddleware],
-    web_sockets: Dict[str, dict],
-    event_handlers: Dict[Events, FunctionInfo],
+    routes: list[Route],
+    global_middlewares: list[GlobalMiddleware],
+    route_middlewares: list[RouteMiddleware],
+    web_sockets: dict[str, dict],
+    event_handlers: dict[Events, FunctionInfo],
     socket: SocketHeld,
     workers: int,
     processes: int,
     response_headers: Headers,
-    excluded_response_headers_paths: Optional[List[str]],
+    excluded_response_headers_paths: list[str] | None,
     client_timeout: int = 30,
     keep_alive_timeout: int = 20,
-) -> List[Process]:
+) -> list[Process]:
     process_pool: List = []
     if sys.platform.startswith("win32") or processes == 1:
         spawn_process(
@@ -130,7 +127,6 @@ def init_processpool(
 
     return process_pool
 
-
 def initialize_event_loop():
     if sys.platform.startswith("win32") or sys.platform.startswith("linux-cross"):
         loop = asyncio.new_event_loop()
@@ -146,19 +142,18 @@ def initialize_event_loop():
         asyncio.set_event_loop(loop)
         return loop
 
-
 def spawn_process(
-    directories: List[Directory],
+    directories: list[Directory],
     request_headers: Headers,
-    routes: List[Route],
-    global_middlewares: List[GlobalMiddleware],
-    route_middlewares: List[RouteMiddleware],
-    web_sockets: Dict[str, dict],
-    event_handlers: Dict[Events, FunctionInfo],
+    routes: list[Route],
+    global_middlewares: list[GlobalMiddleware],
+    route_middlewares: list[RouteMiddleware],
+    web_sockets: dict[str, dict],
+    event_handlers: dict[Events, FunctionInfo],
     socket: SocketHeld,
     workers: int,
     response_headers: Headers,
-    excluded_response_headers_paths: Optional[List[str]],
+    excluded_response_headers_paths: list[str] | None,
     client_timeout: int = 30,
     keep_alive_timeout: int = 20,
 ):
@@ -168,8 +163,8 @@ def spawn_process(
 
     :param directories List: the list of all the directories and related data
     :param headers tuple: All the global headers in a tuple
-    :param routes Tuple[Route]: The routes tuple, containing the description about every route.
-    :param middlewares Tuple[Route]: The middleware routes tuple, containing the description about every route.
+    :param routes tuple[Route]: The routes tuple, containing the description about every route.
+    :param middlewares tuple[Route]: The middleware routes tuple, containing the description about every route.
     :param web_sockets list: This is a list of all the web socket routes
     :param event_handlers Dict: This is an event dict that contains the event handlers
     :param socket SocketHeld: This is the main tcp socket, which is being shared across multiple processes.

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -84,7 +84,7 @@ def init_processpool(
     client_timeout: int = 30,
     keep_alive_timeout: int = 20,
 ) -> list[Process]:
-    process_pool: List = []
+    process_pool: list = []
     if sys.platform.startswith("win32") or processes == 1:
         spawn_process(
             directories,

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -11,6 +11,7 @@ from robyn.robyn import FunctionInfo, Headers, Server, SocketHeld
 from robyn.router import GlobalMiddleware, Route, RouteMiddleware
 from robyn.types import Directory
 
+
 def run_processes(
     url: str,
     port: int,
@@ -65,6 +66,7 @@ def run_processes(
         process.join()
 
     return process_pool
+
 
 def init_processpool(
     directories: list[Directory],
@@ -127,6 +129,7 @@ def init_processpool(
 
     return process_pool
 
+
 def initialize_event_loop():
     if sys.platform.startswith("win32") or sys.platform.startswith("linux-cross"):
         loop = asyncio.new_event_loop()
@@ -141,6 +144,7 @@ def initialize_event_loop():
         loop = uvloop.new_event_loop()
         asyncio.set_event_loop(loop)
         return loop
+
 
 def spawn_process(
     directories: list[Directory],

--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -4,15 +4,14 @@ import signal
 import subprocess
 import sys
 import time
-from typing import List, Union
+from typing import List
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from robyn.logger import Colors, logger
 
-
-def compile_rust_files(directory_path: str) -> List[str]:
+def compile_rust_files(directory_path: str) -> list[str]:
     rust_files = glob.glob(os.path.join(directory_path, "**/*.rs"), recursive=True)
     rust_binaries: list[str] = []
 
@@ -48,7 +47,6 @@ def compile_rust_files(directory_path: str) -> List[str]:
 
     return rust_binaries
 
-
 def create_rust_file(file_name: str) -> None:
     if file_name.endswith(".rs"):
         file_name = file_name.removesuffix(".rs")
@@ -71,12 +69,10 @@ def create_rust_file(file_name: str) -> None:
     else:
         print("Created rust file : %s", rust_file)
 
-
-def clean_rust_binaries(rust_binaries: List[str]) -> None:
+def clean_rust_binaries(rust_binaries: list[str]) -> None:
     for file in rust_binaries:
         print("Cleaning rust file : %s", file)
         os.remove(file)
-
 
 def setup_reloader(directory_path: str, file_path: str) -> None:
     event_handler = EventHandler(file_path, directory_path)
@@ -111,12 +107,11 @@ def setup_reloader(directory_path: str, file_path: str) -> None:
         observer.join()
         event_handler.process.wait()
 
-
 class EventHandler(FileSystemEventHandler):
     def __init__(self, file_path: str, directory_path: str) -> None:
         self.file_path = file_path
         self.directory_path = directory_path
-        self.process: Union[subprocess.Popen[bytes], None] = None  # Keep track of the subprocess
+        self.process: subprocess.Popen[bytes] | None = None  # Keep track of the subprocess
         self.built_rust_binaries: List = []  # Keep track of the built rust binaries
 
         self.last_reload = time.time()  # Keep track of the last reload. EventHandler is initialized with the process.

--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -11,6 +11,7 @@ from watchdog.observers import Observer
 
 from robyn.logger import Colors, logger
 
+
 def compile_rust_files(directory_path: str) -> list[str]:
     rust_files = glob.glob(os.path.join(directory_path, "**/*.rs"), recursive=True)
     rust_binaries: list[str] = []
@@ -47,6 +48,7 @@ def compile_rust_files(directory_path: str) -> list[str]:
 
     return rust_binaries
 
+
 def create_rust_file(file_name: str) -> None:
     if file_name.endswith(".rs"):
         file_name = file_name.removesuffix(".rs")
@@ -69,10 +71,12 @@ def create_rust_file(file_name: str) -> None:
     else:
         print("Created rust file : %s", rust_file)
 
+
 def clean_rust_binaries(rust_binaries: list[str]) -> None:
     for file in rust_binaries:
         print("Cleaning rust file : %s", file)
         os.remove(file)
+
 
 def setup_reloader(directory_path: str, file_path: str) -> None:
     event_handler = EventHandler(file_path, directory_path)
@@ -106,6 +110,7 @@ def setup_reloader(directory_path: str, file_path: str) -> None:
         observer.stop()
         observer.join()
         event_handler.process.wait()
+
 
 class EventHandler(FileSystemEventHandler):
     def __init__(self, file_path: str, directory_path: str) -> None:

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -1,23 +1,21 @@
 import asyncio
 import mimetypes
 import os
-from typing import AsyncGenerator, Generator, Optional, Union
+from typing import AsyncGenerator, Generator, Optional
 
 from robyn.robyn import Headers, Response
-
 
 class FileResponse:
     def __init__(
         self,
         file_path: str,
-        status_code: Optional[int] = None,
-        headers: Optional[Headers] = None,
+        status_code: int | None = None,
+        headers: Headers | None = None,
     ):
         self.file_path = file_path
         self.description = ""
         self.status_code = status_code or 200
         self.headers = headers or Headers({"Content-Disposition": "attachment"})
-
 
 def html(html: str) -> Response:
     """
@@ -31,7 +29,6 @@ def html(html: str) -> Response:
         headers=Headers({"Content-Type": "text/html"}),
     )
 
-
 def serve_html(file_path: str) -> FileResponse:
     """
     This function will help in serving a single html file
@@ -41,8 +38,7 @@ def serve_html(file_path: str) -> FileResponse:
 
     return FileResponse(file_path, headers=Headers({"Content-Type": "text/html"}))
 
-
-def serve_file(file_path: str, file_name: Optional[str] = None) -> FileResponse:
+def serve_file(file_path: str, file_name: str | None = None) -> FileResponse:
     """
     This function will help in serving a file
 
@@ -60,7 +56,6 @@ def serve_file(file_path: str, file_name: Optional[str] = None) -> FileResponse:
         file_path,
         headers=headers,
     )
-
 
 class AsyncGeneratorWrapper:
     """Optimized true-streaming wrapper for async generators"""
@@ -120,13 +115,12 @@ class AsyncGeneratorWrapper:
             print(f"Error in async generator: {e}")
             raise StopIteration
 
-
 class StreamingResponse:
     def __init__(
         self,
-        content: Union[Generator[str, None, None], AsyncGenerator[str, None]],
-        status_code: Optional[int] = None,
-        headers: Optional[Headers] = None,
+        content: Generator[str | None | None] | AsyncGenerator[str | None],
+        status_code: int | None = None,
+        headers: Headers | None = None,
         media_type: str = "text/event-stream",
     ):
         # Convert async generator to sync generator if needed
@@ -147,11 +141,10 @@ class StreamingResponse:
             self.headers.set("Content-Type", "text/event-stream")
             # Cache-Control and Connection headers are set by Rust layer with optimized headers
 
-
 def SSEResponse(
-    content: Union[Generator[str, None, None], AsyncGenerator[str, None]],
-    status_code: Optional[int] = None,
-    headers: Optional[Headers] = None,
+    content: Generator[str | None | None] | AsyncGenerator[str | None],
+    status_code: int | None = None,
+    headers: Headers | None = None,
 ) -> StreamingResponse:
     """
     Create a Server-Sent Events (SSE) streaming response.
@@ -163,8 +156,7 @@ def SSEResponse(
     """
     return StreamingResponse(content=content, status_code=status_code, headers=headers, media_type="text/event-stream")
 
-
-def SSEMessage(data: str, event: Optional[str] = None, id: Optional[str] = None, retry: Optional[int] = None) -> str:
+def SSEMessage(data: str, event: str | None = None, id: str | None = None, retry: int | None = None) -> str:
     """
     Optimized SSE message formatting with minimal allocations.
 

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -124,7 +124,7 @@ class AsyncGeneratorWrapper:
 class StreamingResponse:
     def __init__(
         self,
-        content: Generator[str | None | None] | AsyncGenerator[str | None],
+        content: Generator[str, None, None] | AsyncGenerator[str, None],
         status_code: int | None = None,
         headers: Headers | None = None,
         media_type: str = "text/event-stream",
@@ -149,7 +149,7 @@ class StreamingResponse:
 
 
 def SSEResponse(
-    content: Generator[str | None | None] | AsyncGenerator[str | None],
+    content: Generator[str, None, None] | AsyncGenerator[str, None],
     status_code: int | None = None,
     headers: Headers | None = None,
 ) -> StreamingResponse:

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -1,9 +1,10 @@
 import asyncio
 import mimetypes
 import os
-from typing import AsyncGenerator, Generator, Optional
+from typing import AsyncGenerator, Generator
 
 from robyn.robyn import Headers, Response
+
 
 class FileResponse:
     def __init__(
@@ -17,6 +18,7 @@ class FileResponse:
         self.status_code = status_code or 200
         self.headers = headers or Headers({"Content-Disposition": "attachment"})
 
+
 def html(html: str) -> Response:
     """
     This function will help in serving a simple html string
@@ -29,6 +31,7 @@ def html(html: str) -> Response:
         headers=Headers({"Content-Type": "text/html"}),
     )
 
+
 def serve_html(file_path: str) -> FileResponse:
     """
     This function will help in serving a single html file
@@ -37,6 +40,7 @@ def serve_html(file_path: str) -> FileResponse:
     """
 
     return FileResponse(file_path, headers=Headers({"Content-Type": "text/html"}))
+
 
 def serve_file(file_path: str, file_name: str | None = None) -> FileResponse:
     """
@@ -56,6 +60,7 @@ def serve_file(file_path: str, file_name: str | None = None) -> FileResponse:
         file_path,
         headers=headers,
     )
+
 
 class AsyncGeneratorWrapper:
     """Optimized true-streaming wrapper for async generators"""
@@ -115,6 +120,7 @@ class AsyncGeneratorWrapper:
             print(f"Error in async generator: {e}")
             raise StopIteration
 
+
 class StreamingResponse:
     def __init__(
         self,
@@ -141,6 +147,7 @@ class StreamingResponse:
             self.headers.set("Content-Type", "text/event-stream")
             # Cache-Control and Connection headers are set by Rust layer with optimized headers
 
+
 def SSEResponse(
     content: Generator[str | None | None] | AsyncGenerator[str | None],
     status_code: int | None = None,
@@ -155,6 +162,7 @@ def SSEResponse(
     :return: StreamingResponse configured for SSE
     """
     return StreamingResponse(content=content, status_code=status_code, headers=headers, media_type="text/event-stream")
+
 
 def SSEMessage(data: str, event: str | None = None, id: str | None = None, retry: int | None = None) -> str:
     """

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Optional, Union
+from typing import Callable
 
 def get_version() -> str:
     pass
@@ -108,13 +108,13 @@ class QueryParams:
         """
         pass
 
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, key: str, default: str | None = None) -> str | None:
         """
         Gets the last value of the query parameter with the given key.
 
         Args:
             key (str): The key of the query parameter
-            default (Optional[str]): The default value if the key does not exist
+            default (str | None): The default value if the key does not exist
         """
         pass
 
@@ -135,7 +135,7 @@ class QueryParams:
         """
         pass
 
-    def get_first(self, key: str) -> Optional[str]:
+    def get_first(self, key: str) -> str | None:
         """
         Gets the first value of the query parameter with the given key.
 
@@ -145,7 +145,7 @@ class QueryParams:
         """
         pass
 
-    def get_all(self, key: str) -> Optional[list[str]]:
+    def get_all(self, key: str) -> list[str] | None:
         """
         Gets all the values of the query parameter with the given key.
 
@@ -183,23 +183,23 @@ class Cookie:
 
     Attributes:
         value (str): The cookie value
-        path (Optional[str]): Cookie path (e.g. "/")
-        domain (Optional[str]): Cookie domain
-        max_age (Optional[int]): Max age in seconds
-        expires (Optional[str]): Expiry date (deprecated, use max_age instead)
+        path (str | None): Cookie path (e.g. "/")
+        domain (str | None): Cookie domain
+        max_age (int | None): Max age in seconds
+        expires (str | None): Expiry date (deprecated, use max_age instead)
         secure (bool): Only send over HTTPS
         http_only (bool): Not accessible via JavaScript
-        same_site (Optional[str]): "Strict", "Lax", or "None" (case-insensitive)
+        same_site (str | None): "Strict", "Lax", or "None" (case-insensitive)
     """
 
     value: str
-    path: Optional[str] = None
-    domain: Optional[str] = None
-    max_age: Optional[int] = None
-    expires: Optional[str] = None
+    path: str | None = None
+    domain: str | None = None
+    max_age: int | None = None
+    expires: str | None = None
     secure: bool = False
     http_only: bool = False
-    same_site: Optional[str] = None
+    same_site: str | None = None
 
     @staticmethod
     def deleted() -> "Cookie":
@@ -227,7 +227,7 @@ class Cookies:
         """
         pass
 
-    def get(self, name: str) -> Optional[Cookie]:
+    def get(self, name: str) -> Cookie | None:
         """
         Gets the cookie with the given name.
 
@@ -272,7 +272,7 @@ class Cookies:
     def __setitem__(self, name: str, cookie: Cookie) -> None:
         pass
 
-    def __getitem__(self, name: str) -> Optional[Cookie]:
+    def __getitem__(self, name: str) -> Cookie | None:
         pass
 
     def __contains__(self, name: str) -> bool:
@@ -297,10 +297,10 @@ class CookiesIter:
         pass
 
 class Headers:
-    def __init__(self, default_headers: Optional[dict]) -> None:
+    def __init__(self, default_headers: dict | None) -> None:
         pass
 
-    def __getitem__(self, key: str) -> Optional[str]:
+    def __getitem__(self, key: str) -> str | None:
         pass
 
     def __setitem__(self, key: str, value: str) -> None:
@@ -317,7 +317,7 @@ class Headers:
         """
         pass
 
-    def get(self, key: str) -> Optional[str]:
+    def get(self, key: str) -> str | None:
         """
         Gets the last value of the header with the given key.
 
@@ -371,27 +371,27 @@ class Request:
         query_params (QueryParams): The query parameters of the request. e.g. /user?id=123 -> {"id": "123"}
         headers Headers: The headers of the request. e.g. Headers({"Content-Type": "application/json"})
         path_params (dict[str, str]): The parameters of the request. e.g. /user/:id -> {"id": "123"}
-        body (Union[str, bytes]): The body of the request. If the request is a JSON, it will be a dict.
+        body (str | bytes): The body of the request. If the request is a JSON, it will be a dict.
         method (str): The method of the request. e.g. GET, POST, PUT etc.
         url (Url): The url of the request. e.g. https://localhost/user
         form_data (dict[str, str]): The form data of the request. e.g. {"name": "John"}
         files (dict[str, bytes]): The files of the request. e.g. {"file": b"file"}
-        ip_addr (Optional[str]): The IP Address of the client
-        identity (Optional[Identity]): The identity of the client
+        ip_addr (str | None): The IP Address of the client
+        identity (Identity | None): The identity of the client
     """
 
     query_params: QueryParams
     headers: Headers
     path_params: dict[str, str]
-    body: Union[str, bytes]
+    body: str | bytes
     method: str
     url: Url
     form_data: dict[str, str]
     files: dict[str, bytes]
-    ip_addr: Optional[str]
-    identity: Optional[Identity]
+    ip_addr: str | None
+    identity: Identity | None
 
-    def json(self) -> Union[dict, list]:
+    def json(self) -> dict | list:
         """
         Parse the request body as JSON and return a Python dict or list with preserved types.
 
@@ -417,31 +417,31 @@ class Response:
 
     Attributes:
         status_code (int): The status code of the response. e.g. 200, 404, 500 etc.
-        response_type (Optional[str]): The response type of the response. e.g. text, json, html, file etc.
-        headers (Union[Headers, dict]): The headers of the response or Headers directly. e.g. {"Content-Type": "application/json"}
-        description (Union[str, bytes]): The body of the response. If the response is a JSON, it will be a dict.
-        file_path (Optional[str]): The file path of the response. e.g. /home/user/file.txt
+        response_type (str | None): The response type of the response. e.g. text, json, html, file etc.
+        headers (Headers | dict): The headers of the response or Headers directly. e.g. {"Content-Type": "application/json"}
+        description (str | bytes): The body of the response. If the response is a JSON, it will be a dict.
+        file_path (str | None): The file path of the response. e.g. /home/user/file.txt
         cookies (Cookies): The cookies to set in the response.
     """
 
     status_code: int
-    headers: Union[Headers, dict]
-    description: Union[str, bytes]
-    response_type: Optional[str] = None
-    file_path: Optional[str] = None
+    headers: Headers | dict
+    description: str | bytes
+    response_type: str | None = None
+    file_path: str | None = None
     cookies: Cookies = None  # Initialized automatically
 
     def set_cookie(
         self,
         key: str,
         value: str,
-        path: Optional[str] = None,
-        domain: Optional[str] = None,
-        max_age: Optional[int] = None,
-        expires: Optional[str] = None,
+        path: str | None = None,
+        domain: str | None = None,
+        max_age: int | None = None,
+        expires: str | None = None,
         secure: bool = False,
         http_only: bool = False,
-        same_site: Optional[str] = None,
+        same_site: str | None = None,
     ) -> None:
         """
         Sets a cookie in the response. If a cookie with the same key exists,
@@ -450,13 +450,13 @@ class Response:
         Args:
             key (str): The name of the cookie
             value (str): The value of the cookie
-            path (Optional[str]): Cookie path (e.g. "/")
-            domain (Optional[str]): Cookie domain
-            max_age (Optional[int]): Max age in seconds
-            expires (Optional[str]): Expiry date (RFC 7231 format)
+            path (str | None): Cookie path (e.g. "/")
+            domain (str | None): Cookie domain
+            max_age (int | None): Max age in seconds
+            expires (str | None): Expiry date (RFC 7231 format)
             secure (bool): Only send over HTTPS
             http_only (bool): Not accessible via JavaScript
-            same_site (Optional[str]): "Strict", "Lax", or "None"
+            same_site (str | None): "Strict", "Lax", or "None"
         """
         pass
 
@@ -473,14 +473,14 @@ class Server:
         route: str,
         directory_path: str,
         show_files_listing: bool,
-        index_file: Optional[str],
+        index_file: str | None,
     ) -> None:
         pass
     def apply_request_headers(self, headers: Headers) -> None:
         pass
     def apply_response_headers(self, headers: Headers) -> None:
         pass
-    def set_response_headers_exclude_paths(self, excluded_response_headers_paths: Optional[list[str]] = None):
+    def set_response_headers_exclude_paths(self, excluded_response_headers_paths: list[str] | None = None):
         pass
 
     def add_route(

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -1,9 +1,10 @@
 import inspect
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from functools import wraps
 from types import CoroutineType
-from typing import Callable, Dict, List, NamedTuple, Optional, Union, is_typeddict
+from typing import TYPE_CHECKING, NamedTuple, is_typeddict
 
 from robyn import status_codes
 from robyn._param_utils import QueryParamValidationError, parse_route_param_names, resolve_individual_params
@@ -24,10 +25,12 @@ from robyn.types import Body, Files, FormData, IPAddress, JsonBody, Method, Path
 
 _logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from robyn import SubRouter
+
 
 def lower_http_method(method: HttpMethod):
     return (str(method))[11:].lower()
-
 
 class Route(NamedTuple):
     route_type: HttpMethod
@@ -36,8 +39,7 @@ class Route(NamedTuple):
     is_const: bool
     auth_required: bool
     openapi_name: str
-    openapi_tags: List[str]
-
+    openapi_tags: list[str]
 
 class RouteMiddleware(NamedTuple):
     middleware_type: MiddlewareType
@@ -45,28 +47,28 @@ class RouteMiddleware(NamedTuple):
     function: FunctionInfo
     route_type: HttpMethod
 
-
 class GlobalMiddleware(NamedTuple):
     middleware_type: MiddlewareType
     function: FunctionInfo
 
-
 class BaseRouter(ABC):
     @abstractmethod
-    def add_route(*args) -> Union[Callable, CoroutineType, Dict]: ...
-
+    def add_route(*args) -> Callable | CoroutineType | dict: ...
 
 class Router(BaseRouter):
     def __init__(self) -> None:
         super().__init__()
-        self.routes: List[Route] = []
+        self.routes: list[Route] = []
 
     def _format_tuple_response(self, res: tuple) -> Response:
         if len(res) != 3:
             raise ValueError("Tuple should have 3 elements")
 
         description, headers, status_code = res
-        description = self._format_response(description).description
+        formatted = self._format_response(description)
+        if isinstance(formatted, StreamingResponse):
+            raise ValueError("StreamingResponse is not supported in tuple responses")
+        description = formatted.description
         new_headers: Headers = Headers(headers)
         if new_headers.contains("Content-Type"):
             headers.set("Content-Type", new_headers.get("Content-Type"))
@@ -77,10 +79,7 @@ class Router(BaseRouter):
             description=description,
         )
 
-    def _format_response(
-        self,
-        res: Union[Dict, List, Response, StreamingResponse, bytes, tuple, str],
-    ) -> Union[Response, StreamingResponse]:
+    def _format_response(self, res: dict | list | Response | StreamingResponse | bytes | tuple | str) -> Response | StreamingResponse:
         if isinstance(res, Response):
             return res
 
@@ -135,10 +134,10 @@ class Router(BaseRouter):
         is_const: bool,
         auth_required: bool,
         openapi_name: str,
-        openapi_tags: List[str],
-        exception_handler: Optional[Callable],
+        openapi_tags: list[str],
+        exception_handler: Callable | None,
         injected_dependencies: dict,
-    ) -> Union[Callable, CoroutineType]:
+    ) -> Callable | CoroutineType:
         # Pre-compute handler signature ONCE at registration time.
         # This avoids calling inspect.signature() on every request.
         route_param_names = parse_route_param_names(endpoint)
@@ -210,9 +209,9 @@ class Router(BaseRouter):
                                     description=jsonify({"error": f"Invalid JSON body: {e}"}),
                                 )
                         elif issubclass(handler_param_type, Body):
-                            type_filtered_params[handler_param_name] = getattr(request, "body")
+                            type_filtered_params[handler_param_name] = request.body
                         elif issubclass(handler_param_type, QueryParams):
-                            type_filtered_params[handler_param_name] = getattr(request, "query_params")
+                            type_filtered_params[handler_param_name] = request.query_params
                         elif is_typeddict(handler_param_type):
                             try:
                                 type_filtered_params[handler_param_name] = request.json()
@@ -362,16 +361,15 @@ class Router(BaseRouter):
         #    for route in router:
         #        openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler)
 
-    def get_routes(self) -> List[Route]:
+    def get_routes(self) -> list[Route]:
         return self.routes
-
 
 class MiddlewareRouter(BaseRouter):
     def __init__(self, dependencies: DependencyMap = DependencyMap()) -> None:
         super().__init__()
-        self.global_middlewares: List[GlobalMiddleware] = []
-        self.route_middlewares: List[RouteMiddleware] = []
-        self.authentication_handler: Optional[AuthenticationHandler] = None
+        self.global_middlewares: list[GlobalMiddleware] = []
+        self.route_middlewares: list[RouteMiddleware] = []
+        self.authentication_handler: AuthenticationHandler | None = None
         self.dependencies = dependencies
 
     def set_authentication_handler(self, authentication_handler: AuthenticationHandler):
@@ -437,7 +435,7 @@ class MiddlewareRouter(BaseRouter):
     # These inner functions are basically a wrapper around the closure(decorator) being returned.
     # They take a handler, convert it into a closure and return the arguments.
     # Arguments are returned as they could be modified by the middlewares.
-    def add_middleware(self, middleware_type: MiddlewareType, endpoint: Optional[str]) -> Callable[..., None]:
+    def add_middleware(self, middleware_type: MiddlewareType, endpoint: str | None) -> Callable[..., None]:
         """
         This method adds a middleware to the router.
 
@@ -509,20 +507,19 @@ class MiddlewareRouter(BaseRouter):
 
         return inner
 
-    def get_route_middlewares(self) -> List[RouteMiddleware]:
+    def get_route_middlewares(self) -> list[RouteMiddleware]:
         return self.route_middlewares
 
-    def get_global_middlewares(self) -> List[GlobalMiddleware]:
+    def get_global_middlewares(self) -> list[GlobalMiddleware]:
         return self.global_middlewares
-
 
 class WebSocketRouter(BaseRouter):
     def __init__(self) -> None:
         super().__init__()
-        self.routes: Dict[str, dict] = {}
+        self.routes: dict[str, dict] = {}
 
     def add_route(self, endpoint: str, handlers: dict) -> None:  # type: ignore
         self.routes[endpoint] = handlers
 
-    def get_routes(self) -> Dict[str, dict]:
+    def get_routes(self) -> dict[str, dict]:
         return self.routes

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -26,7 +26,7 @@ from robyn.types import Body, Files, FormData, IPAddress, JsonBody, Method, Path
 _logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from robyn import SubRouter
+    pass
 
 
 # Prebuilt Headers singletons reused across every request so the hot path
@@ -42,6 +42,7 @@ _TEXT_HEADERS = Headers({"Content-Type": "text/plain"})
 def lower_http_method(method: HttpMethod):
     return (str(method))[11:].lower()
 
+
 class Route(NamedTuple):
     route_type: HttpMethod
     route: str
@@ -51,19 +52,23 @@ class Route(NamedTuple):
     openapi_name: str
     openapi_tags: list[str]
 
+
 class RouteMiddleware(NamedTuple):
     middleware_type: MiddlewareType
     route: str
     function: FunctionInfo
     route_type: HttpMethod
 
+
 class GlobalMiddleware(NamedTuple):
     middleware_type: MiddlewareType
     function: FunctionInfo
 
+
 class BaseRouter(ABC):
     @abstractmethod
     def add_route(*args) -> Callable | CoroutineType | dict: ...
+
 
 class Router(BaseRouter):
     def __init__(self) -> None:
@@ -369,6 +374,7 @@ class Router(BaseRouter):
     def get_routes(self) -> list[Route]:
         return self.routes
 
+
 class MiddlewareRouter(BaseRouter):
     def __init__(self, dependencies: DependencyMap = DependencyMap()) -> None:
         super().__init__()
@@ -517,6 +523,7 @@ class MiddlewareRouter(BaseRouter):
 
     def get_global_middlewares(self) -> list[GlobalMiddleware]:
         return self.global_middlewares
+
 
 class WebSocketRouter(BaseRouter):
     def __init__(self) -> None:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import wraps
 from types import CoroutineType
-from typing import TYPE_CHECKING, NamedTuple, is_typeddict
+from typing import NamedTuple, is_typeddict
 
 from robyn import status_codes
 from robyn._param_utils import QueryParamValidationError, parse_route_param_names, resolve_individual_params
@@ -24,9 +24,6 @@ from robyn.robyn import FunctionInfo, Headers, HttpMethod, Identity, MiddlewareT
 from robyn.types import Body, Files, FormData, IPAddress, JsonBody, Method, PathParams
 
 _logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    pass
 
 
 # Prebuilt Headers singletons reused across every request so the hot path

--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -12,11 +12,11 @@ class TemplateInterface(ABC):
     Interface for implementing various template engines in Robyn.
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs) -> None:
         """
         Initializes the template interface.
         """
-        ...
+        super().__init__()
 
     @abstractmethod
     def render_template(self, *args, **kwargs) -> Response:

--- a/robyn/types.py
+++ b/robyn/types.py
@@ -1,15 +1,14 @@
 from dataclasses import dataclass
-from typing import Dict, NewType, Optional, TypedDict
+from typing import NewType, TypedDict
 
 from robyn._param_utils import QueryParamValidationError
-
 
 @dataclass
 class Directory:
     route: str
     directory_path: str
     show_files_listing: bool
-    index_file: Optional[str]
+    index_file: str | None
 
     def as_list(self):
         return [
@@ -19,13 +18,11 @@ class Directory:
             self.index_file,
         ]
 
-
-PathParams = NewType("PathParams", Dict[str, str])
+PathParams = NewType("PathParams", dict[str, str])
 Method = NewType("Method", str)
-FormData = NewType("FormData", Dict[str, str])
-Files = NewType("Files", Dict[str, bytes])
-IPAddress = NewType("IPAddress", Optional[str])
-
+FormData = NewType("FormData", dict[str, str])
+Files = NewType("Files", dict[str, bytes])
+IPAddress = NewType("IPAddress", str | None)
 
 class JSONResponse(TypedDict):
     """
@@ -34,14 +31,12 @@ class JSONResponse(TypedDict):
 
     pass
 
-
 class Body:
     """
     A type alias for openapi request bodies. This class should be inherited by the request body class annotation.
     """
 
     pass
-
 
 class JsonBody:
     """
@@ -76,6 +71,5 @@ class JsonBody:
     """
 
     pass
-
 
 __all__ = ["JSONResponse", "Body", "JsonBody", "QueryParamValidationError", "Directory", "PathParams", "Method", "FormData", "Files", "IPAddress"]

--- a/robyn/types.py
+++ b/robyn/types.py
@@ -3,6 +3,7 @@ from typing import NewType, TypedDict
 
 from robyn._param_utils import QueryParamValidationError
 
+
 @dataclass
 class Directory:
     route: str
@@ -18,11 +19,13 @@ class Directory:
             self.index_file,
         ]
 
+
 PathParams = NewType("PathParams", dict[str, str])
 Method = NewType("Method", str)
 FormData = NewType("FormData", dict[str, str])
 Files = NewType("Files", dict[str, bytes])
 IPAddress = NewType("IPAddress", str | None)
+
 
 class JSONResponse(TypedDict):
     """
@@ -31,12 +34,14 @@ class JSONResponse(TypedDict):
 
     pass
 
+
 class Body:
     """
     A type alias for openapi request bodies. This class should be inherited by the request body class annotation.
     """
 
     pass
+
 
 class JsonBody:
     """
@@ -71,5 +76,6 @@ class JsonBody:
     """
 
     pass
+
 
 __all__ = ["JSONResponse", "Body", "JsonBody", "QueryParamValidationError", "Directory", "PathParams", "Method", "FormData", "Files", "IPAddress"]


### PR DESCRIPTION
## Description

This PR fixes #1298 

## Summary

This PR does the following:
- Modernize typing across core modules and stubs (PEP 604 unions, `collections.abc.Callable`, `StrEnum`, and `TypeAlias` usage).
- Remove mutable default arguments by initializing `Config` and `DependencyMap` lazily in constructors.
- Tighten HTTP method handling and router response formatting, including explicit validation for string methods and guarding tuple responses against streaming.
- Minor cleanup/formatting touches and small robustness improvements (e.g., optional `allow_connection_pickling`).

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized public type hints and method signatures to current Python syntax across the framework (PEP 604 / built-in generics). No runtime behavior changes; APIs remain functionally compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->