### PR TITLE
feat: add RedirectResponse for convenient HTTP redirects

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -20,7 +20,7 @@ from robyn.mcp import MCPApp
 from robyn.openapi import OpenAPI
 from robyn.processpool import run_processes
 from robyn.reloader import compile_rust_files
-from robyn.responses import SSEMessage, SSEResponse, StreamingResponse, html, serve_file, serve_html
+from robyn.responses import RedirectResponse, SSEMessage, SSEResponse, StreamingResponse, html, serve_file, serve_html
 from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, WebSocketConnector, get_version
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
 from robyn.types import Directory, JsonBody
@@ -802,6 +802,7 @@ __all__ = [
     "StreamingResponse",
     "SSEResponse",
     "SSEMessage",
+    "RedirectResponse",
     "ALLOW_CORS",
     "SubRouter",
     "AuthenticationHandler",

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -38,9 +38,7 @@ class RedirectResponse(Response):
         headers: Optional[Headers] = None,
     ):
         if status_code not in _REDIRECT_STATUS_CODES:
-            raise ValueError(
-                f"Invalid redirect status code {status_code}. Must be one of: {sorted(_REDIRECT_STATUS_CODES)}"
-            )
+            raise ValueError(f"Invalid redirect status code {status_code}. Must be one of: {sorted(_REDIRECT_STATUS_CODES)}")
         redirect_headers = headers or Headers({})
         redirect_headers.set("Location", url)
         super().__init__(

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -19,6 +19,31 @@ class FileResponse:
         self.headers = headers or Headers({"Content-Disposition": "attachment"})
 
 
+class RedirectResponse(Response):
+    """Convenience response that issues an HTTP redirect.
+
+    Args:
+        url: The target URL to redirect to.
+        status_code: HTTP status code (default 307 Temporary Redirect).
+            Common values: 301 (permanent), 302 (found), 303 (see other), 307 (temporary), 308 (permanent redirect).
+        headers: Optional additional headers.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        status_code: int = 307,
+        headers: Optional[Headers] = None,
+    ):
+        redirect_headers = headers or Headers({})
+        redirect_headers.set("Location", url)
+        super().__init__(
+            status_code=status_code,
+            headers=redirect_headers,
+            description="",
+        )
+
+
 def html(html: str) -> Response:
     """
     This function will help in serving a simple html string

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -5,6 +5,8 @@ from typing import AsyncGenerator, Generator, Optional, Union
 
 from robyn.robyn import Headers, Response
 
+_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+
 
 class FileResponse:
     def __init__(
@@ -35,6 +37,10 @@ class RedirectResponse(Response):
         status_code: int = 307,
         headers: Optional[Headers] = None,
     ):
+        if status_code not in _REDIRECT_STATUS_CODES:
+            raise ValueError(
+                f"Invalid redirect status code {status_code}. Must be one of: {sorted(_REDIRECT_STATUS_CODES)}"
+            )
         redirect_headers = headers or Headers({})
         redirect_headers.set("Location", url)
         super().__init__(

--- a/unit_tests/test_redirect_response.py
+++ b/unit_tests/test_redirect_response.py
@@ -1,0 +1,22 @@
+from robyn.responses import RedirectResponse
+
+
+def test_redirect_response_defaults():
+    resp = RedirectResponse("/new-location")
+    assert resp.status_code == 307
+    assert resp.headers.get("Location") == "/new-location"
+
+
+def test_redirect_response_301():
+    resp = RedirectResponse("/permanent", status_code=301)
+    assert resp.status_code == 301
+    assert resp.headers.get("Location") == "/permanent"
+
+
+def test_redirect_response_with_extra_headers():
+    from robyn.robyn import Headers
+
+    h = Headers({"X-Custom": "value"})
+    resp = RedirectResponse("/target", headers=h)
+    assert resp.headers.get("Location") == "/target"
+    assert resp.headers.get("X-Custom") == "value"

--- a/unit_tests/test_redirect_response.py
+++ b/unit_tests/test_redirect_response.py
@@ -1,3 +1,5 @@
+import pytest
+
 from robyn.responses import RedirectResponse
 
 
@@ -20,3 +22,8 @@ def test_redirect_response_with_extra_headers():
     resp = RedirectResponse("/target", headers=h)
     assert resp.headers.get("Location") == "/target"
     assert resp.headers.get("X-Custom") == "value"
+
+
+def test_redirect_response_invalid_status_code():
+    with pytest.raises(ValueError, match="Invalid redirect status code"):
+        RedirectResponse("/target", status_code=200)


### PR DESCRIPTION
## Summary
- Adds a `RedirectResponse` class to `robyn/responses.py` that extends `Response` and automatically sets the `Location` header and redirect status code.
- Defaults to `307 Temporary Redirect`; also supports `301`, `302`, `303`, and `308`.
- Exports `RedirectResponse` from the top-level `robyn` package via `__init__.py` and `__all__`.

## Test plan
- [x] Unit tests added in `unit_tests/test_redirect_response.py`
  - `test_redirect_response_defaults` — verifies default 307 status and Location header
  - `test_redirect_response_301` — verifies permanent redirect with custom status code
  - `test_redirect_response_with_extra_headers` — verifies Location is set alongside custom headers
- [ ] Run `pytest unit_tests/test_redirect_response.py` to confirm all tests pass
- [ ] Verify no regressions in existing test suite

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New publicly available RedirectResponse for issuing HTTP redirects with configurable status codes (default 307) and support for custom headers.

* **Tests**
  * Added unit tests covering default behavior, alternative status codes, header preservation, and validation for invalid status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->