### PR TITLE
fix: make request.json parse bodies consistently

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -794,6 +794,16 @@ async def request_json(request: Request):
     return json["key"]
 
 
+@app.post("/sync/request_json/echo")
+def sync_request_json_echo_post(request: Request):
+    return request.json()
+
+
+@app.post("/async/request_json/echo")
+async def async_request_json_echo_post(request: Request):
+    return request.json()
+
+
 # JSON type preservation test
 @app.post("/sync/request_json/types")
 def sync_json_types(request: Request):
@@ -872,6 +882,16 @@ async def async_body_put(request: Request):
     return request.body
 
 
+@app.put("/sync/request_json/echo")
+def sync_request_json_echo_put(request: Request):
+    return request.json()
+
+
+@app.put("/async/request_json/echo")
+async def async_request_json_echo_put(request: Request):
+    return request.json()
+
+
 # --- DELETE ---
 
 # dict
@@ -944,6 +964,16 @@ def sync_body_patch(request: Request):
 @app.patch("/async/body")
 async def async_body_patch(request: Request):
     return request.body
+
+
+@app.patch("/sync/request_json/echo")
+def sync_request_json_echo_patch(request: Request):
+    return request.json()
+
+
+@app.patch("/async/request_json/echo")
+async def async_request_json_echo_patch(request: Request):
+    return request.json()
 
 
 # ==== Exception Handling ====

--- a/integration_tests/helpers/http_methods_helpers.py
+++ b/integration_tests/helpers/http_methods_helpers.py
@@ -85,6 +85,54 @@ def json_post(
     return response
 
 
+def json_put(
+    endpoint: str,
+    json_data=None,
+    expected_status_code: int = 200,
+    headers: dict = {},
+    should_check_response: bool = True,
+) -> requests.Response:
+    """
+    Makes a PUT request with JSON body to the given endpoint and checks the response.
+
+    endpoint str: The endpoint to make the request to.
+    json_data: The JSON-serializable data to send with the request (dict, list, etc.).
+    expected_status_code int: The expected status code of the response.
+    headers dict: The headers to send with the request.
+    should_check_response bool: A boolean to indicate if the status code and headers should be checked.
+    """
+
+    endpoint = endpoint.strip("/")
+    response = requests.put(f"{BASE_URL}/{endpoint}", json=json_data, headers=headers)
+    if should_check_response:
+        check_response(response, expected_status_code)
+    return response
+
+
+def json_patch(
+    endpoint: str,
+    json_data=None,
+    expected_status_code: int = 200,
+    headers: dict = {},
+    should_check_response: bool = True,
+) -> requests.Response:
+    """
+    Makes a PATCH request with JSON body to the given endpoint and checks the response.
+
+    endpoint str: The endpoint to make the request to.
+    json_data: The JSON-serializable data to send with the request (dict, list, etc.).
+    expected_status_code int: The expected status code of the response.
+    headers dict: The headers to send with the request.
+    should_check_response bool: A boolean to indicate if the status code and headers should be checked.
+    """
+
+    endpoint = endpoint.strip("/")
+    response = requests.patch(f"{BASE_URL}/{endpoint}", json=json_data, headers=headers)
+    if should_check_response:
+        check_response(response, expected_status_code)
+    return response
+
+
 def multipart_post(
     endpoint: str,
     files: Optional[dict] = None,

--- a/integration_tests/test_request_json.py
+++ b/integration_tests/test_request_json.py
@@ -1,6 +1,6 @@
 import pytest
 
-from integration_tests.helpers.http_methods_helpers import post
+from integration_tests.helpers.http_methods_helpers import json_patch, json_post, json_put, post
 
 
 @pytest.mark.parametrize(
@@ -13,6 +13,28 @@ from integration_tests.helpers.http_methods_helpers import post
         ("/async/request_json", '{"hello": "world"', "None"),
     ],
 )
-def test_request(route, body, expected_result):
+def test_request(route, body, expected_result, session):
     res = post(route, body)
     assert res.text == expected_result
+
+
+@pytest.mark.parametrize("function_type", ["sync", "async"])
+def test_request_json_method_parity(function_type: str, session):
+    payload = {
+        "name": "robyn",
+        "count": 3,
+        "active": True,
+        "metadata": {
+            "tags": ["post", "put", "patch"],
+            "optional": None,
+        },
+    }
+
+    responses = [
+        json_post(f"/{function_type}/request_json/echo", json_data=payload),
+        json_put(f"/{function_type}/request_json/echo", json_data=payload),
+        json_patch(f"/{function_type}/request_json/echo", json_data=payload),
+    ]
+
+    for response in responses:
+        assert response.json() == payload

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -256,14 +256,16 @@ impl PyRequest {
     }
 
     pub fn json(&self, py: Python) -> PyResult<Py<PyAny>> {
-        match self.body.downcast_bound::<PyString>(py) {
-            Ok(python_string) => {
-                let parsed: Value = serde_json::from_str(python_string.extract()?)
-                    .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {}", e)))?;
-                json_value_to_py(py, &parsed)
-            }
-            Err(e) => Err(e.into()),
+        let parsed: Value = if let Ok(python_string) = self.body.downcast_bound::<PyString>(py) {
+            serde_json::from_str(python_string.extract()?)
+        } else if let Ok(python_bytes) = self.body.downcast_bound::<PyBytes>(py) {
+            serde_json::from_slice(python_bytes.as_bytes())
+        } else {
+            return Err(PyValueError::new_err("Invalid JSON body"));
         }
+        .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {}", e)))?;
+
+        json_value_to_py(py, &parsed)
     }
 }
 

--- a/unit_tests/test_request_object.py
+++ b/unit_tests/test_request_object.py
@@ -25,3 +25,20 @@ def test_request_object():
     print(request.headers.get("Content-Type"))
     assert request.headers.get("Content-Type") == "application/json"
     assert request.method == "GET"
+
+
+def test_request_json_accepts_bytes_body():
+    request = Request(
+        query_params=QueryParams(),
+        headers=Headers({"Content-Type": "application/json"}),
+        path_params={},
+        body=b'{"hello": "world", "count": 1}',
+        method="POST",
+        url=Url(scheme="https", host="localhost", path="/user"),
+        ip_addr=None,
+        identity=None,
+        form_data={},
+        files={},
+    )
+
+    assert request.json() == {"hello": "world", "count": 1}


### PR DESCRIPTION
## Description

This PR fixes #1335.

## Summary

This PR makes `request.json()` parse both string and bytes request bodies, so JSON parsing behaves consistently across POST, PUT, and PATCH handlers.

It also adds regression coverage for:
- POST/PUT/PATCH `request.json()` parity
- sync and async handlers
- bytes-backed request bodies

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation: 👉 No documentation changes were needed because this fixes existing documented behavior.
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new echo endpoints for JSON requests across multiple HTTP methods.
  * Introduced HTTP helper functions for PUT and PATCH requests with JSON payloads.
  * Added test coverage for method parity validation.

* **Bug Fixes**
  * Improved JSON body parsing to properly handle both string and bytes formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparckles/Robyn/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->