### PR TITLE
docs: add HTTPException usage examples to exceptions reference

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/exceptions.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/exceptions.mdx
@@ -1,3 +1,48 @@
+## Handling Errors
+
+Batman learned how to handle errors for different exceptions in his application. He wrote the following code to handle exceptions:
+
+<Row>
+<Col>
+</Col>
+  <Col sticky>
+
+    <CodeGroup title="Request" tag="GET" label="/items/:item_id">
+
+    ```python {{ title: 'untyped' }}
+    from robyn import Robyn, HTTPException, status_codes
+
+    app = Robyn(__file__)
+
+    items = {"foo": "The Foo Wrestlers"}
+
+    @app.get("/items/:item_id")
+    async def read_item(request, item_id):
+        if item_id not in items:
+            raise HTTPException(status_code=status_codes.HTTP_404_NOT_FOUND, detail="Item not found")
+        return {"item": items[item_id]}
+    ```
+
+    ```python {{ title: 'typed' }}
+    from robyn import Robyn, HTTPException, Request, status_codes
+    from typing import Dict
+
+    app = Robyn(__file__)
+
+    items: Dict[str, str] = {"foo": "The Foo Wrestlers"}
+
+    @app.get("/items/:item_id")
+    async def read_item(request: Request, item_id: str) -> Dict[str, str]:
+        if item_id not in items:
+            raise HTTPException(status_code=status_codes.HTTP_404_NOT_FOUND, detail="Item not found")
+        return {"item": items[item_id]}
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
 ## Custom Exception Handler
 
 Batman learned how to create custom error handlers for different exception types in his application. He wrote the following code to handle exceptions and return a custom error response:


### PR DESCRIPTION
## Summary
- Adds a new "Handling Errors" section to the exceptions API reference page showing how to use `HTTPException` with `status_codes` for error handling in route handlers
- Includes both typed and untyped code examples using Robyn's path parameter syntax
- Placed before the existing "Custom Exception Handler" section for logical flow

Supersedes #951

## Test plan
- [ ] Verify the docs site renders the new section correctly
- [ ] Confirm code examples use valid Robyn API (`HTTPException`, `status_codes`, `:param` syntax)

Made with [Cursor](https://cursor.com)