### PR TITLE
fix(docs): escape apostrophe breaking testing.mdx build

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/testing.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/testing.mdx
@@ -1,5 +1,5 @@
 export const description =
-  'On this page, we'll explore Robyn\'s built-in TestClient for fast, in-process unit testing without starting a server.'
+  'On this page, we\'ll explore Robyn\'s built-in TestClient for fast, in-process unit testing without starting a server.'
 
 ## Testing
 


### PR DESCRIPTION
## Problem

The Vercel docs deployment was failing with `next build` exiting with code 1. The dashboard surfaced only `<img>` lint warnings, but those are non-fatal — the real error was a webpack/MDX compile failure:

```
./src/pages/documentation/en/api_reference/testing.mdx
testing.mdx:2:21: Could not parse import/exports with acorn: SyntaxError: Unexpected token
> Build failed because of webpack errors
```

## Root cause

Line 2 of `testing.mdx` declared the `description` export as a single-quoted JS string containing an unescaped apostrophe in `we'll`. That apostrophe closed the string early, leaving the remainder as invalid JS. The later `Robyn\'s` in the same line was already escaped — `we'll` was not.

## Fix

Escape the apostrophe: `we'll` → `we\'ll`.

Verified locally with `npx next build` — the build now completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed apostrophe formatting in the testing API reference documentation page to improve display accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparckles/Robyn/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->