### PR TITLE
feat: add BackgroundTasks for post-response execution

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -10,6 +10,7 @@ import multiprocess as mp  # type: ignore
 
 from robyn import status_codes
 from robyn.argument_parser import Config
+from robyn.background import BackgroundTask, BackgroundTasks
 from robyn.authentication import AuthenticationHandler
 from robyn.dependency_injection import DependencyMap
 from robyn.env_populator import load_vars
@@ -811,4 +812,6 @@ __all__ = [
     "WebSocketDisconnect",
     "JsonBody",
     "MCPApp",
+    "BackgroundTask",
+    "BackgroundTasks",
 ]

--- a/robyn/background.py
+++ b/robyn/background.py
@@ -14,7 +14,10 @@ class BackgroundTask:
         self.func = func
         self.args = args
         self.kwargs = kwargs
-        self.is_async = inspect.iscoroutinefunction(func)
+        self.is_async = inspect.iscoroutinefunction(func) or (
+            callable(func)
+            and inspect.iscoroutinefunction(getattr(func, "__call__", None))
+        )
 
     def __call__(self) -> None:
         if self.is_async:
@@ -53,7 +56,10 @@ class BackgroundTasks:
             try:
                 task()
             except Exception:
-                _logger.exception("Background task %s failed", task.func.__name__)
+                func_name = getattr(task.func, "__name__", None) or getattr(
+                    task.func, "__qualname__", repr(task.func)
+                )
+                _logger.exception("Background task %s failed", func_name)
 
     def run_in_thread(self) -> None:
         """Execute all tasks in a background thread."""

--- a/robyn/background.py
+++ b/robyn/background.py
@@ -14,10 +14,7 @@ class BackgroundTask:
         self.func = func
         self.args = args
         self.kwargs = kwargs
-        self.is_async = inspect.iscoroutinefunction(func) or (
-            callable(func)
-            and inspect.iscoroutinefunction(getattr(func, "__call__", None))
-        )
+        self.is_async = inspect.iscoroutinefunction(func) or (callable(func) and inspect.iscoroutinefunction(getattr(func, "__call__", None)))
 
     def __call__(self) -> None:
         if self.is_async:
@@ -56,9 +53,7 @@ class BackgroundTasks:
             try:
                 task()
             except Exception:
-                func_name = getattr(task.func, "__name__", None) or getattr(
-                    task.func, "__qualname__", repr(task.func)
-                )
+                func_name = getattr(task.func, "__name__", None) or getattr(task.func, "__qualname__", repr(task.func))
                 _logger.exception("Background task %s failed", func_name)
 
     def run_in_thread(self) -> None:

--- a/robyn/background.py
+++ b/robyn/background.py
@@ -1,0 +1,66 @@
+import asyncio
+import inspect
+import logging
+import threading
+from typing import Any, Callable, List
+
+_logger = logging.getLogger(__name__)
+
+
+class BackgroundTask:
+    """A single background task to be executed after the response is sent."""
+
+    def __init__(self, func: Callable, *args: Any, **kwargs: Any) -> None:
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+        self.is_async = inspect.iscoroutinefunction(func)
+
+    def __call__(self) -> None:
+        if self.is_async:
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(self.func(*self.args, **self.kwargs))
+            finally:
+                loop.close()
+        else:
+            self.func(*self.args, **self.kwargs)
+
+
+class BackgroundTasks:
+    """Collection of tasks to run after the response is sent.
+
+    Usage::
+
+        @app.post("/send-email")
+        async def send_email(request):
+            tasks = BackgroundTasks()
+            tasks.add_task(send_welcome_email, user_email="user@example.com")
+            tasks.add_task(log_signup, user_id=42)
+            return {"status": "accepted"}, tasks
+    """
+
+    def __init__(self) -> None:
+        self._tasks: List[BackgroundTask] = []
+
+    def add_task(self, func: Callable, *args: Any, **kwargs: Any) -> None:
+        """Add a task to be run in the background after the response is sent."""
+        self._tasks.append(BackgroundTask(func, *args, **kwargs))
+
+    def run(self) -> None:
+        """Execute all tasks. Called by the framework after the response is sent."""
+        for task in self._tasks:
+            try:
+                task()
+            except Exception:
+                _logger.exception("Background task %s failed", task.func.__name__)
+
+    def run_in_thread(self) -> None:
+        """Execute all tasks in a background thread."""
+        if not self._tasks:
+            return
+        thread = threading.Thread(target=self.run, daemon=True)
+        thread.start()
+
+    def __len__(self) -> int:
+        return len(self._tasks)

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -18,6 +18,7 @@ from robyn.pydantic_support import (
     serialize_pydantic_response,
     validate_pydantic_body,
 )
+from robyn.background import BackgroundTasks
 from robyn.responses import FileResponse, StreamingResponse
 from robyn.robyn import FunctionInfo, Headers, HttpMethod, Identity, MiddlewareType, QueryParams, Request, Response, Url
 from robyn.types import Body, Files, FormData, IPAddress, JsonBody, Method, PathParams
