### PR TITLE
feat: add deprecated and include_in_schema flags to route decorators

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -391,7 +391,9 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated
+            )
 
         return inner
 
@@ -416,7 +418,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.POST,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -441,7 +452,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.PUT,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -466,7 +486,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.DELETE,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -491,7 +520,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.PATCH,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -516,7 +554,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.HEAD,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -541,7 +588,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.OPTIONS,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -566,7 +622,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.CONNECT,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -591,7 +656,16 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+            return self.add_route(
+                HttpMethod.TRACE,
+                endpoint,
+                handler,
+                auth_required=auth_required,
+                openapi_name=openapi_name,
+                openapi_tags=openapi_tags,
+                include_in_schema=include_in_schema,
+                deprecated=deprecated,
+            )
 
         return inner
 
@@ -745,29 +819,151 @@ class SubRouter(BaseRobyn):
 
         return f"{normalized_prefix}{normalized_endpoint}"
 
-    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def get(
+        self,
+        endpoint: str,
+        const: bool = False,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["get"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().get(
+            endpoint=self.__add_prefix(endpoint),
+            const=const,
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def post(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["post"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().post(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def put(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["put"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().put(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def delete(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["delete"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().delete(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def patch(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["patch"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().patch(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def head(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["head"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().head(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def trace(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["trace"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().trace(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
-    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"], include_in_schema: bool = True, deprecated: bool = False):
-        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
+    def options(
+        self,
+        endpoint: str,
+        auth_required: bool = False,
+        openapi_name: str = "",
+        openapi_tags: List[str] = ["options"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
+    ):
+        return super().options(
+            endpoint=self.__add_prefix(endpoint),
+            auth_required=auth_required,
+            openapi_name=openapi_name,
+            openapi_tags=openapi_tags,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
+        )
 
     def websocket(self, endpoint: str):
         """

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -155,6 +155,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: Union[List[str], None] = None,
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         Connect a URI to a handler
@@ -215,6 +217,8 @@ class BaseRobyn(ABC):
             openapi_tags=list_openapi_tags,
             exception_handler=self.exception_handler,
             injected_dependencies=injected_dependencies,
+            include_in_schema=include_in_schema,
+            deprecated=deprecated,
         )
 
         logger.info("Added route %s %s", route_type, normalized_endpoint)
@@ -371,6 +375,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["get"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.get decorator to add a route with the GET method
@@ -380,10 +386,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags)
+            return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -393,6 +401,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["post"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.post decorator to add a route with POST method
@@ -401,10 +411,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.POST, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -414,6 +426,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["put"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.put decorator to add a get route with PUT method
@@ -422,10 +436,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.PUT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -435,6 +451,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["delete"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.delete decorator to add a route with DELETE method
@@ -443,10 +461,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.DELETE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -456,6 +476,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["patch"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.patch decorator to add a route with PATCH method
@@ -464,10 +486,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.PATCH, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -477,6 +501,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["head"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.head decorator to add a route with HEAD method
@@ -485,10 +511,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.HEAD, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -498,6 +526,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["options"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.options decorator to add a route with OPTIONS method
@@ -506,10 +536,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.OPTIONS, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -519,6 +551,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["connect"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.connect decorator to add a route with CONNECT method
@@ -527,10 +561,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.CONNECT, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -540,6 +576,8 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: List[str] = ["trace"],
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ):
         """
         The @app.trace decorator to add a route with TRACE method
@@ -548,10 +586,12 @@ class BaseRobyn(ABC):
         :param auth_required bool: represents if the route needs authentication or not
         :param openapi_name: str -- the name of the endpoint in the openapi spec
         :param openapi_tags: List[str] -- for grouping of endpoints in the openapi spec
+        :param include_in_schema bool: whether to include this route in the OpenAPI schema
+        :param deprecated bool: whether this route is deprecated
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+            return self.add_route(HttpMethod.TRACE, endpoint, handler, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
         return inner
 
@@ -705,29 +745,29 @@ class SubRouter(BaseRobyn):
 
         return f"{normalized_prefix}{normalized_endpoint}"
 
-    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"]):
-        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def get(self, endpoint: str, const: bool = False, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["get"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().get(endpoint=self.__add_prefix(endpoint), const=const, auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"]):
-        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def post(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["post"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().post(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"]):
-        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def put(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["put"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().put(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"]):
-        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def delete(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["delete"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().delete(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"]):
-        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def patch(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["patch"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().patch(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"]):
-        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def head(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["head"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().head(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"]):
-        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def trace(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["trace"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().trace(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
-    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"]):
-        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags)
+    def options(self, endpoint: str, auth_required: bool = False, openapi_name: str = "", openapi_tags: List[str] = ["options"], include_in_schema: bool = True, deprecated: bool = False):
+        return super().options(endpoint=self.__add_prefix(endpoint), auth_required=auth_required, openapi_name=openapi_name, openapi_tags=openapi_tags, include_in_schema=include_in_schema, deprecated=deprecated)
 
     def websocket(self, endpoint: str):
         """

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -168,7 +168,7 @@ class OpenAPI:
             "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
         }
 
-    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable):
+    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: List[str], handler: Callable, deprecated: bool = False):
         """
         Adds the given path to openapi spec
 
@@ -177,6 +177,7 @@ class OpenAPI:
         @param openapi_name: str the name of the endpoint
         @param openapi_tags: List[str] for grouping of endpoints
         @param handler: Callable the handler function for the endpoint
+        @param deprecated: bool whether this endpoint is deprecated
         """
 
         if self.openapi_file_override:
@@ -224,7 +225,7 @@ class OpenAPI:
                 return_annotation = signature.return_annotation
 
         modified_endpoint, path_obj = self.get_path_obj(
-            endpoint, openapi_name, openapi_description, openapi_tags, query_params, request_body, return_annotation
+            endpoint, openapi_name, openapi_description, openapi_tags, query_params, request_body, return_annotation, deprecated=deprecated
         )
 
         if modified_endpoint not in self.openapi_spec["paths"]:
@@ -274,6 +275,7 @@ class OpenAPI:
         query_params: Optional[str_typed_dict],
         request_body: Optional[str_typed_dict],
         return_annotation: Optional[str_typed_dict],
+        deprecated: bool = False,
     ) -> Tuple[str, dict]:
         """
         Get the "path" openapi object according to spec
@@ -299,6 +301,9 @@ class OpenAPI:
             "parameters": [],
             "tags": tags,
         }
+
+        if deprecated:
+            openapi_path_object["deprecated"] = True
 
         # robyn has paths like /:url/:etc whereas openapi requires path like /{url}/{path}
         # this function is used for converting path params to the required form

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -37,6 +37,8 @@ class Route(NamedTuple):
     auth_required: bool
     openapi_name: str
     openapi_tags: List[str]
+    include_in_schema: bool = True
+    deprecated: bool = False
 
 
 class RouteMiddleware(NamedTuple):
@@ -138,6 +140,8 @@ class Router(BaseRouter):
         openapi_tags: List[str],
         exception_handler: Optional[Callable],
         injected_dependencies: dict,
+        include_in_schema: bool = True,
+        deprecated: bool = False,
     ) -> Union[Callable, CoroutineType]:
         # Pre-compute handler signature ONCE at registration time.
         # This avoids calling inspect.signature() on every request.
@@ -340,7 +344,7 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags, include_in_schema, deprecated))
             return async_inner_handler
         else:
             function = FunctionInfo(
@@ -350,12 +354,21 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags, include_in_schema, deprecated))
             return inner_handler
 
     def prepare_routes_openapi(self, openapi: OpenAPI, included_routers: List) -> None:
         for route in self.routes:
-            openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler)
+            if not route.include_in_schema:
+                continue
+            openapi.add_openapi_path_obj(
+                lower_http_method(route.route_type),
+                route.route,
+                route.openapi_name,
+                route.openapi_tags,
+                route.function.handler,
+                deprecated=route.deprecated,
+            )
 
         # TODO! after include_routes does not immediately merge all the routes
         # for router in included_routers:

--- a/unit_tests/test_openapi_flags.py
+++ b/unit_tests/test_openapi_flags.py
@@ -1,0 +1,35 @@
+from robyn import Robyn
+
+
+def test_deprecated_route():
+    app = Robyn(__file__)
+
+    @app.get("/old-endpoint", deprecated=True)
+    async def old_handler():
+        return "old"
+
+    routes = app.router.get_routes()
+    assert routes[0].deprecated is True
+
+
+def test_include_in_schema_false():
+    app = Robyn(__file__)
+
+    @app.get("/health", include_in_schema=False)
+    async def health():
+        return "ok"
+
+    routes = app.router.get_routes()
+    assert routes[0].include_in_schema is False
+
+
+def test_defaults():
+    app = Robyn(__file__)
+
+    @app.get("/normal")
+    async def normal():
+        return "normal"
+
+    routes = app.router.get_routes()
+    assert routes[0].deprecated is False
+    assert routes[0].include_in_schema is True


### PR DESCRIPTION
## Summary

- Adds `deprecated=` and `include_in_schema=` parameters to all route decorators (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`, `connect`, `trace`) and `SubRouter` equivalents.
- Routes marked `deprecated=True` emit `"deprecated": true` in the generated OpenAPI spec, causing Swagger UI to render them with strikethrough styling.
- Routes marked `include_in_schema=False` are silently excluded from the OpenAPI spec (useful for health checks, internal endpoints, etc.).
- Both flags default to the current behaviour (`include_in_schema=True`, `deprecated=False`), so this change is fully backwards-compatible.

## Test plan

- [x] `unit_tests/test_openapi_flags.py` — three new tests covering `deprecated=True`, `include_in_schema=False`, and default values.
- [ ] Verify existing test suite still passes.
- [ ] Manual: register a deprecated route, hit `/openapi.json`, confirm `"deprecated": true` appears.
- [ ] Manual: register a route with `include_in_schema=False`, confirm it is absent from `/openapi.json`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route registration and sub-router helpers now accept flags to exclude routes from generated OpenAPI docs and to mark endpoints as deprecated; deprecated endpoints are reflected in the OpenAPI output.

* **Tests**
  * Added tests to verify flag propagation and default behavior for included-in-schema and deprecated route settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->