### PR TITLE
feat: add to_dict() and get_headers() methods to Headers

### DIFF
--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -362,6 +362,14 @@ class Headers:
         """
         pass
 
+    def get_headers(self) -> dict[str, list[str]]:
+        """Returns all headers as a dictionary where keys are header names and values are lists of all values for that header."""
+        ...
+
+    def to_dict(self) -> dict[str, str]:
+        """Returns headers as a flattened dictionary, joining duplicate headers with commas."""
+        ...
+
 @dataclass
 class Request:
     """

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -94,6 +94,20 @@ impl Headers {
         dict.into()
     }
 
+    pub fn to_dict(&self, py: Python) -> Py<PyDict> {
+        let dict = PyDict::new(py);
+        for iter in self.headers.iter() {
+            let (key, values) = iter.pair();
+            let joined_value = if values.len() == 1 {
+                values[0].clone()
+            } else {
+                values.join(",")
+            };
+            dict.set_item(key, joined_value).unwrap();
+        }
+        dict.into()
+    }
+
     pub fn contains(&self, key: String) -> bool {
         self.headers.contains_key(&key.to_lowercase())
     }

--- a/unit_tests/test_request_object.py
+++ b/unit_tests/test_request_object.py
@@ -25,3 +25,38 @@ def test_request_object():
     print(request.headers.get("Content-Type"))
     assert request.headers.get("Content-Type") == "application/json"
     assert request.method == "GET"
+
+
+def test_headers_to_dict():
+    headers = Headers({"Content-Type": "application/json", "Authorization": "Bearer token"})
+    headers_dict = headers.to_dict()
+    assert headers_dict["content-type"] == "application/json"
+    assert headers_dict["authorization"] == "Bearer token"
+    custom_header = headers_dict.get("x-custom", "default")
+    assert custom_header == "default"
+
+
+def test_headers_to_dict_with_duplicates():
+    headers = Headers({})
+    headers.append("X-Custom", "value1")
+    headers.append("X-Custom", "value2")
+    headers.append("X-Custom", "value3")
+    headers_dict = headers.to_dict()
+    assert headers_dict["x-custom"] == "value1,value2,value3"
+
+
+def test_headers_get_headers():
+    headers = Headers({})
+    headers.set("Content-Type", "application/json")
+    headers.append("X-Custom", "value1")
+    headers.append("X-Custom", "value2")
+    headers_lists = headers.get_headers()
+    assert headers_lists["content-type"] == ["application/json"]
+    assert headers_lists["x-custom"] == ["value1", "value2"]
+
+
+def test_headers_to_dict_empty():
+    headers = Headers({})
+    headers_dict = headers.to_dict()
+    assert headers_dict == {}
+    assert headers_dict.get("any-header", "default") == "default"


### PR DESCRIPTION
## Summary

- Adds `Headers.to_dict()` which returns a flat `dict[str, str]` with comma-joined values for duplicate headers, matching standard HTTP semantics.
- Adds Python type stubs for both `to_dict()` and `get_headers()` in `robyn.pyi`.
- Adds unit tests covering single values, duplicates, empty headers, and `get_headers()` list preservation.

Supersedes #1184

## Test plan

- [x] `test_headers_to_dict` — basic single-value headers
- [x] `test_headers_to_dict_with_duplicates` — comma-joining of multi-value headers
- [x] `test_headers_get_headers` — list preservation via `get_headers()`
- [x] `test_headers_to_dict_empty` — empty headers edge case

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `get_headers()` method to retrieve all headers grouped by name with values as lists.
  * Added `to_dict()` method to retrieve headers as a flattened dictionary, with multiple values concatenated by commas.

* **Tests**
  * Added unit tests for both new header retrieval methods, including edge cases for duplicate and missing headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->