### PR TITLE
fix: graceful shutdown instead of SIGKILL on worker processes

### DIFF
--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -51,9 +51,18 @@ def run_processes(
     )
 
     def terminating_signal_handler(_sig, _frame):
-        logger.info("Terminating server!!", bold=True)
+        logger.info("Gracefully shutting down server...", bold=True)
         for process in process_pool:
-            process.kill()
+            process.terminate()
+
+        for process in process_pool:
+            process.join(timeout=30)
+            if process.is_alive():
+                logger.warning("Process %s did not shut down in time, forcing kill.", process.pid)
+                process.kill()
+                process.join(timeout=5)
+
+        sys.exit(0)
 
     signal.signal(signal.SIGINT, terminating_signal_handler)
     signal.signal(signal.SIGTERM, terminating_signal_handler)
@@ -220,6 +229,12 @@ def spawn_process(
     try:
         server.start(socket, workers)
         loop = asyncio.get_event_loop()
+
+        if not sys.platform.startswith("win32"):
+            loop.add_signal_handler(signal.SIGTERM, loop.stop)
+
         loop.run_forever()
     except KeyboardInterrupt:
+        pass
+    finally:
         loop.close()

--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -123,7 +123,13 @@ class EventHandler(FileSystemEventHandler):
 
     def stop_server(self) -> None:
         if self.process:
-            os.kill(self.process.pid, signal.SIGTERM)  # Stop the subprocess using os.kill()
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logger.warning("Process %s did not shut down in time, forcing kill.", self.process.pid)
+                self.process.kill()
+                self.process.wait()
 
     def reload(self) -> None:
         self.stop_server()
@@ -137,10 +143,6 @@ class EventHandler(FileSystemEventHandler):
 
         clean_rust_binaries(self.built_rust_binaries)
         self.built_rust_binaries = compile_rust_files(self.directory_path)
-
-        prev_process = self.process
-        if prev_process:
-            prev_process.kill()
 
         self.process = subprocess.Popen(
             [sys.executable, *arguments],


### PR DESCRIPTION
## Summary
- Replace `process.kill()` (SIGKILL) with `process.terminate()` (SIGTERM) + `process.join(timeout=30)` in the parent signal handler, with a force-kill fallback for workers that don't exit in time.
- In child processes, register a SIGTERM handler via `loop.add_signal_handler(signal.SIGTERM, loop.stop)` so the event loop exits cleanly, allowing the Rust shutdown handler to fire and in-flight requests to complete.
- Move `loop.close()` into a `finally` block so it always runs regardless of how the loop exits.

## Test plan
- [ ] Existing integration tests pass
- [ ] Manual test: start multi-process server, send SIGTERM, verify processes exit with code 0 or -15 (not -9)
- [ ] Manual test: verify in-flight requests complete before the process exits
- [ ] Manual test: verify force-kill fallback works if a process hangs beyond 30s

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown flow: workers now receive a graceful termination window (up to 30s) before forcible stop, reducing abrupt terminations.
  * Safer restart behavior: stopped subprocesses are given a bounded grace period (≈5s) before escalation to forceful kill.
  * More robust signal handling: termination signals are handled more predictably on supported platforms and interruption paths always ensure event-loop cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->