### PR TITLE
feat: add status_code parameter to route decorators

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -408,7 +408,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+            )
 
         return inner
 
@@ -431,7 +433,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+            )
 
         return inner
 
@@ -454,7 +458,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+            )
 
         return inner
 
@@ -477,7 +483,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+            )
 
         return inner
 
@@ -500,7 +508,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+            )
 
         return inner
 
@@ -523,7 +533,15 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.OPTIONS,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                status_code=status_code,
+            )
 
         return inner
 
@@ -546,7 +564,15 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.CONNECT,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                status_code=status_code,
+            )
 
         return inner
 
@@ -569,7 +595,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+            return self.add_route(
+                HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+            )
 
         return inner
 
@@ -723,29 +751,62 @@ class SubRouter(BaseRobyn):
 
         return f"{normalized_prefix}{normalized_endpoint}"
 
-    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"], status_code: Optional[int] = None):
-        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+    def get(
+        self,
+        endpoint: str,
+        const: bool = False,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["get"],
+        status_code: Optional[int] = None,
+    ):
+        return super().get(
+            endpoint=self.__add_prefix(endpoint),
+            const=const,
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            status_code=status_code,
+        )
 
     def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"], status_code: Optional[int] = None):
-        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+        return super().post(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
     def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"], status_code: Optional[int] = None):
-        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+        return super().put(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
-    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"], status_code: Optional[int] = None):
-        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+    def delete(
+        self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"], status_code: Optional[int] = None
+    ):
+        return super().delete(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
     def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"], status_code: Optional[int] = None):
-        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+        return super().patch(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
     def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"], status_code: Optional[int] = None):
-        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+        return super().head(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
     def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"], status_code: Optional[int] = None):
-        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+        return super().trace(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
-    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"], status_code: Optional[int] = None):
-        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
+    def options(
+        self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"], status_code: Optional[int] = None
+    ):
+        return super().options(
+            endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code
+        )
 
     def websocket(self, endpoint: str):
         """

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -155,6 +155,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: Union[List[str], None] = None,
+        status_code: Optional[int] = None,
     ):
         """
         Connect a URI to a handler
@@ -164,9 +165,7 @@ class BaseRobyn(ABC):
         :param handler function: represents the sync or async function passed as a handler for the route
         :param is_const bool: represents if the handler is a const function or not
         :param auth_required bool: represents if the route needs authentication or not
-        """
-
-        """ We will add the status code here only
+        :param status_code int|None: default HTTP status code for the response
         """
         injected_dependencies = self.dependencies.get_dependency_map(self)
 
@@ -215,6 +214,7 @@ class BaseRobyn(ABC):
             openapi_tags=list_openapi_tags,
             exception_handler=self.exception_handler,
             injected_dependencies=injected_dependencies,
+            default_status_code=status_code,
         )
 
         logger.info("Added route %s %s", route_type, normalized_endpoint)
@@ -371,6 +371,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["get"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.get decorator to add a route with the GET method
@@ -380,10 +381,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags)
+            return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags, status_code=status_code)
 
         return inner
 
@@ -393,6 +395,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["post"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.post decorator to add a route with POST method
@@ -401,10 +404,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -414,6 +418,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["put"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.put decorator to add a get route with PUT method
@@ -422,10 +427,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -435,6 +441,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["delete"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.delete decorator to add a route with DELETE method
@@ -443,10 +450,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -456,6 +464,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["patch"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.patch decorator to add a route with PATCH method
@@ -464,10 +473,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -477,6 +487,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["head"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.head decorator to add a route with HEAD method
@@ -485,10 +496,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -498,6 +510,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["options"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.options decorator to add a route with OPTIONS method
@@ -506,10 +519,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -519,6 +533,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["connect"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.connect decorator to add a route with CONNECT method
@@ -527,10 +542,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -540,6 +556,7 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["trace"],
+        status_code: Optional[int] = None,
     ):
         """
         The @app.trace decorator to add a route with TRACE method
@@ -548,10 +565,11 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param status_code: int|None -- default HTTP status code for the response
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
         return inner
 
@@ -705,29 +723,29 @@ class SubRouter(BaseRobyn):
 
         return f"{normalized_prefix}{normalized_endpoint}"
 
-    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"]):
-        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"], status_code: Optional[int] = None):
+        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"]):
-        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"], status_code: Optional[int] = None):
+        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"]):
-        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"], status_code: Optional[int] = None):
+        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"]):
-        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"], status_code: Optional[int] = None):
+        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"]):
-        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"], status_code: Optional[int] = None):
+        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"]):
-        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"], status_code: Optional[int] = None):
+        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"]):
-        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"], status_code: Optional[int] = None):
+        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
-    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"]):
-        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"], status_code: Optional[int] = None):
+        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, status_code=status_code)
 
     def websocket(self, endpoint: str):
         """

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -168,7 +168,9 @@ class OpenAPI:
             "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
         }
 
-    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable, status_code: Optional[int] = None):
+    def add_openapi_path_obj(
+        self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable, status_code: Optional[int] = None
+    ):
         """
         Adds the given path to openapi spec
 

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -168,7 +168,7 @@ class OpenAPI:
             "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
         }
 
-    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable):
+    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable, status_code: Optional[int] = None):
         """
         Adds the given path to openapi spec
 
@@ -177,6 +177,7 @@ class OpenAPI:
         @param openapi_name: str the name of the endpoint
         @param openapi_tags: List[str] for grouping of endpoints
         @param handler: Callable the handler function for the endpoint
+        @param status_code: Optional[int] default response status code
         """
 
         if self.openapi_file_override:
@@ -224,7 +225,7 @@ class OpenAPI:
                 return_annotation = signature.return_annotation
 
         modified_endpoint, path_obj = self.get_path_obj(
-            endpoint, openapi_name, openapi_description, openapi_tags, query_params, request_body, return_annotation
+            endpoint, openapi_name, openapi_description, openapi_tags, query_params, request_body, return_annotation, status_code=status_code
         )
 
         if modified_endpoint not in self.openapi_spec["paths"]:
@@ -274,6 +275,7 @@ class OpenAPI:
         query_params: Optional[str_typed_dict],
         request_body: Optional[str_typed_dict],
         return_annotation: Optional[str_typed_dict],
+        status_code: Optional[int] = None,
     ) -> Tuple[str, dict]:
         """
         Get the "path" openapi object according to spec
@@ -369,7 +371,8 @@ class OpenAPI:
             response_type = "application/json"
             response_schema = self.get_schema_object("response object", return_annotation)
 
-        openapi_path_object["responses"] = {"200": {"description": "Successful Response", "content": {response_type: {"schema": response_schema}}}}
+        response_key = str(status_code) if status_code is not None else "200"
+        openapi_path_object["responses"] = {response_key: {"description": "Successful Response", "content": {response_type: {"schema": response_schema}}}}
 
         return endpoint_with_path_params_wrapped_in_braces, openapi_path_object
 

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -275,12 +275,11 @@ class Router(BaseRouter):
 
         @wraps(handler)
         async def async_inner_handler(*args, **kwargs):
+            was_explicit_response = False
             try:
-                response = self._format_response(
-                    await wrapped_handler(*args, **kwargs),
-                )
-                if default_status_code is not None and response.status_code == 200:
-                    response.status_code = default_status_code
+                raw_result = await wrapped_handler(*args, **kwargs)
+                was_explicit_response = isinstance(raw_result, (Response, StreamingResponse))
+                response = self._format_response(raw_result)
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -299,16 +298,17 @@ class Router(BaseRouter):
                 response = self._format_response(
                     exception_handler(err),
                 )
+            if default_status_code is not None and not was_explicit_response and response.status_code == 200:
+                response.status_code = default_status_code
             return response
 
         @wraps(handler)
         def inner_handler(*args, **kwargs):
+            was_explicit_response = False
             try:
-                response = self._format_response(
-                    wrapped_handler(*args, **kwargs),
-                )
-                if default_status_code is not None and response.status_code == 200:
-                    response.status_code = default_status_code
+                raw_result = wrapped_handler(*args, **kwargs)
+                was_explicit_response = isinstance(raw_result, (Response, StreamingResponse))
+                response = self._format_response(raw_result)
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -327,6 +327,8 @@ class Router(BaseRouter):
                 response = self._format_response(
                     exception_handler(err),
                 )
+            if default_status_code is not None and not was_explicit_response and response.status_code == 200:
+                response.status_code = default_status_code
             return response
 
         params = dict(handler_params)

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -37,6 +37,7 @@ class Route(NamedTuple):
     auth_required: bool
     openapi_name: str
     openapi_tags: List[str]
+    default_status_code: Optional[int] = None
 
 
 class RouteMiddleware(NamedTuple):
@@ -138,6 +139,7 @@ class Router(BaseRouter):
         openapi_tags: List[str],
         exception_handler: Optional[Callable],
         injected_dependencies: dict,
+        default_status_code: Optional[int] = None,
     ) -> Union[Callable, CoroutineType]:
         # Pre-compute handler signature ONCE at registration time.
         # This avoids calling inspect.signature() on every request.
@@ -277,6 +279,8 @@ class Router(BaseRouter):
                 response = self._format_response(
                     await wrapped_handler(*args, **kwargs),
                 )
+                if default_status_code is not None and response.status_code == 200:
+                    response.status_code = default_status_code
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -303,6 +307,8 @@ class Router(BaseRouter):
                 response = self._format_response(
                     wrapped_handler(*args, **kwargs),
                 )
+                if default_status_code is not None and response.status_code == 200:
+                    response.status_code = default_status_code
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -340,7 +346,7 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags, default_status_code))
             return async_inner_handler
         else:
             function = FunctionInfo(
@@ -350,12 +356,12 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags, default_status_code))
             return inner_handler
 
     def prepare_routes_openapi(self, openapi: OpenAPI, included_routers: List) -> None:
         for route in self.routes:
-            openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler)
+            openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler, route.default_status_code)
 
         # TODO! after include_routes does not immediately merge all the routes
         # for router in included_routers:

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -361,7 +361,9 @@ class Router(BaseRouter):
 
     def prepare_routes_openapi(self, openapi: OpenAPI, included_routers: List) -> None:
         for route in self.routes:
-            openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler, route.default_status_code)
+            openapi.add_openapi_path_obj(
+                lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler, route.default_status_code
+            )
 
         # TODO! after include_routes does not immediately merge all the routes
         # for router in included_routers:

--- a/unit_tests/test_status_code.py
+++ b/unit_tests/test_status_code.py
@@ -1,0 +1,24 @@
+from robyn import Robyn
+
+
+def test_status_code_on_post(tmp_path):
+    app = Robyn(__file__)
+
+    @app.post("/items", status_code=201)
+    async def create_item():
+        return {"id": 1}
+
+    routes = app.router.get_routes()
+    assert len(routes) == 1
+    assert routes[0].default_status_code == 201
+
+
+def test_status_code_default_none(tmp_path):
+    app = Robyn(__file__)
+
+    @app.get("/items")
+    async def list_items():
+        return []
+
+    routes = app.router.get_routes()
+    assert routes[0].default_status_code is None


### PR DESCRIPTION
## Summary

- Adds a `status_code=` parameter to all route decorators (`@app.get`, `@app.post`, `@app.put`, `@app.delete`, `@app.patch`, `@app.head`, `@app.options`, `@app.connect`, `@app.trace`) and `SubRouter` equivalents.
- When set, the default status code is applied to responses that would otherwise return 200 (i.e., when the handler returns a plain value, not an explicit `Response` object).
- The configured status code is also reflected in the auto-generated OpenAPI spec.

### Usage

```python
@app.post("/items", status_code=201)
async def create_item():
    return {"id": 1}
```

## Test plan

- [x] New unit tests in `unit_tests/test_status_code.py` verify route registration with `status_code=201` and default `None`.
- [x] All existing unit tests pass (`19 passed`).
- [ ] Integration tests: verify the actual HTTP response status code when hitting a route with a custom `status_code`.
- [ ] Verify OpenAPI spec reflects the custom status code (e.g., `"201"` instead of `"200"`).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route registration and all HTTP method decorators accept an optional status_code to set a default response status (e.g., 201 for POST).
  * OpenAPI documentation reflects any specified default status codes.

* **Behavior**
  * When a handler doesn't return an explicit response status, the configured default status_code is applied.

* **Tests**
  * Added tests verifying routes record and expose configured default status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->