### PR TITLE
Fix path param warning for request handlers

### DIFF
--- a/robyn/router.py
+++ b/robyn/router.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import wraps
 from types import CoroutineType
 from typing import NamedTuple, is_typeddict
@@ -71,6 +71,13 @@ class Router(BaseRouter):
     def __init__(self) -> None:
         super().__init__()
         self.routes: list[Route] = []
+
+    def _handler_can_access_path_params(self, handler_params: Mapping[str, inspect.Parameter]) -> bool:
+        for param in handler_params.values():
+            if param.annotation in (Request, PathParams):
+                return True
+
+        return bool({"r", "req", "request", "path_params"} & set(handler_params))
 
     def _format_tuple_response(self, res: tuple) -> Response:
         if len(res) != 3:
@@ -151,7 +158,7 @@ class Router(BaseRouter):
         handler_params = inspect.signature(handler).parameters
         handler_param_names = set(handler_params.keys())
 
-        unused_route_params = route_param_names - handler_param_names
+        unused_route_params = set() if self._handler_can_access_path_params(handler_params) else route_param_names - handler_param_names
         if unused_route_params:
             _logger.warning(
                 "Route '%s' declares path params %s but handler '%s' doesn't use them",

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -34,6 +34,9 @@ _logger = logging.getLogger(__name__)
 # never receive the Response and can't mutate it either.
 _JSON_HEADERS = Headers({"Content-Type": "application/json"})
 _TEXT_HEADERS = Headers({"Content-Type": "text/plain"})
+_REQUEST_PARAM_NAMES = {"r", "req", "request"}
+_PATH_PARAMS_PARAM_NAMES = {"path_params"}
+_PATH_PARAM_ACCESS_TYPES = (Request, PathParams)
 
 
 def lower_http_method(method: HttpMethod):
@@ -74,10 +77,10 @@ class Router(BaseRouter):
 
     def _handler_can_access_path_params(self, handler_params: Mapping[str, inspect.Parameter]) -> bool:
         for param in handler_params.values():
-            if param.annotation in (Request, PathParams):
+            if param.annotation in _PATH_PARAM_ACCESS_TYPES:
                 return True
 
-        return bool({"r", "req", "request", "path_params"} & set(handler_params))
+        return bool((_REQUEST_PARAM_NAMES | _PATH_PARAMS_PARAM_NAMES) & set(handler_params))
 
     def _format_tuple_response(self, res: tuple) -> Response:
         if len(res) != 3:

--- a/unit_tests/test_router_path_param_warnings.py
+++ b/unit_tests/test_router_path_param_warnings.py
@@ -1,0 +1,102 @@
+import logging
+
+import pytest
+
+from robyn.robyn import HttpMethod, Request
+from robyn.router import Router
+from robyn.types import PathParams
+
+
+def add_get_route(router, endpoint, handler):
+    router.add_route(
+        route_type=HttpMethod.GET,
+        endpoint=endpoint,
+        handler=handler,
+        is_const=False,
+        auth_required=False,
+        openapi_name="",
+        openapi_tags=[],
+        exception_handler=None,
+        injected_dependencies={"router_dependencies": {}, "global_dependencies": {}},
+    )
+
+
+def path_param_warning_messages(caplog):
+    return [record.getMessage() for record in caplog.records if record.name == "robyn.router" and "declares path params" in record.getMessage()]
+
+
+def handler_with_request_name(request):
+    return request
+
+
+def handler_with_req_name(req):
+    return req
+
+
+def handler_with_r_name(r):
+    return r
+
+
+def handler_with_path_params_name(path_params):
+    return path_params
+
+
+def handler_with_path_param_name(key_id):
+    return key_id
+
+
+def handler_with_typed_request(request_data: Request):
+    return request_data
+
+
+def handler_with_typed_path_params(path_data: PathParams):
+    return path_data
+
+
+def handler_with_typed_request_and_named_param(request_data: Request, user_id):
+    return request_data, user_id
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [
+        handler_with_request_name,
+        handler_with_req_name,
+        handler_with_r_name,
+        handler_with_path_params_name,
+        handler_with_path_param_name,
+        handler_with_typed_request,
+        handler_with_typed_path_params,
+    ],
+)
+def test_path_param_warning_skipped_for_request_or_path_params_access(caplog, handler):
+    caplog.set_level(logging.WARNING, logger="robyn.router")
+
+    add_get_route(Router(), "/v1/keys/:key_id", handler)
+
+    assert path_param_warning_messages(caplog) == []
+
+
+def test_path_param_warning_skipped_when_request_can_access_remaining_params(caplog):
+    caplog.set_level(logging.WARNING, logger="robyn.router")
+
+    add_get_route(Router(), "/users/:user_id/posts/:post_id", handler_with_typed_request_and_named_param)
+
+    assert path_param_warning_messages(caplog) == []
+
+
+def test_path_param_warning_logged_when_param_is_not_accessible(caplog):
+    def handler():
+        return "ok"
+
+    caplog.set_level(logging.WARNING, logger="robyn.router")
+
+    add_get_route(Router(), "/users/:user_id/posts/:post_id", handler)
+
+    warning_messages = path_param_warning_messages(caplog)
+
+    assert len(warning_messages) == 1
+    assert "Route '/users/:user_id/posts/:post_id' declares path params" in warning_messages[0]
+    assert "user_id" in warning_messages[0]
+    assert "post_id" in warning_messages[0]
+    assert "handler 'handler' doesn't use them" in warning_messages[0]


### PR DESCRIPTION
## Description

This PR fixes #1336.

## Summary

This PR updates the path-param warning heuristic so it respects Robyn's supported request access patterns. Routes with path params no longer warn when the handler can access those params through `Request`, `PathParams`, reserved request aliases, or direct path-param arguments.

The warning still fires when a route declares path params and the handler has no supported way to access them.

Tests cover direct param access, request aliases, typed `Request`, `path_params`, typed `PathParams`, multi-param request access, and the real inaccessible-param warning case.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation (not needed; this fixes warning behavior for an existing API)
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

Validation run locally:

- `python -m pytest unit_tests`
- `pre-commit run --all-files`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router's detection of whether handlers can access declared path parameters through various access methods, reducing false warnings about unused parameters.

* **Tests**
  * Added comprehensive test suite validating router warning behavior for path parameters across different handler configurations and access patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparckles/Robyn/pull/1393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->