### PR TITLE
fix: prevent AttributeError in Pydantic GET/HEAD warning log

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -168,10 +168,10 @@ class Router(BaseRouter):
             _logger.warning(
                 "Handler '%s' on %s '%s' uses Pydantic body parameter(s) %s, but %s requests typically do not carry a request body",
                 handler.__name__,
-                route_type.name,
+                route_type,
                 endpoint,
                 list(pydantic_params.keys()),
-                route_type.name,
+                route_type,
             )
 
         def wrapped_handler(*args, **kwargs):


### PR DESCRIPTION
## Description

This PR fixes a crash that occurs when registering GET/HEAD handlers with Pydantic body parameters.

## Summary

### Problem
When a handler uses a Pydantic `BaseModel` as a parameter and the route is registered with `@app.get()` or `@app.head()`, the server crashes at startup with:

```
AttributeError: 'builtins.HttpMethod' object has no attribute 'name'
```

**Root cause:** The Rust-backed `HttpMethod` enum (compiled via PyO3) does not expose a `.name` attribute like Python's standard `Enum`. However, `router.py:165` was calling `route_type.name` in a GET/HEAD-specific warning log. POST, PUT, PATCH, and DELETE were unaffected because this warning block only executes for GET and HEAD.

### Steps to reproduce
```python
from pydantic import BaseModel
from robyn import Robyn

app = Robyn(__file__)

class Foo(BaseModel):
    x: int

@app.get("/test")
async def test(params: Foo):
    return {"x": params.x}
```

### Fix
Replaced `route_type.name` with `route_type` in the warning log. The Rust `HttpMethod` enum implements the `Display` trait, so `str()` (and f-strings) produce the correct string representation (e.g., `HttpMethod.GET`). This avoids calling the nonexistent `.name` attribute while keeping the warning message informative.

### Changes
- `robyn/router.py`: Changed `route_type.name` → `route_type` in the Pydantic GET/HEAD warning block (2 occurrences)

## PR Checklist

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] I have tested my changes locally
- [x] I have added relevant documentation — **N/A (bug fix only, no API changes)**
- [x] I have added relevant tests — **N/A (minor logging change, existing tests cover this path)**

## Pre-Commit Instructions:

- [x] pre-commit run --files robyn/router.py PASSED



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging format for improved consistency when warning about handler parameter usage on certain request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->