@@ -273,10 +274,12 @@ class Router(BaseRouter):
 
         @wraps(handler)
         async def async_inner_handler(*args, **kwargs):
+            background = None
             try:
-                response = self._format_response(
-                    await wrapped_handler(*args, **kwargs),
-                )
+                result = await wrapped_handler(*args, **kwargs)
+                if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], BackgroundTasks):
+                    result, background = result
+                response = self._format_response(result)
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -295,14 +298,19 @@ class Router(BaseRouter):
                 response = self._format_response(
                     exception_handler(err),
                 )
+
+            if background is not None:
+                background.run_in_thread()
             return response
 
         @wraps(handler)
         def inner_handler(*args, **kwargs):
+            background = None
             try:
-                response = self._format_response(
-                    wrapped_handler(*args, **kwargs),
-                )
+                result = wrapped_handler(*args, **kwargs)
+                if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], BackgroundTasks):
+                    result, background = result
+                response = self._format_response(result)
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -321,6 +329,9 @@ class Router(BaseRouter):
                 response = self._format_response(
                     exception_handler(err),
                 )
+
+            if background is not None:
+                background.run_in_thread()
             return response
 
         params = dict(handler_params)

--- a/unit_tests/test_background_tasks.py
+++ b/unit_tests/test_background_tasks.py
@@ -1,0 +1,73 @@
+import time
+
+from robyn.background import BackgroundTask, BackgroundTasks
+
+
+def test_background_task_sync():
+    results = []
+
+    def append_result(value):
+        results.append(value)
+
+    task = BackgroundTask(append_result, "hello")
+    task()
+    assert results == ["hello"]
+
+
+def test_background_task_async():
+    results = []
+
+    async def async_append(value):
+        results.append(value)
+
+    task = BackgroundTask(async_append, "async_hello")
+    task()
+    assert results == ["async_hello"]
+
+
+def test_background_tasks_collection():
+    results = []
+
+    def task_a():
+        results.append("a")
+
+    def task_b(x):
+        results.append(x)
+
+    tasks = BackgroundTasks()
+    tasks.add_task(task_a)
+    tasks.add_task(task_b, "b")
+
+    assert len(tasks) == 2
+    tasks.run()
+    assert results == ["a", "b"]
+
+
+def test_background_tasks_run_in_thread():
+    results = []
+
+    def slow_task():
+        results.append("done")
+
+    tasks = BackgroundTasks()
+    tasks.add_task(slow_task)
+    tasks.run_in_thread()
+
+    time.sleep(0.5)
+    assert results == ["done"]
+
+
+def test_background_tasks_error_handling():
+    results = []
+
+    def failing_task():
+        raise ValueError("fail")
+
+    def ok_task():
+        results.append("ok")
+
+    tasks = BackgroundTasks()
+    tasks.add_task(failing_task)
+    tasks.add_task(ok_task)
+    tasks.run()
+    assert results == ["ok"]

--- a/unit_tests/test_background_tasks.py
+++ b/unit_tests/test_background_tasks.py
@@ -1,4 +1,4 @@
-import time
+import threading
 
 from robyn.background import BackgroundTask, BackgroundTasks
 
@@ -44,16 +44,18 @@ def test_background_tasks_collection():
 
 
 def test_background_tasks_run_in_thread():
+    event = threading.Event()
     results = []
 
     def slow_task():
         results.append("done")
+        event.set()
 
     tasks = BackgroundTasks()
     tasks.add_task(slow_task)
     tasks.run_in_thread()
 
-    time.sleep(0.5)
+    event.wait(timeout=5)
     assert results == ["done"]
 
 


### PR DESCRIPTION
## Summary

- Adds `BackgroundTask` and `BackgroundTasks` classes in `robyn/background.py` for scheduling work to run after the response is sent to the client.
- Integrates with the router so handlers can return `(response, BackgroundTasks)` tuples; tasks are executed in a background thread after response dispatch.
- Exports the new classes from `robyn.__init__` for convenient access.

## Usage

```python
from robyn import BackgroundTasks

@app.post("/notify")
async def notify(request):
    tasks = BackgroundTasks()
    tasks.add_task(send_email, to="user@example.com")
    tasks.add_task(log_event, event="signup")
    return {"status": "queued"}, tasks
```

Both sync and async callables are supported. Errors in individual tasks are logged but do not affect other tasks or the response.

Closes #548

## Test plan

- [x] Unit tests for `BackgroundTask` (sync and async execution)
- [x] Unit tests for `BackgroundTasks` (collection, `run`, `run_in_thread`, error isolation)
- [ ] Verify existing test suite still passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background task support to run operations after responding to clients.
  * Handles both sync and async callables, with optional threaded execution.
  * Queue multiple tasks for ordered, sequential execution with per-task error isolation.

* **Tests**
  * Added unit tests covering task execution, threading behavior, ordering, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->