### PR TITLE
fix: add body alias to Response constructor

### DIFF
--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable
+from typing import Callable, overload
 
 def get_version() -> str:
     pass
@@ -418,18 +418,31 @@ class Response:
     Attributes:
         status_code (int): The status code of the response. e.g. 200, 404, 500 etc.
         response_type (str | None): The response type of the response. e.g. text, json, html, file etc.
-        headers (Headers | dict): The headers of the response or Headers directly. e.g. {"Content-Type": "application/json"}
-        description (str | bytes): The body of the response. If the response is a JSON, it will be a dict.
+        headers (Headers): The response headers. The constructor accepts Headers, dict, or None.
+        description (str | bytes): Legacy supported name for the response body. Prefer body for new code.
+        body (str | bytes): Preferred name for the response body in the constructor.
         file_path (str | None): The file path of the response. e.g. /home/user/file.txt
         cookies (Cookies): The cookies to set in the response.
     """
 
     status_code: int
-    headers: Headers | dict
+    headers: Headers
     description: str | bytes
     response_type: str | None = None
     file_path: str | None = None
     cookies: Cookies = None  # Initialized automatically
+
+    @overload
+    def __init__(self, status_code: int, headers: Headers | dict | None, description: str | bytes) -> None:
+        pass
+
+    @overload
+    def __init__(self, status_code: int, headers: Headers | dict | None = None, *, description: str | bytes) -> None:
+        pass
+
+    @overload
+    def __init__(self, status_code: int, headers: Headers | dict | None = None, *, body: str | bytes) -> None:
+        pass
 
     def set_cookie(
         self,

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -2,9 +2,9 @@ use actix_http::{body::BoxBody, StatusCode};
 use actix_web::{web::Bytes, HttpRequest, HttpResponse, HttpResponseBuilder, Responder};
 use futures::Stream;
 use pyo3::{
-    exceptions::PyIOError,
+    exceptions::{PyIOError, PyTypeError},
     prelude::*,
-    types::{PyBytes, PyDict},
+    types::{PyBytes, PyDict, PyEllipsis},
     Bound, IntoPyObject,
 };
 use std::pin::Pin;
@@ -145,6 +145,10 @@ fn create_python_stream(
             _ => None,
         }
     }))
+}
+
+fn missing_response_body() -> Py<PyAny> {
+    Python::attach(|py| py.Ellipsis())
 }
 
 impl Response {
@@ -304,26 +308,50 @@ impl PyStreamingResponse {
 impl PyResponse {
     // To do: Add check for content-type in header and change response_type accordingly
     #[new]
+    #[pyo3(signature = (status_code, headers=None, description=missing_response_body(), *, body=missing_response_body()))]
     pub fn new(
         py: Python,
         status_code: u16,
-        headers: Bound<'_, PyAny>,
+        headers: Option<Bound<'_, PyAny>>,
         description: Py<PyAny>,
+        body: Py<PyAny>,
     ) -> PyResult<Self> {
+        let description_is_missing = description.bind(py).is(&**PyEllipsis::get(py));
+        let body_is_missing = body.bind(py).is(&**PyEllipsis::get(py));
+
+        let description = match (description_is_missing, body_is_missing) {
+            (false, true) => description,
+            (true, false) => body,
+            (false, false) => {
+                return Err(PyTypeError::new_err(
+                    "Response() got both 'description' and 'body'; use only one",
+                ));
+            }
+            (true, true) => {
+                return Err(PyTypeError::new_err(
+                    "Response() missing required argument 'description' or 'body'",
+                ));
+            }
+        };
+
         check_body_type(py, &description)?;
 
-        let headers_output: Py<Headers> = if let Ok(headers_dict) = headers.downcast::<PyDict>() {
-            // Here you'd have logic to create a Headers instance from a PyDict
-            // For simplicity, let's assume you have a method `from_dict` on Headers for this
-            let headers = Headers::new(Some(headers_dict)); // Hypothetical method
-            Py::new(py, headers)?
-        } else if let Ok(headers) = headers.extract::<Py<Headers>>() {
-            // If it's already a Py<Headers>, use it directly
-            headers
+        let headers_output: Py<Headers> = if let Some(headers) = headers {
+            if let Ok(headers_dict) = headers.downcast::<PyDict>() {
+                // Here you'd have logic to create a Headers instance from a PyDict
+                // For simplicity, let's assume you have a method `from_dict` on Headers for this
+                let headers = Headers::new(Some(headers_dict)); // Hypothetical method
+                Py::new(py, headers)?
+            } else if let Ok(headers) = headers.extract::<Py<Headers>>() {
+                // If it's already a Py<Headers>, use it directly
+                headers
+            } else {
+                return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "headers must be a Headers instance or a dict",
+                ));
+            }
         } else {
-            return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                "headers must be a Headers instance or a dict",
-            ));
+            Py::new(py, Headers::new(None))?
         };
 
         let cookies: Py<Cookies> = Py::new(py, Cookies::new())?;

--- a/unit_tests/test_unsupported_types.py
+++ b/unit_tests/test_unsupported_types.py
@@ -36,8 +36,83 @@ def test_bad_body_types(description):
 
 @pytest.mark.parametrize("description", good_bodies)
 def test_good_body_types(description):
-    _ = Response(
+    response = Response(
         status_code=200,
         headers=Headers({}),
         description=description,
     )
+
+    assert response.description == description
+
+
+@pytest.mark.parametrize("description", good_bodies)
+def test_good_body_types_with_default_headers(description):
+    response = Response(
+        status_code=200,
+        description=description,
+    )
+
+    assert response.description == description
+
+
+@pytest.mark.parametrize("body", good_bodies)
+def test_good_body_alias_types(body):
+    response = Response(
+        status_code=200,
+        headers=Headers({}),
+        body=body,
+    )
+
+    assert response.description == body
+
+
+@pytest.mark.parametrize("body", bad_bodies)
+def test_bad_body_alias_types(body):
+    with pytest.raises(ValueError):
+        _ = Response(
+            status_code=200,
+            headers=Headers({}),
+            body=body,
+        )
+
+
+def test_body_alias_cannot_be_combined_with_description():
+    with pytest.raises(TypeError):
+        _ = Response(
+            status_code=200,
+            headers=Headers({}),
+            description="OK",
+            body="OK",
+        )
+
+
+def test_body_alias_cannot_be_combined_with_positional_description():
+    with pytest.raises(TypeError):
+        _ = Response(
+            200,
+            Headers({}),
+            "OK",
+            body="OK",
+        )
+
+
+def test_positional_description_cannot_be_combined_with_keyword_description():
+    with pytest.raises(TypeError):
+        _ = Response(
+            200,
+            Headers({}),
+            "OK",
+            description="OK",
+        )
+
+
+def test_body_alias_can_use_default_headers():
+    response = Response(status_code=200, body="OK")
+
+    assert response.description == "OK"
+
+
+def test_body_alias_can_use_none_headers():
+    response = Response(status_code=200, headers=None, body="OK")
+
+    assert response.description == "OK"


### PR DESCRIPTION
## Description

This PR fixes #1337.

## Summary

This PR adds `body` as the preferred constructor name for the `Response` payload while keeping the existing `description` parameter fully backward compatible.

It also allows omitted or `None` headers to default to empty headers, so `Response(status_code=200, body="OK")` works as expected. The type stub documents `body` as preferred for new code and `description` as the legacy supported name.

<!--
Thank you for contributing to Robyn!

-->

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Response constructor now supports `body` as an alternative parameter to `description`.
  * `headers` parameter is now optional in Response constructor.

* **Bug Fixes**
  * Improved validation and error handling for Response constructor arguments with better error messages.

* **Tests**
  * Expanded test coverage for Response parameter validation and type checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sparckles/Robyn/pull/1395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->