### PR TITLE
perf: avoid cloning global middleware list on every request

### DIFF
--- a/src/routers/middleware_router.rs
+++ b/src/routers/middleware_router.rs
@@ -90,13 +90,15 @@ impl MiddlewareRouter {
         Ok(())
     }
 
-    pub fn get_global_middlewares(&self, middleware_type: &MiddlewareType) -> Vec<FunctionInfo> {
+    pub fn get_global_middlewares(
+        &self,
+        middleware_type: &MiddlewareType,
+    ) -> std::sync::RwLockReadGuard<'_, Vec<FunctionInfo>> {
         self.globals
             .get(middleware_type)
             .unwrap()
             .read()
             .unwrap()
-            .to_vec()
     }
 
     pub fn has_any_middleware(&self) -> bool {

--- a/src/server.rs
+++ b/src/server.rs
@@ -509,13 +509,14 @@ async fn index(
 
     let mut early_response: Option<Response> = None;
     if !before_middlewares.is_empty() || route_before.is_some() {
-        let mut all_before = before_middlewares;
-        if let Some((function, route_params)) = route_before {
-            all_before.push(function);
+        let route_fn = if let Some((function, route_params)) = route_before {
             request.path_params = route_params;
-        }
-        for before_middleware in all_before {
-            request = match execute_middleware_function(&request, &before_middleware).await {
+            Some(function)
+        } else {
+            None
+        };
+        for before_middleware in before_middlewares.iter().chain(route_fn.as_ref()) {
+            request = match execute_middleware_function(&request, before_middleware).await {
                 Ok(MiddlewareReturn::Request(r)) => r,
                 Ok(MiddlewareReturn::Response(r)) => {
                     early_response = Some(r);
@@ -583,16 +584,13 @@ async fn index(
     let route_after = middleware_router.get_route(&MiddlewareType::AfterRequest, &route);
 
     if !after_middlewares.is_empty() || route_after.is_some() {
-        let mut all_after = after_middlewares;
-        if let Some((function, _)) = route_after {
-            all_after.push(function);
-        }
-        for after_middleware in all_after {
+        let route_fn = route_after.map(|(function, _)| function);
+        for after_middleware in after_middlewares.iter().chain(route_fn.as_ref()) {
             if let ResponseType::Standard(std_response) = response {
                 response = match execute_after_middleware_function(
                     &request,
                     &std_response,
-                    &after_middleware,
+                    after_middleware,
                 )
                 .await
                 {


### PR DESCRIPTION
## Summary
- `get_global_middlewares()` returned `Vec<FunctionInfo>` via `.to_vec()`, cloning every `FunctionInfo` (each requiring GIL acquisition for `Py<PyAny>` refcount bumps). Called twice per request (before + after middleware).
- Now returns `RwLockReadGuard<Vec<FunctionInfo>>` and the server iterates over borrowed references, chaining route-specific middleware via `Iterator::chain`.
- Eliminates 2×N `FunctionInfo` clones and GIL acquisitions per request where N is the number of global middlewares.

## Test plan
- [ ] All existing integration tests pass (middleware behavior is unchanged, only allocation pattern differs)
- [ ] `check_response` helper validates `global_after` header is present on every response, confirming after-middleware still runs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized middleware execution to reduce memory overhead and improve request processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->