### PR TITLE
feat: add headers support to HTTPException and auto-handle in router

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -12,6 +12,7 @@ from robyn import status_codes
 from robyn.argument_parser import Config
 from robyn.authentication import AuthenticationHandler
 from robyn.dependency_injection import DependencyMap
+from robyn.exceptions import HTTPException
 from robyn.env_populator import load_vars
 from robyn.events import Events
 from robyn.jsonify import jsonify
@@ -811,4 +812,5 @@ __all__ = [
     "WebSocketDisconnect",
     "JsonBody",
     "MCPApp",
+    "HTTPException",
 ]

--- a/robyn/exceptions.py
+++ b/robyn/exceptions.py
@@ -2,11 +2,12 @@ import http
 
 
 class HTTPException(Exception):
-    def __init__(self, status_code: int, detail: str | None = None) -> None:
+    def __init__(self, status_code: int, detail: str | None = None, headers: dict | None = None) -> None:
         if detail is None:
             detail = http.HTTPStatus(status_code).phrase
         self.status_code = status_code
         self.detail = detail
+        self.headers = headers or {}
 
     def __str__(self) -> str:
         return f"{self.status_code}: {self.detail}"

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -6,6 +6,7 @@ from types import CoroutineType
 from typing import Callable, Dict, List, NamedTuple, Optional, Union, is_typeddict
 
 from robyn import status_codes
+from robyn.exceptions import HTTPException
 from robyn._param_utils import QueryParamValidationError, parse_route_param_names, resolve_individual_params
 from robyn.authentication import AuthenticationHandler, AuthenticationNotConfiguredError
 from robyn.dependency_injection import DependencyMap
@@ -289,6 +290,12 @@ class Router(BaseRouter):
                     headers=Headers({"Content-Type": "application/json"}),
                     description=jsonify(err.error_detail),
                 )
+            except HTTPException as exc:
+                response = Response(
+                    status_code=exc.status_code,
+                    headers=Headers(exc.headers),
+                    description=exc.detail or "",
+                )
             except Exception as err:
                 if exception_handler is None:
                     raise
@@ -314,6 +321,12 @@ class Router(BaseRouter):
                     status_code=status_codes.HTTP_422_UNPROCESSABLE_ENTITY,
                     headers=Headers({"Content-Type": "application/json"}),
                     description=jsonify(err.error_detail),
+                )
+            except HTTPException as exc:
+                response = Response(
+                    status_code=exc.status_code,
+                    headers=Headers(exc.headers),
+                    description=exc.detail or "",
                 )
             except Exception as err:
                 if exception_handler is None:

--- a/unit_tests/test_http_exception.py
+++ b/unit_tests/test_http_exception.py
@@ -1,0 +1,35 @@
+from robyn.exceptions import HTTPException
+
+
+def test_http_exception_default():
+    exc = HTTPException(404)
+    assert exc.status_code == 404
+    assert exc.detail == "Not Found"
+    assert exc.headers == {}
+
+
+def test_http_exception_custom_detail():
+    exc = HTTPException(403, detail="Go away")
+    assert exc.detail == "Go away"
+
+
+def test_http_exception_with_headers():
+    exc = HTTPException(
+        401,
+        detail="Token expired",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    assert exc.status_code == 401
+    assert exc.detail == "Token expired"
+    assert exc.headers == {"WWW-Authenticate": "Bearer"}
+
+
+def test_http_exception_str():
+    exc = HTTPException(500, detail="Internal error")
+    assert str(exc) == "500: Internal error"
+
+
+def test_http_exception_repr():
+    exc = HTTPException(400, detail="Bad input")
+    assert "HTTPException" in repr(exc)
+    assert "400" in repr(exc)


### PR DESCRIPTION
## Summary

- **`HTTPException` now accepts an optional `headers` dict** that gets included in the HTTP response when the exception is raised.
- **Automatic `HTTPException` handling in the router**: when a handler raises `HTTPException`, the framework catches it and returns the correct `Response` with the appropriate status code, headers, and detail message — no manual `@app.exception` handler needed.
- **`HTTPException` is now exported** from the top-level `robyn` package for convenient imports (`from robyn import HTTPException`).

## Changes

| File | Change |
|---|---|
| `robyn/exceptions.py` | Added `headers: dict \| None = None` parameter to `HTTPException.__init__` |
| `robyn/router.py` | Added `HTTPException` catch block in both `async_inner_handler` and `inner_handler` (before the generic `Exception` catch) |
| `robyn/__init__.py` | Added `HTTPException` to imports and `__all__` |
| `unit_tests/test_http_exception.py` | New test file with 5 unit tests covering default, custom detail, headers, `__str__`, and `__repr__` |

## Test plan

- [x] `test_http_exception_default` — verifies default detail from HTTP status phrase and empty headers
- [x] `test_http_exception_custom_detail` — verifies custom detail override
- [x] `test_http_exception_with_headers` — verifies headers dict is stored and accessible
- [x] `test_http_exception_str` — verifies string representation
- [x] `test_http_exception_repr` — verifies repr contains class name and status code
- [ ] Verify CI passes on all supported Python versions

Made with [Cursor](https://cursor.com)