### PR TITLE
fix: support async authenticate() and propagate auth to SubRouters

### DIFF
--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -202,3 +202,38 @@ jobs:
         run: |
           uv pip install --upgrade twine
           twine upload --skip-existing *.whl
+
+  discord-notify:
+    name: Discord Release Notification
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: always() && needs.release.result == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build and send Discord notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | sed -n '2p')
+          CHANGELOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s" --no-merges | grep -v "^- Release ")
+
+          read -r -d '' MESSAGE << EOM || true
+          Hey @everyone 👋
+
+          **Release Robyn v${VERSION}**
+
+          ${CHANGELOG}
+
+          Upgrade: \`pip install --upgrade robyn\`
+
+          https://github.com/sparckles/Robyn/releases/tag/v${VERSION}
+          EOM
+
+          PAYLOAD=$(jq -n --arg msg "$MESSAGE" '{content: $msg}')
+
+          curl -f -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/release-CI.yml
+++ b/.github/workflows/release-CI.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v6
@@ -56,7 +56,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         target: [x64, x86]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v6
@@ -86,7 +86,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         target: [x86_64, i686]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -123,7 +123,7 @@ jobs:
           ]
         target: [aarch64, armv7]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build Wheels
         uses: PyO3/maturin-action@v1
         env:
@@ -209,16 +209,26 @@ jobs:
     needs: [release]
     if: always() && needs.release.result == 'success'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build and send Discord notification
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+            echo "::warning::GITHUB_REF ($GITHUB_REF) is not a tag push — skipping Discord notification"
+            exit 0
+          fi
+
           VERSION="${GITHUB_REF#refs/tags/v}"
           PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | sed -n '2p')
-          CHANGELOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s" --no-merges | grep -v "^- Release ")
+
+          if [ -n "$PREV_TAG" ]; then
+            CHANGELOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s" --no-merges | grep -v "^- Release " || true)
+          else
+            CHANGELOG=$(git log --pretty=format:"- %s" --no-merges -20 | grep -v "^- Release " || true)
+          fi
 
           read -r -d '' MESSAGE << EOM || true
           Hey @everyone 👋

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -6,7 +6,7 @@ import time
 from collections import defaultdict
 from typing import List, Optional, TypedDict
 
-from integration_tests.subroutes import di_subrouter, static_router, sub_router
+from integration_tests.subroutes import async_auth_subrouter, di_subrouter, inherited_auth_subrouter, static_router, sub_router
 from robyn import Headers, Request, Response, Robyn, SSEMessage, SSEResponse, WebSocketDisconnect, jsonify, serve_file, serve_html
 from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
 from robyn.robyn import QueryParams, Url
@@ -1663,6 +1663,8 @@ def main():
     app.include_router(sub_router)
     app.include_router(di_subrouter)
     app.include_router(static_router)
+    app.include_router(async_auth_subrouter)
+    app.include_router(inherited_auth_subrouter)
 
     class BasicAuthHandler(AuthenticationHandler):
         def authenticate(self, request: Request) -> Optional[Identity]:

--- a/integration_tests/subroutes/__init__.py
+++ b/integration_tests/subroutes/__init__.py
@@ -1,11 +1,12 @@
 from robyn import SubRouter, WebSocketDisconnect, jsonify
 
+from .auth_subrouter import async_auth_subrouter, inherited_auth_subrouter
 from .di_subrouter import di_subrouter
 from .file_api import static_router
 
 sub_router = SubRouter(__name__, prefix="/sub_router")
 
-__all__ = ["sub_router", "di_subrouter", "static_router"]
+__all__ = ["sub_router", "di_subrouter", "static_router", "async_auth_subrouter", "inherited_auth_subrouter"]
 
 
 @sub_router.websocket("/ws")

--- a/integration_tests/subroutes/auth_subrouter.py
+++ b/integration_tests/subroutes/auth_subrouter.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from robyn import Request, SubRouter
+from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
+
+
+class AsyncAuthHandler(AuthenticationHandler):
+    """Auth handler with async authenticate() for testing async ORM patterns."""
+
+    async def authenticate(self, request: Request) -> Optional[Identity]:
+        token = self.token_getter.get_token(request)
+        if token is not None:
+            self.token_getter.set_token(request, token)
+        if token == "valid":
+            return Identity(claims={"async_key": "async_value"})
+        return None
+
+
+async_auth_subrouter = SubRouter(__name__, prefix="/async_auth_sub")
+async_auth_subrouter.configure_authentication(AsyncAuthHandler(token_getter=BearerGetter()))
+
+
+@async_auth_subrouter.get("/protected", auth_required=True)
+async def async_auth_protected(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"async_key": "async_value"}
+    return "async_auth_protected"
+
+
+inherited_auth_subrouter = SubRouter(__name__, prefix="/inherited_auth_sub")
+
+
+@inherited_auth_subrouter.get("/protected", auth_required=True)
+async def inherited_auth_protected(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "inherited_auth_protected"

--- a/integration_tests/test_async_authentication.py
+++ b/integration_tests/test_async_authentication.py
@@ -1,0 +1,57 @@
+import pytest
+
+from integration_tests.helpers.http_methods_helpers import get
+
+
+# --- Async authentication handler (SubRouter with its own async handler) ---
+
+
+@pytest.mark.benchmark
+def test_async_auth_handler_valid_token(session):
+    r = get("/async_auth_sub/protected", headers={"Authorization": "Bearer valid"})
+    assert r.text == "async_auth_protected"
+
+
+@pytest.mark.benchmark
+def test_async_auth_handler_invalid_token(session):
+    r = get(
+        "/async_auth_sub/protected",
+        headers={"Authorization": "Bearer invalid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+@pytest.mark.benchmark
+def test_async_auth_handler_no_token(session):
+    r = get("/async_auth_sub/protected", should_check_response=False)
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+# --- Inherited authentication (SubRouter without its own handler, inherits parent's) ---
+
+
+@pytest.mark.benchmark
+def test_inherited_auth_valid_token(session):
+    r = get("/inherited_auth_sub/protected", headers={"Authorization": "Bearer valid"})
+    assert r.text == "inherited_auth_protected"
+
+
+@pytest.mark.benchmark
+def test_inherited_auth_invalid_token(session):
+    r = get(
+        "/inherited_auth_sub/protected",
+        headers={"Authorization": "Bearer invalid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"
+
+
+@pytest.mark.benchmark
+def test_inherited_auth_no_token(session):
+    r = get("/inherited_auth_sub/protected", should_check_response=False)
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate") == "BearerGetter"

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -585,14 +585,28 @@ class BaseRobyn(ABC):
 
         self.dependencies.merge_dependencies(router)
 
+        if router.authentication_handler is None and self.authentication_handler is not None:
+            router.authentication_handler = self.authentication_handler
+            router.middleware_router.set_authentication_handler(self.authentication_handler)
+
     def configure_authentication(self, authentication_handler: AuthenticationHandler):
         """
         Configures the authentication handler for the application.
+
+        The handler is also propagated to any already-included SubRouters that
+        have not configured their own authentication handler, so that routes
+        declared with ``auth_required=True`` on those SubRouters work without
+        requiring a separate ``configure_authentication`` call on each one.
 
         :param authentication_handler: the instance of a class inheriting the AuthenticationHandler base class
         """
         self.authentication_handler = authentication_handler
         self.middleware_router.set_authentication_handler(authentication_handler)
+
+        for router in self.included_routers:
+            if router.authentication_handler is None:
+                router.authentication_handler = authentication_handler
+                router.middleware_router.set_authentication_handler(authentication_handler)
 
     @property
     def mcp(self):

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -67,8 +67,15 @@ class AuthenticationHandler(ABC):
     def authenticate(self, request: Request) -> Optional[Identity]:
         """
         Authenticates the user.
+
+        This method may be overridden as either a regular (sync) method or an
+        ``async def`` coroutine.  When the implementation is async, the
+        framework will ``await`` it automatically, allowing the use of async
+        ORMs, HTTP clients, or any other async I/O inside the authentication
+        logic.
+
         :param request: The request object.
-        :return: The identity of the user.
+        :return: The identity of the user, or ``None`` to reject the request.
         """
         raise NotImplementedError()
 

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -407,16 +407,23 @@ class MiddlewareRouter(BaseRouter):
     def add_auth_middleware(self, endpoint: str, route_type: HttpMethod):
         """
         This method adds an authentication middleware to the specified endpoint.
+
+        Supports both sync and async ``authenticate()`` implementations.
+        The wrapper is always async so the Rust executor can ``await`` it;
+        when the underlying ``authenticate()`` is synchronous, the extra
+        overhead is negligible.
         """
 
         injected_dependencies: dict = {}
 
         def decorator(handler):
             @wraps(handler)
-            def inner_handler(request: Request, *args):
+            async def inner_handler(request: Request, *args):
                 if not self.authentication_handler:
                     raise AuthenticationNotConfiguredError()
                 identity = self.authentication_handler.authenticate(request)
+                if inspect.isawaitable(identity):
+                    identity = await identity
                 if identity is None:
                     return self.authentication_handler.unauthorized_response
                 request.identity = identity


### PR DESCRIPTION
## Summary

Closes #1296

- **Async `authenticate()` support**: The auth middleware wrapper in `add_auth_middleware` is now `async def` and uses `inspect.isawaitable()` to detect and `await` async `authenticate()` implementations. This enables users to use async ORMs, HTTP clients, and other async I/O directly in their `AuthenticationHandler.authenticate()` method.
- **Auth propagation to SubRouters**: Both `configure_authentication()` and `include_router()` now propagate the parent app's authentication handler to SubRouters that haven't configured their own. This works regardless of call order — whether `include_router` or `configure_authentication` is called first.
- **Docs**: Updated `AuthenticationHandler.authenticate()` docstring to document async override support.

## Changes

| File | Change |
|------|--------|
| `robyn/router.py` | `inner_handler` in `add_auth_middleware` is now `async def`; awaits result if `authenticate()` is async |
| `robyn/__init__.py` | `include_router` and `configure_authentication` propagate auth handler to SubRouters |
| `robyn/authentication.py` | Docstring updated to document async support |
| `integration_tests/subroutes/auth_subrouter.py` | New: SubRouter with async auth handler + SubRouter testing inherited auth |
| `integration_tests/test_async_authentication.py` | New: 6 tests for async auth and inherited auth |

## Test plan

- [ ] Existing sync auth tests still pass (regression)
- [ ] Async auth handler: valid token returns 200 with correct identity
- [ ] Async auth handler: invalid/missing token returns 401
- [ ] Inherited auth on SubRouter: valid token returns 200
- [ ] Inherited auth on SubRouter: invalid/missing token returns 401
- [ ] SubRouter with its own auth handler is NOT overwritten by parent's


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for asynchronous authentication handlers
  * Authentication inheritance for included sub-routers (child routers inherit parent auth when not configured)

* **Tests**
  * Integration tests covering async authentication and inheritance scenarios

* **Documentation**
  * Clarified auth handler docs: async/sync implementations and None-to-reject behavior

* **Chores**
  * CI updated and added automated Discord release notifications upon successful releases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->