### PR TITLE
feat(openapi): consolidate OpenAPI/Swagger fixes + FastAPI-parity route flags

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/openapi.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/openapi.mdx
@@ -193,6 +193,106 @@ def create_user(user: UserCreate) -> dict:
 
 For the full guide on Pydantic validation, nested models, error responses, and OpenAPI integration, see the dedicated [Pydantic Integration](/documentation/en/api_reference/pydantic) page.
 
+## Documenting routes (status codes, deprecation, extra responses)
+
+Every route decorator (`@app.get`, `@app.post`, … and the `SubRouter` equivalents) accepts a set of FastAPI-style flags so you can document — and in some cases change the runtime behaviour of — a route directly from the decorator:
+
+- `status_code` — the default success status code. It is reflected in the spec (e.g. `201` instead of `200`) **and** applied at runtime to plain returns (dict/list/str/bytes). An explicit `Response(...)` return always keeps its own status.
+- `response_model` — a type (typically a Pydantic model) used as the success response schema. When the handler returns a dict, it is validated and re-serialized through the model so the wire response matches the docs.
+- `responses` — additional documented responses keyed by status code. Each value may be a plain description string, a `{"description": ..., "model": SomeType}` dict, or a full OpenAPI response object.
+- `deprecated=True` — marks the operation deprecated (rendered with strikethrough in Swagger UI).
+- `include_in_schema=False` — hides the route from the spec entirely (useful for health checks and internal endpoints).
+
+<CodeGroup title="Route documentation flags">
+
+```python
+from robyn.types import JSONResponse
+
+
+class UserResponse(JSONResponse):
+    id: int
+    name: str
+
+
+class ErrorResponse(JSONResponse):
+    message: str
+
+
+@app.post(
+    "/users",
+    status_code=201,
+    response_model=UserResponse,
+    responses={
+        404: "User not found",
+        422: {"description": "Validation error", "model": ErrorResponse},
+    },
+    openapi_tags=["Users"],
+)
+def create_user(body: UserResponse) -> UserResponse:
+    """Create a user (responds with 201)"""
+    return {"id": 1, "name": "Bruce"}
+
+
+@app.get("/legacy", deprecated=True)
+def legacy():
+    """Old endpoint kept for backwards-compat"""
+    return "use /users instead"
+
+
+@app.get("/healthz", include_in_schema=False)
+def healthz():
+    return "ok"
+```
+
+</CodeGroup>
+
+## Authentication & the Swagger "Authorize" button
+
+When you call `app.configure_authentication(...)`, Robyn automatically registers a matching security scheme (`BearerAuth` for a `BearerGetter`) so Swagger UI's **Authorize** button works out of the box. Routes declared with `auth_required=True` advertise that requirement in the spec, so they render with a lock icon and send the credential when you try them out.
+
+You can also declare schemes explicitly via `Components(securitySchemes=...)`:
+
+<CodeGroup title="Security schemes">
+
+```python
+from robyn.openapi import OpenAPI, OpenAPIInfo, Components
+
+app = Robyn(
+    __file__,
+    openapi=OpenAPI(
+        info=OpenAPIInfo(
+            components=Components(
+                securitySchemes={
+                    "BearerAuth": {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"},
+                }
+            )
+        )
+    ),
+)
+
+
+@app.get("/me", auth_required=True)
+def me(request):
+    """Requires a Bearer token — shows a lock in Swagger UI"""
+    return "secret"
+```
+
+</CodeGroup>
+
+If no security scheme is configured, Robyn no longer emits an empty `securitySchemes` object, so the **Authorize** button stays hidden instead of opening an empty popup.
+
+## A note on auto-generated parameters
+
+Robyn builds the OpenAPI spec by **inspecting your handler's type annotations** — not its body. Reading values dynamically via `request.query_params`, `request.json()`, or `request.path_params` produces working endpoints, but Robyn has nothing to introspect, so those parameters won't appear in `/docs`.
+
+To document them, annotate the handler with typed params instead:
+
+- Query params: a subclass of `QueryParams` (e.g. `query_params: MyQueryParams`)
+- Request body: a subclass of `Body`/`JsonBody`, a `TypedDict`, or a Pydantic `BaseModel`
+- Path params: derived automatically from the route string (`/users/:id`)
+
+Stdlib return/field types such as `datetime`, `date`, `UUID`, `Decimal`, `Enum`, and `Literal` are mapped to their proper JSON Schema `type`/`format`, and container types like `list[str]` and `Optional[str]` render correctly.
+
 
 ## What's next?
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import datetime
 import json
 import os
 import pathlib
@@ -1372,6 +1373,47 @@ async def async_json_body_typed(data: TemperatureInput):
 def openapi_json_body_endpoint(request: Request, data: TemperatureInput) -> dict:
     """Convert fahrenheit to celsius using JsonBody"""
     return {"celsius": (float(data.get("fahrenheit", 0)) - 32) * 5 / 9}
+
+
+# ===== OpenAPI per-route metadata (status_code / deprecated / include_in_schema /
+# responses / datetime return) — consolidated parity features =====
+
+
+class ErrorResponse(JSONResponse):
+    message: str
+
+
+@app.get("/openapi/datetime_return")
+def openapi_datetime_return() -> datetime.datetime:
+    """Returns a timestamp (regression for datetime return types)"""
+    return datetime.datetime.now()
+
+
+@app.post("/openapi/created", status_code=201, openapi_tags=["openapi-extras"])
+def openapi_created() -> CreateItemResponse:
+    """Create an item and respond with 201"""
+    return CreateItemResponse(success=True, items_changed=1)
+
+
+@app.get(
+    "/openapi/with_responses",
+    responses={404: "Item not found", 422: {"description": "Validation error", "model": ErrorResponse}},
+)
+def openapi_with_responses() -> dict:
+    """Documents extra 404/422 responses"""
+    return {}
+
+
+@app.get("/openapi/deprecated", deprecated=True)
+def openapi_deprecated() -> str:
+    """A deprecated endpoint"""
+    return "old"
+
+
+@app.get("/openapi/hidden", include_in_schema=False)
+def openapi_hidden() -> str:
+    """Should never appear in the openapi spec"""
+    return "hidden"
 
 
 # ===== Server-Sent Events (SSE) Routes =====

--- a/integration_tests/test_openapi.py
+++ b/integration_tests/test_openapi.py
@@ -507,3 +507,65 @@ def test_typeddict_body_invalid_json():
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 400
+
+
+# ===== Consolidated OpenAPI parity features =====
+
+
+@pytest.mark.benchmark
+def test_openapi_status_code_in_spec():
+    """status_code= should set the success response key (#1368)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    responses = spec["paths"]["/openapi/created"]["post"]["responses"]
+    assert "201" in responses
+    assert "200" not in responses
+
+
+@pytest.mark.benchmark
+def test_openapi_additional_responses():
+    """responses= should document extra status codes (#1257)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    responses = spec["paths"]["/openapi/with_responses"]["get"]["responses"]
+    assert responses["404"]["description"] == "Item not found"
+    assert responses["422"]["description"] == "Validation error"
+    schema = responses["422"]["content"]["application/json"]["schema"]
+    assert "message" in schema["properties"]
+
+
+@pytest.mark.benchmark
+def test_openapi_deprecated_flag():
+    """deprecated=True should appear in the spec (#1369)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    assert spec["paths"]["/openapi/deprecated"]["get"]["deprecated"] is True
+
+
+@pytest.mark.benchmark
+def test_openapi_include_in_schema_false():
+    """include_in_schema=False routes must be absent from the spec (#1369)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    assert "/openapi/hidden" not in spec["paths"]
+
+
+@pytest.mark.benchmark
+def test_openapi_datetime_return_type():
+    """datetime return types must produce a valid schema, not crash (#1124)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    schema = spec["paths"]["/openapi/datetime_return"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    assert schema["type"] == "string"
+    assert schema["format"] == "date-time"
+
+
+@pytest.mark.benchmark
+def test_openapi_security_scheme_registered():
+    """configure_authentication should register a security scheme (#1122, #1339)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    schemes = spec.get("components", {}).get("securitySchemes", {})
+    assert "BearerAuth" in schemes
+    assert schemes["BearerAuth"]["scheme"] == "bearer"
+
+
+@pytest.mark.benchmark
+def test_openapi_auth_required_route_has_security():
+    """auth_required routes should advertise the security requirement (#1122, #1339)."""
+    spec = get("/openapi.json", should_check_response=False).json()
+    assert spec["paths"]["/sync/auth"]["get"]["security"] == [{"BearerAuth": []}]

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -5,6 +5,7 @@ import socket
 from abc import ABC
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import multiprocess as mp  # type: ignore
 
@@ -17,7 +18,7 @@ from robyn.events import Events
 from robyn.jsonify import jsonify
 from robyn.logger import Colors, logger
 from robyn.mcp import MCPApp
-from robyn.openapi import OpenAPI
+from robyn.openapi import OpenAPI, RouteOpenAPIMeta
 from robyn.processpool import run_processes
 from robyn.reloader import compile_rust_files
 from robyn.responses import SSEMessage, SSEResponse, StreamingResponse, html, serve_file, serve_html
@@ -157,6 +158,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] | None = None,
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         Connect a URI to a handler
@@ -166,13 +172,25 @@ class BaseRobyn(ABC):
         :param handler function: represents the sync or async function passed as a handler for the route
         :param is_const bool: represents if the handler is a const function or not
         :param auth_required bool: represents if the route needs authentication or not
-        """
-
-        """ We will add the status code here only
+        :param openapi_name str: the name (summary) of the endpoint in the openapi spec
+        :param openapi_tags list[str]: tags for grouping endpoints in the openapi spec
+        :param status_code int|None: default success status code (also reflected in the openapi spec)
+        :param response_model Any: type/Pydantic model used as the success response schema
+        :param responses dict|None: additional documented responses keyed by status code
+        :param deprecated bool: marks the operation as deprecated in the openapi spec
+        :param include_in_schema bool: when False the route is omitted from the openapi spec
         """
         injected_dependencies = self.dependencies.get_dependency_map(self)
 
         list_openapi_tags: list[str] = openapi_tags if openapi_tags else []
+
+        openapi_metadata = RouteOpenAPIMeta(
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
+        )
 
         if isinstance(route_type, str):
             http_methods = {
@@ -214,6 +232,7 @@ class BaseRobyn(ABC):
             openapi_tags=list_openapi_tags,
             exception_handler=self.exception_handler,
             injected_dependencies=injected_dependencies,
+            openapi_metadata=openapi_metadata,
         )
 
         logger.info("Added route %s %s", route_type, normalized_endpoint)
@@ -344,12 +363,17 @@ class BaseRobyn(ABC):
 
         self.router.prepare_routes_openapi(self.openapi, self.included_routers)
 
+        # Drop empty component buckets (e.g. an empty securitySchemes that would
+        # otherwise make Swagger UI show an empty "Authorize" popup — #1122, #1339).
+        self.openapi.prune_empty_components()
+
         self.add_route(
             route_type=HttpMethod.GET,
             endpoint="/openapi.json",
             handler=self.openapi.get_openapi_config,
             is_const=True,
             auth_required=auth_required,
+            include_in_schema=False,
         )
         self.add_route(
             route_type=HttpMethod.GET,
@@ -357,6 +381,7 @@ class BaseRobyn(ABC):
             handler=self.openapi.get_openapi_docs_page,
             is_const=True,
             auth_required=auth_required,
+            include_in_schema=False,
         )
         self.exclude_response_headers_for(["/docs", "/openapi.json"])
 
@@ -370,6 +395,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["get"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.get decorator to add a route with the GET method
@@ -382,7 +412,20 @@ class BaseRobyn(ABC):
         """
 
         def inner(handler):
-            return self.add_route(HttpMethod.GET, endpoint, handler, const, auth_required, openapi_name, openapi_tags)
+            return self.add_route(
+                HttpMethod.GET,
+                endpoint,
+                handler,
+                const,
+                auth_required,
+                openapi_name,
+                openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
+            )
 
         return inner
 
@@ -392,6 +435,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["post"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.post decorator to add a route with POST method
@@ -410,6 +458,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -420,6 +473,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["put"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.put decorator to add a get route with PUT method
@@ -438,6 +496,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -448,6 +511,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["delete"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.delete decorator to add a route with DELETE method
@@ -466,6 +534,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -476,6 +549,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["patch"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.patch decorator to add a route with PATCH method
@@ -494,6 +572,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -504,6 +587,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["head"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.head decorator to add a route with HEAD method
@@ -522,6 +610,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -532,6 +625,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["options"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.options decorator to add a route with OPTIONS method
@@ -550,6 +648,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -560,6 +663,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["connect"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.connect decorator to add a route with CONNECT method
@@ -578,6 +686,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -588,6 +701,11 @@ class BaseRobyn(ABC):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["trace"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         """
         The @app.trace decorator to add a route with TRACE method
@@ -606,6 +724,11 @@ class BaseRobyn(ABC):
                 auth_required=auth_required,
                 openapi_name=openapi_name,
                 openapi_tags=openapi_tags,
+                status_code=status_code,
+                response_model=response_model,
+                responses=responses,
+                deprecated=deprecated,
+                include_in_schema=include_in_schema,
             )
 
         return inner
@@ -648,6 +771,21 @@ class BaseRobyn(ABC):
         """
         self.authentication_handler = authentication_handler
         self.middleware_router.set_authentication_handler(authentication_handler)
+
+        # Auto-register a matching OpenAPI security scheme so Swagger UI's
+        # "Authorize" button works out of the box for auth_required routes
+        # (#1122, #1339). Users can still add/override schemes via OpenAPIInfo.
+        if self.openapi is not None and not self.openapi.openapi_file_override:
+            token_getter = getattr(authentication_handler, "token_getter", None)
+            scheme = getattr(token_getter, "scheme", "") or ""
+            if scheme.lower().startswith("bearer"):
+                self.openapi.add_security_scheme("BearerAuth", {"type": "http", "scheme": "bearer"})
+            elif not self.openapi._security_scheme_names:
+                # Generic fallback: advertise the Authorization header as an API key.
+                self.openapi.add_security_scheme(
+                    "ApiKeyAuth",
+                    {"type": "apiKey", "in": "header", "name": "Authorization"},
+                )
 
     @property
     def mcp(self):
@@ -776,6 +914,11 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["get"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().get(
             endpoint=self.__add_prefix(endpoint),
@@ -783,6 +926,11 @@ class SubRouter(BaseRobyn):
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def post(
@@ -791,12 +939,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["post"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().post(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def put(
@@ -805,12 +963,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["put"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().put(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def delete(
@@ -819,12 +987,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["delete"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().delete(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def patch(
@@ -833,12 +1011,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["patch"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().patch(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def head(
@@ -847,12 +1035,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["head"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().head(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def trace(
@@ -861,12 +1059,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["trace"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().trace(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def options(
@@ -875,12 +1083,22 @@ class SubRouter(BaseRobyn):
         auth_required: bool = False,
         openapi_name: str = "",
         openapi_tags: list[str] = ["options"],
+        status_code: int | None = None,
+        response_model: Any = None,
+        responses: dict[int | str, Any] | None = None,
+        deprecated: bool = False,
+        include_in_schema: bool = True,
     ):
         return super().options(
             endpoint=self.__add_prefix(endpoint),
             auth_required=auth_required,
             openapi_name=openapi_name,
             openapi_tags=openapi_tags,
+            status_code=status_code,
+            response_model=response_model,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
         )
 
     def websocket(self, endpoint: str):

--- a/robyn/openapi.py
+++ b/robyn/openapi.py
@@ -1,9 +1,13 @@
+import datetime
+import decimal
+import enum
 import inspect
 import json
 import logging
 import re
 import types
 import typing
+import uuid
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from importlib import resources
@@ -22,6 +26,61 @@ _logger = logging.getLogger(__name__)
 class str_typed_dict(TypedDict):
     key: str
     value: str
+
+
+@dataclass
+class RouteOpenAPIMeta:
+    """Per-route OpenAPI metadata captured from the route decorators.
+
+    Mirrors the familiar FastAPI knobs so handlers can document their
+    behaviour without hand-writing the spec.
+
+    @param status_code: int | None the default success status code (e.g. 201). Reflected
+        both at runtime (for plain returns) and as the success response key in the spec.
+    @param deprecated: bool marks the operation as deprecated (strikethrough in Swagger UI).
+    @param include_in_schema: bool when False the route is omitted from the generated spec.
+    @param response_model: Any a type (typically a Pydantic model) used as the success
+        response schema, overriding the handler's return annotation.
+    @param responses: dict | None additional responses keyed by status code. Each value may be
+        a description string, a full OpenAPI response object, or a dict with a ``model`` key.
+    @param summary: str | None overrides the operation summary (defaults to ``openapi_name``).
+    @param description: str | None overrides the operation description (defaults to the docstring).
+    @param operation_id: str | None an explicit ``operationId`` for the operation.
+    """
+
+    status_code: int | None = None
+    deprecated: bool = False
+    include_in_schema: bool = True
+    response_model: Any = None
+    responses: dict[int | str, Any] | None = None
+    summary: str | None = None
+    description: str | None = None
+    operation_id: str | None = None
+
+
+# Special leaf types that map to a JSON Schema ``type``/``format`` pair.
+# Mirrors the representation Pydantic/FastAPI emit for these stdlib types so
+# that a handler returning e.g. ``datetime`` produces a valid, descriptive
+# schema instead of crashing or rendering as a bare object (see #1124, #1073).
+_LEAF_TYPE_SCHEMAS: dict[type, dict] = {
+    datetime.datetime: {"type": "string", "format": "date-time"},
+    datetime.date: {"type": "string", "format": "date"},
+    datetime.time: {"type": "string", "format": "time"},
+    datetime.timedelta: {"type": "string", "format": "duration"},
+    uuid.UUID: {"type": "string", "format": "uuid"},
+    decimal.Decimal: {"type": "number"},
+    bytes: {"type": "string", "format": "binary"},
+}
+
+# Primitive Python types and their JSON Schema ``type`` names.
+_PRIMITIVE_TYPE_NAMES: dict[type, str] = {
+    int: "integer",
+    str: "string",
+    bool: "boolean",
+    float: "number",
+    dict: "object",
+    list: "array",
+}
 
 
 @dataclass
@@ -170,7 +229,50 @@ class OpenAPI:
             "externalDocs": asdict(self.info.externalDocs) if self.info.externalDocs.url else None,
         }
 
-    def add_openapi_path_obj(self, route_type: str, endpoint: str, openapi_name: str, openapi_tags: list[str], handler: Callable):
+    def add_security_scheme(self, name: str, scheme: dict) -> None:
+        """Register a reusable security scheme (e.g. Bearer/API-key auth).
+
+        Populating ``components.securitySchemes`` is what makes Swagger UI's
+        "Authorize" button appear and work; without it the button is either
+        absent or opens an empty popup (see #1122, #1339).
+
+        @param name: str the key under ``components.securitySchemes`` (e.g. ``"BearerAuth"``).
+        @param scheme: dict the OpenAPI Security Scheme Object, e.g.
+            ``{"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}``.
+        """
+        if self.openapi_file_override:
+            return
+        self.openapi_spec["components"].setdefault("securitySchemes", {})[name] = scheme
+
+    @property
+    def _security_scheme_names(self) -> list[str]:
+        return list(self.openapi_spec.get("components", {}).get("securitySchemes", {}) or {})
+
+    def prune_empty_components(self) -> None:
+        """Drop empty ``components`` buckets so the generated spec stays clean.
+
+        In particular an empty ``securitySchemes: {}`` makes Swagger UI render an
+        empty "Available authorizations" popup; omitting it removes the button
+        entirely until the user actually configures a scheme (#1122, #1339).
+        """
+        if self.openapi_file_override:
+            return
+        components = self.openapi_spec.get("components")
+        if isinstance(components, dict):
+            for key in list(components):
+                if not components[key]:
+                    del components[key]
+
+    def add_openapi_path_obj(
+        self,
+        route_type: str,
+        endpoint: str,
+        openapi_name: str,
+        openapi_tags: list[str],
+        handler: Callable,
+        auth_required: bool = False,
+        meta: "RouteOpenAPIMeta | None" = None,
+    ):
         """
         Adds the given path to openapi spec
 
@@ -179,9 +281,17 @@ class OpenAPI:
         @param openapi_name: str the name of the endpoint
         @param openapi_tags: list[str] for grouping of endpoints
         @param handler: Callable the handler function for the endpoint
+        @param auth_required: bool whether the route requires authentication (adds a security requirement)
+        @param meta: RouteOpenAPIMeta | None per-route OpenAPI metadata from the decorator
         """
 
         if self.openapi_file_override:
+            return
+
+        if meta is None:
+            meta = RouteOpenAPIMeta()
+
+        if not meta.include_in_schema:
             return
 
         query_params = None
@@ -225,8 +335,23 @@ class OpenAPI:
             if signature.return_annotation is not Signature.empty:
                 return_annotation = signature.return_annotation
 
+        # An explicit response_model wins over the handler's return annotation.
+        if meta.response_model is not None:
+            return_annotation = meta.response_model
+
+        summary = meta.summary if meta.summary is not None else openapi_name
+        description = meta.description if meta.description is not None else openapi_description
+
         modified_endpoint, path_obj = self.get_path_obj(
-            endpoint, openapi_name, openapi_description, openapi_tags, query_params, request_body, return_annotation
+            endpoint,
+            summary,
+            description,
+            openapi_tags,
+            query_params,
+            request_body,
+            return_annotation,
+            auth_required=auth_required,
+            meta=meta,
         )
 
         if modified_endpoint not in self.openapi_spec["paths"]:
@@ -276,6 +401,8 @@ class OpenAPI:
         query_params: str_typed_dict | None,
         request_body: str_typed_dict | None,
         return_annotation: str_typed_dict | None,
+        auth_required: bool = False,
+        meta: "RouteOpenAPIMeta | None" = None,
     ) -> tuple[str, dict]:
         """
         Get the "path" openapi object according to spec
@@ -287,10 +414,15 @@ class OpenAPI:
         @param query_params: TypedDict | None query params for the function
         @param request_body: TypedDict | None request body for the function
         @param return_annotation: TypedDict | None return type of the endpoint handler
+        @param auth_required: bool whether the route requires authentication
+        @param meta: RouteOpenAPIMeta | None per-route OpenAPI metadata (status_code, responses, ...)
 
         @return: (str, dict) a tuple containing the endpoint with path params wrapped in braces and the "path" openapi object
         according to spec
         """
+
+        if meta is None:
+            meta = RouteOpenAPIMeta()
 
         if not description:
             description = "No description provided"
@@ -301,6 +433,17 @@ class OpenAPI:
             "parameters": [],
             "tags": tags,
         }
+
+        if meta.operation_id is not None:
+            openapi_path_object["operationId"] = meta.operation_id
+
+        if meta.deprecated:
+            openapi_path_object["deprecated"] = True
+
+        # auth_required routes advertise every configured security scheme so the
+        # Swagger UI "Authorize" lock appears on them (#1122, #1339).
+        if auth_required and self._security_scheme_names:
+            openapi_path_object["security"] = [{scheme_name: []} for scheme_name in self._security_scheme_names]
 
         # robyn has paths like /:url/:etc whereas openapi requires path like /{url}/{path}
         # this function is used for converting path params to the required form
@@ -371,9 +514,49 @@ class OpenAPI:
             response_type = "application/json"
             response_schema = self.get_schema_object("response object", return_annotation)
 
-        openapi_path_object["responses"] = {"200": {"description": "Successful Response", "content": {response_type: {"schema": response_schema}}}}
+        success_status = str(meta.status_code) if meta.status_code is not None else "200"
+
+        openapi_path_object["responses"] = {success_status: {"description": "Successful Response", "content": {response_type: {"schema": response_schema}}}}
+
+        # Merge any user-declared additional responses (e.g. 404, 422) so a single
+        # operation can document multiple outcomes (#1257).
+        if meta.responses:
+            for status, response in self._build_responses(meta.responses).items():
+                openapi_path_object["responses"][status] = response
 
         return endpoint_with_path_params_wrapped_in_braces, openapi_path_object
+
+    def _build_responses(self, responses: dict[int | str, Any]) -> dict[str, dict]:
+        """Normalise user-supplied ``responses=`` into OpenAPI Response Objects.
+
+        Each value may be:
+          - a plain ``str`` (used as the response ``description``),
+          - a dict with an optional ``model`` key (a type/Pydantic model whose schema
+            becomes ``content.application/json.schema``), or
+          - a fully-formed OpenAPI Response Object (passed through unchanged).
+        """
+        built: dict[str, dict] = {}
+        for status, value in responses.items():
+            key = str(status)
+
+            if isinstance(value, str):
+                built[key] = {"description": value}
+                continue
+
+            if not isinstance(value, dict):
+                _logger.warning("OpenAPI response for status %s is not a str or dict — ignoring", key)
+                continue
+
+            response_obj = {k: v for k, v in value.items() if k != "model"}
+            response_obj.setdefault("description", "")
+
+            model = value.get("model")
+            if model is not None:
+                schema = self.get_schema_object("response object", model)
+                response_obj.setdefault("content", {})["application/json"] = {"schema": schema}
+
+            built[key] = response_obj
+        return built
 
     def get_openapi_type(self, typed_dict: str_typed_dict) -> str:
         """
@@ -382,18 +565,11 @@ class OpenAPI:
         @param typed_dict: TypedDict The TypedDict to be converted
         @return: str the type inferred
         """
-        type_mapping = {
-            int: "integer",
-            str: "string",
-            bool: "boolean",
-            float: "number",
-            dict: "object",
-            list: "array",
-        }
+        if typed_dict in _PRIMITIVE_TYPE_NAMES:
+            return _PRIMITIVE_TYPE_NAMES[typed_dict]
 
-        for type_name in type_mapping:
-            if typed_dict is type_name:
-                return type_mapping[type_name]
+        if typed_dict in _LEAF_TYPE_SCHEMAS:
+            return _LEAF_TYPE_SCHEMAS[typed_dict]["type"]
 
         # default to "string" if type is not found
         return "string"
@@ -411,29 +587,53 @@ class OpenAPI:
             "title": parameter.capitalize(),
         }
 
-        type_mapping: dict = {
-            int: "integer",
-            str: "string",
-            bool: "boolean",
-            float: "number",
-            dict: "object",
-            list: "array",
-        }
+        # Primitive scalars (int, str, bool, float, dict, list).
+        if param_type in _PRIMITIVE_TYPE_NAMES:
+            properties["type"] = _PRIMITIVE_TYPE_NAMES[param_type]
+            return properties
 
-        for type_name in type_mapping:
-            if param_type is type_name:
-                properties["type"] = type_mapping[type_name]
-                return properties
+        # Special stdlib leaf types (datetime, date, UUID, Decimal, bytes, ...).
+        # Pydantic-free handlers can return these without crashing or rendering
+        # as a bare object (#1124).
+        if isinstance(param_type, type) and param_type in _LEAF_TYPE_SCHEMAS:
+            properties.update(_LEAF_TYPE_SCHEMAS[param_type])
+            return properties
+
+        # typing.Any -> any value, no constraints.
+        if param_type is Any:
+            return properties
 
         origin = get_origin(param_type)
         args = get_args(param_type)
 
-        # Check if it's a generic type (like list[Object])
-        if origin is list:
+        # typing.Literal[...] -> an enum of literal values.
+        if origin is typing.Literal:
+            properties["enum"] = list(args)
+            inferred = type(args[0]) if args else str
+            properties["type"] = _PRIMITIVE_TYPE_NAMES.get(inferred, "string")
+            return properties
+
+        # enum.Enum subclass -> enum of member values.
+        if isinstance(param_type, type) and issubclass(param_type, enum.Enum):
+            members = list(param_type)
+            properties["enum"] = [member.value for member in members]
+            if members:
+                properties["type"] = _PRIMITIVE_TYPE_NAMES.get(type(members[0].value), "string")
+            return properties
+
+        # Sequence generics (list[X], tuple[X, ...], set[X]) -> array.
+        if origin in (list, tuple, set, frozenset):
             properties["type"] = "array"
             if args:
                 item_type = args[0]
                 properties["items"] = self.get_schema_object(f"{parameter}_item", item_type)
+            return properties
+
+        # Mapping generics (dict[str, V]) -> object with typed additionalProperties.
+        if origin is dict:
+            properties["type"] = "object"
+            if len(args) == 2:
+                properties["additionalProperties"] = self.get_schema_object(f"{parameter}_value", args[1])
             return properties
 
         is_union = origin in (typing.Union, types.UnionType)
@@ -443,8 +643,10 @@ class OpenAPI:
 
             any_of: list[dict] = []
             for arg in non_none_args:
-                if arg in type_mapping:
-                    any_of.append({"type": type_mapping[arg]})
+                if arg in _PRIMITIVE_TYPE_NAMES:
+                    any_of.append({"type": _PRIMITIVE_TYPE_NAMES[arg]})
+                elif isinstance(arg, type) and arg in _LEAF_TYPE_SCHEMAS:
+                    any_of.append(dict(_LEAF_TYPE_SCHEMAS[arg]))
                 else:
                     any_of.append(self.get_schema_object(parameter, arg))
             if nullable:
@@ -464,8 +666,14 @@ class OpenAPI:
             properties["type"] = "object"
             properties["properties"] = {}
             if hasattr(param_type, "__annotations__"):
-                for e in param_type.__annotations__:
-                    properties["properties"][e] = self.get_schema_object(e, param_type.__annotations__[e])
+                # get_type_hints resolves PEP 563 string annotations (e.g. "list[int]");
+                # fall back to the raw __annotations__ if they can't be resolved.
+                try:
+                    annotations = typing.get_type_hints(param_type)
+                except Exception:
+                    annotations = dict(param_type.__annotations__)
+                for field_name, field_type in annotations.items():
+                    properties["properties"][field_name] = self.get_schema_object(field_name, field_type)
             return properties
 
         properties["type"] = "object"

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -192,8 +192,7 @@ def spawn_process(
     server.set_response_headers_exclude_paths(excluded_response_headers_paths)
 
     for route in routes:
-        route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags = route
-        server.add_route(route_type, endpoint, function, is_const)
+        server.add_route(route.route_type, route.route, route.function, route.is_const)
 
     for middleware_type, middleware_function in global_middlewares:
         server.add_global_middleware(middleware_type, middleware_function)

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -11,11 +11,12 @@ from robyn._param_utils import QueryParamValidationError, parse_route_param_name
 from robyn.authentication import AuthenticationHandler, AuthenticationNotConfiguredError
 from robyn.dependency_injection import DependencyMap
 from robyn.jsonify import jsonify
-from robyn.openapi import OpenAPI
+from robyn.openapi import OpenAPI, RouteOpenAPIMeta
 from robyn.pydantic_support import (
     PydanticBodyValidationError,
     check_pydantic_installed_for_handler,
     detect_pydantic_params,
+    is_pydantic_model,
     serialize_pydantic_response,
     validate_pydantic_body,
 )
@@ -51,6 +52,7 @@ class Route(NamedTuple):
     auth_required: bool
     openapi_name: str
     openapi_tags: list[str]
+    openapi_metadata: RouteOpenAPIMeta = RouteOpenAPIMeta()
 
 
 class RouteMiddleware(NamedTuple):
@@ -143,6 +145,43 @@ class Router(BaseRouter):
             description=str(res).encode("utf-8"),
         )
 
+    def _apply_response_model(self, result, response_model, default_status_code):
+        """Validate/serialize a dict return through a Pydantic ``response_model``.
+
+        When ``response_model`` is a Pydantic model and the handler returned a
+        plain dict, the dict is validated and re-serialized through the model so
+        the wire response matches the documented schema (FastAPI parity). Explicit
+        ``Response``/``StreamingResponse`` returns and non-Pydantic models are left
+        untouched.
+        """
+        if response_model is None or not is_pydantic_model(response_model):
+            return result
+        if isinstance(result, (Response, StreamingResponse)):
+            return result
+        if isinstance(result, dict):
+            validated = response_model.model_validate(result)
+            return Response(
+                status_code=default_status_code or status_codes.HTTP_200_OK,
+                headers=_JSON_HEADERS,
+                description=validated.model_dump_json(),
+            )
+        return result
+
+    def _coerce_status_code(self, formatted, default_status_code):
+        """Apply the route's default ``status_code`` to a non-Response return.
+
+        Only plain returns (dict/list/str/bytes) are wrapped — when a handler
+        returns an explicit ``Response``/``StreamingResponse`` its own status code
+        always wins, matching FastAPI's behaviour.
+        """
+        if default_status_code is None or isinstance(formatted, (Response, StreamingResponse)):
+            return formatted
+        if isinstance(formatted, (dict, list)):
+            return Response(status_code=default_status_code, headers=_JSON_HEADERS, description=jsonify(formatted))
+        if isinstance(formatted, bytes):
+            return Response(status_code=default_status_code, headers=_TEXT_HEADERS, description=formatted)
+        return Response(status_code=default_status_code, headers=_TEXT_HEADERS, description=str(formatted).encode("utf-8"))
+
     def add_route(  # type: ignore
         self,
         route_type: HttpMethod,
@@ -154,9 +193,15 @@ class Router(BaseRouter):
         openapi_tags: list[str],
         exception_handler: Callable | None,
         injected_dependencies: dict,
+        openapi_metadata: RouteOpenAPIMeta | None = None,
     ) -> Callable | CoroutineType:
         # Pre-compute handler signature ONCE at registration time.
         # This avoids calling inspect.signature() on every request.
+        if openapi_metadata is None:
+            openapi_metadata = RouteOpenAPIMeta()
+        default_status_code = openapi_metadata.status_code
+        response_model = openapi_metadata.response_model
+
         route_param_names = parse_route_param_names(endpoint)
         handler_params = inspect.signature(handler).parameters
         handler_param_names = set(handler_params.keys())
@@ -290,9 +335,12 @@ class Router(BaseRouter):
         @wraps(handler)
         async def async_inner_handler(*args, **kwargs):
             try:
-                response = self._format_response(
-                    await wrapped_handler(*args, **kwargs),
-                )
+                result = await wrapped_handler(*args, **kwargs)
+                if response_model is not None or default_status_code is not None:
+                    result = self._apply_response_model(result, response_model, default_status_code)
+                    response = self._coerce_status_code(self._format_response(result), default_status_code)
+                else:
+                    response = self._format_response(result)
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -316,9 +364,12 @@ class Router(BaseRouter):
         @wraps(handler)
         def inner_handler(*args, **kwargs):
             try:
-                response = self._format_response(
-                    wrapped_handler(*args, **kwargs),
-                )
+                result = wrapped_handler(*args, **kwargs)
+                if response_model is not None or default_status_code is not None:
+                    result = self._apply_response_model(result, response_model, default_status_code)
+                    response = self._coerce_status_code(self._format_response(result), default_status_code)
+                else:
+                    response = self._format_response(result)
             except QueryParamValidationError as err:
                 response = Response(
                     status_code=status_codes.HTTP_400_BAD_REQUEST,
@@ -356,7 +407,7 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags, openapi_metadata))
             return async_inner_handler
         else:
             function = FunctionInfo(
@@ -366,12 +417,20 @@ class Router(BaseRouter):
                 params,
                 new_injected_dependencies,
             )
-            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags))
+            self.routes.append(Route(route_type, endpoint, function, is_const, auth_required, openapi_name, openapi_tags, openapi_metadata))
             return inner_handler
 
     def prepare_routes_openapi(self, openapi: OpenAPI, included_routers: list) -> None:
         for route in self.routes:
-            openapi.add_openapi_path_obj(lower_http_method(route.route_type), route.route, route.openapi_name, route.openapi_tags, route.function.handler)
+            openapi.add_openapi_path_obj(
+                lower_http_method(route.route_type),
+                route.route,
+                route.openapi_name,
+                route.openapi_tags,
+                route.function.handler,
+                auth_required=route.auth_required,
+                meta=route.openapi_metadata,
+            )
 
         # TODO! after include_routes does not immediately merge all the routes
         # for router in included_routers:

--- a/unit_tests/test_openapi_consolidated.py
+++ b/unit_tests/test_openapi_consolidated.py
@@ -1,0 +1,307 @@
+"""Consolidated OpenAPI/Swagger tests.
+
+Covers the behaviour added in the consolidated OpenAPI PR that closes:
+  - #1124 (datetime/date return types crashing schema generation)
+  - #1073 (container types not rendered in request bodies)
+  - #1257 (multiple/additional responses)
+  - #1122 / #1339 (empty Swagger "Authorize" popup + security schemes)
+and the FastAPI-parity route flags status_code/deprecated/include_in_schema/
+response_model/responses (superseding PRs #1368, #1369, #1370, #1373).
+"""
+
+import datetime
+import decimal
+import enum
+import typing
+import uuid
+
+import pytest
+
+from robyn.openapi import Components, OpenAPI, OpenAPIInfo, RouteOpenAPIMeta
+from robyn.router import Router
+from robyn.types import Body, JSONResponse
+
+
+# --------------------------------------------------------------------------- #
+# Schema generation for stdlib leaf types (#1124, #1073)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "py_type, expected",
+    [
+        (datetime.datetime, {"type": "string", "format": "date-time"}),
+        (datetime.date, {"type": "string", "format": "date"}),
+        (datetime.time, {"type": "string", "format": "time"}),
+        (datetime.timedelta, {"type": "string", "format": "duration"}),
+        (uuid.UUID, {"type": "string", "format": "uuid"}),
+        (decimal.Decimal, {"type": "number"}),
+        (bytes, {"type": "string", "format": "binary"}),
+    ],
+)
+def test_schema_leaf_types(py_type, expected):
+    api = OpenAPI()
+    schema = api.get_schema_object("when", py_type)
+    for key, value in expected.items():
+        assert schema[key] == value
+
+
+def test_schema_enum():
+    class Color(enum.Enum):
+        RED = "red"
+        GREEN = "green"
+
+    api = OpenAPI()
+    schema = api.get_schema_object("color", Color)
+    assert schema["type"] == "string"
+    assert schema["enum"] == ["red", "green"]
+
+
+def test_schema_int_enum():
+    class Priority(enum.IntEnum):
+        LOW = 1
+        HIGH = 2
+
+    api = OpenAPI()
+    schema = api.get_schema_object("priority", Priority)
+    assert schema["type"] == "integer"
+    assert schema["enum"] == [1, 2]
+
+
+def test_schema_literal():
+    api = OpenAPI()
+    schema = api.get_schema_object("mode", typing.Literal["a", "b", "c"])
+    assert schema["enum"] == ["a", "b", "c"]
+    assert schema["type"] == "string"
+
+
+def test_schema_typed_dict_value():
+    api = OpenAPI()
+    schema = api.get_schema_object("meta", dict[str, int])
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"]["type"] == "integer"
+
+
+def test_schema_set_is_array():
+    api = OpenAPI()
+    schema = api.get_schema_object("tags", set[str])
+    assert schema["type"] == "array"
+    assert schema["items"]["type"] == "string"
+
+
+def test_schema_any_has_no_type():
+    api = OpenAPI()
+    schema = api.get_schema_object("anything", typing.Any)
+    assert "type" not in schema
+
+
+def test_schema_body_with_containers_and_datetime():
+    """A Body subclass mixing list/optional/datetime fields (#1073, #1124)."""
+
+    class ActionItemsRequest(Body):
+        action_items: str
+        emails: list[str]
+        meeting_summary: typing.Optional[str]
+        scheduled_for: datetime.datetime
+
+    api = OpenAPI()
+    schema = api.get_schema_object("req", ActionItemsRequest)
+    props = schema["properties"]
+    assert props["emails"]["type"] == "array"
+    assert props["emails"]["items"]["type"] == "string"
+    assert "anyOf" in props["meeting_summary"]
+    assert props["scheduled_for"] == {"title": "Scheduled_for", "type": "string", "format": "date-time"}
+
+
+def test_datetime_return_annotation_does_not_crash():
+    """Regression for #1124: a datetime return type used to crash startup."""
+
+    def handler() -> datetime.datetime:
+        """Returns now"""
+        return datetime.datetime.now()
+
+    api = OpenAPI()
+    api.add_openapi_path_obj("get", "/now", "now", ["t"], handler)
+    schema = api.openapi_spec["paths"]["/now"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    assert schema["type"] == "string"
+    assert schema["format"] == "date-time"
+
+
+# --------------------------------------------------------------------------- #
+# Per-route flags: status_code / deprecated / include_in_schema (#1368, #1369)
+# --------------------------------------------------------------------------- #
+def _path_obj(api, endpoint, handler, meta, auth_required=False):
+    api.add_openapi_path_obj("get", endpoint, "name", ["t"], handler, auth_required=auth_required, meta=meta)
+    return api.openapi_spec["paths"].get(endpoint, {}).get("get")
+
+
+def test_status_code_sets_success_response_key():
+    api = OpenAPI()
+
+    def handler() -> dict:
+        """h"""
+        return {}
+
+    obj = _path_obj(api, "/created", handler, RouteOpenAPIMeta(status_code=201))
+    assert "201" in obj["responses"]
+    assert "200" not in obj["responses"]
+
+
+def test_deprecated_flag_in_spec():
+    api = OpenAPI()
+
+    def handler():
+        """h"""
+
+    obj = _path_obj(api, "/old", handler, RouteOpenAPIMeta(deprecated=True))
+    assert obj["deprecated"] is True
+
+
+def test_include_in_schema_false_omits_route():
+    api = OpenAPI()
+
+    def handler():
+        """h"""
+
+    obj = _path_obj(api, "/hidden", handler, RouteOpenAPIMeta(include_in_schema=False))
+    assert obj is None
+    assert "/hidden" not in api.openapi_spec["paths"]
+
+
+def test_operation_id_in_spec():
+    api = OpenAPI()
+
+    def handler():
+        """h"""
+
+    obj = _path_obj(api, "/op", handler, RouteOpenAPIMeta(operation_id="get_op"))
+    assert obj["operationId"] == "get_op"
+
+
+# --------------------------------------------------------------------------- #
+# Additional responses (#1257, #1373)
+# --------------------------------------------------------------------------- #
+def test_additional_responses_string_and_model():
+    class ErrorResponse(JSONResponse):
+        message: str
+
+    api = OpenAPI()
+
+    def handler() -> dict:
+        """h"""
+        return {}
+
+    meta = RouteOpenAPIMeta(responses={404: "Not found", 422: {"description": "Invalid", "model": ErrorResponse}})
+    obj = _path_obj(api, "/items", handler, meta)
+    assert obj["responses"]["404"] == {"description": "Not found"}
+    assert obj["responses"]["422"]["description"] == "Invalid"
+    schema = obj["responses"]["422"]["content"]["application/json"]["schema"]
+    assert "message" in schema["properties"]
+
+
+def test_additional_responses_passthrough_object():
+    api = OpenAPI()
+
+    def handler() -> dict:
+        """h"""
+        return {}
+
+    raw = {"description": "Teapot", "content": {"text/plain": {"schema": {"type": "string"}}}}
+    obj = _path_obj(api, "/tea", handler, RouteOpenAPIMeta(responses={418: raw}))
+    assert obj["responses"]["418"] == raw
+
+
+# --------------------------------------------------------------------------- #
+# response_model schema override (#1370)
+# --------------------------------------------------------------------------- #
+def test_response_model_overrides_return_annotation():
+    class UserOut(JSONResponse):
+        name: str
+        age: int
+
+    api = OpenAPI()
+
+    def handler() -> str:
+        """h"""
+        return "ignored"
+
+    api.add_openapi_path_obj("get", "/user", "user", ["t"], handler, meta=RouteOpenAPIMeta(response_model=UserOut))
+    schema = api.openapi_spec["paths"]["/user"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    assert schema["type"] == "object"
+    assert "name" in schema["properties"]
+    assert "age" in schema["properties"]
+
+
+# --------------------------------------------------------------------------- #
+# Security schemes + components cleanup (#1122, #1339)
+# --------------------------------------------------------------------------- #
+def test_auth_required_emits_operation_security():
+    api = OpenAPI(info=OpenAPIInfo(components=Components(securitySchemes={"BearerAuth": {"type": "http", "scheme": "bearer"}})))
+
+    def handler():
+        """h"""
+
+    obj = _path_obj(api, "/secret", handler, RouteOpenAPIMeta(), auth_required=True)
+    assert obj["security"] == [{"BearerAuth": []}]
+
+
+def test_auth_required_without_scheme_has_no_security():
+    api = OpenAPI()
+
+    def handler():
+        """h"""
+
+    obj = _path_obj(api, "/secret", handler, RouteOpenAPIMeta(), auth_required=True)
+    assert "security" not in obj
+
+
+def test_prune_empty_components_removes_empty_security_schemes():
+    api = OpenAPI()
+    # Default spec ships an empty securitySchemes bucket that makes Swagger UI
+    # render an empty Authorize popup.
+    assert api.openapi_spec["components"]["securitySchemes"] == {}
+    api.prune_empty_components()
+    assert "securitySchemes" not in api.openapi_spec["components"]
+
+
+def test_add_security_scheme_keeps_bucket_after_prune():
+    api = OpenAPI()
+    api.add_security_scheme("BearerAuth", {"type": "http", "scheme": "bearer"})
+    api.prune_empty_components()
+    assert api.openapi_spec["components"]["securitySchemes"]["BearerAuth"]["scheme"] == "bearer"
+
+
+# --------------------------------------------------------------------------- #
+# Runtime application of response_model / status_code (Router helpers)
+# --------------------------------------------------------------------------- #
+def test_coerce_status_code_wraps_plain_dict():
+    router = Router()
+    resp = router._coerce_status_code({"a": 1}, 201)
+    assert resp.status_code == 201
+
+
+def test_coerce_status_code_respects_explicit_response():
+    from robyn.robyn import Response
+
+    router = Router()
+    explicit = Response(status_code=204, headers={}, description="")
+    resp = router._coerce_status_code(explicit, 201)
+    assert resp.status_code == 204
+
+
+def test_coerce_status_code_noop_when_none():
+    router = Router()
+    result = {"a": 1}
+    assert router._coerce_status_code(result, None) is result
+
+
+def test_apply_response_model_requires_pydantic():
+    pydantic = pytest.importorskip("pydantic")
+
+    class UserResponse(pydantic.BaseModel):
+        name: str
+        age: int
+
+    router = Router()
+    resp = router._apply_response_model({"name": "Alice", "age": 30, "extra": "dropped"}, UserResponse, 201)
+    assert resp.status_code == 201
+    assert b"Alice" in (resp.description if isinstance(resp.description, bytes) else resp.description.encode())
+    assert "dropped" not in (resp.description if isinstance(resp.description, str) else resp.description.decode())


### PR DESCRIPTION
## Summary

A single **consolidated** pass over Robyn's OpenAPI/Swagger generation. It fixes the long-standing schema bugs and adds the FastAPI-style per-route documentation knobs that several stacked draft PRs each implemented in isolation (and which conflict with one another). The goal is one reviewable PR that lets us close the rest.

Benchmarked against **FastAPI** semantics and Python typing best practices throughout (naming: `status_code` / `response_model` / `responses` / `deprecated` / `include_in_schema`).

## What's in it

**1. Schema generation for real-world types** (`openapi.py`)
- stdlib leaf types → proper JSON Schema `type`/`format`: `datetime`, `date`, `time`, `timedelta`, `UUID`, `Decimal`, `bytes`. A `datetime` return type used to **crash** spec generation at startup.
- `Enum`/`IntEnum`, `typing.Literal`, typed `dict[K, V]` (`additionalProperties`), `set`/`tuple`, and `typing.Any`.
- hardened container rendering (`list[str]`, `Optional[str]`, nested bodies).

**2. Security schemes & the Swagger "Authorize" button** (`openapi.py`, `__init__.py`)
- no longer emit an empty `securitySchemes: {}` → Swagger UI stops showing an **empty "Authorize" popup**; the button appears only once a scheme exists.
- `configure_authentication()` auto-registers a matching scheme (`BearerAuth` for `BearerGetter`); `auth_required` routes advertise the requirement (lock icon + credential on "Try it out").
- new `OpenAPI.add_security_scheme()` / `prune_empty_components()`.

**3. Per-route FastAPI-parity flags** — on every decorator, `SubRouter`, and `add_route`:
| flag | effect |
|---|---|
| `status_code` | default success code; in the spec **and** applied to plain returns at runtime (explicit `Response` keeps its own status) |
| `response_model` | type/Pydantic model as the success schema; dict returns are validated + re-serialized through it |
| `responses` | extra documented responses keyed by status code (string, `{"description","model"}`, or full object) |
| `deprecated` | marks the operation deprecated |
| `include_in_schema` | hides the route from the spec |

Carried via a new `RouteOpenAPIMeta` on the `Route` namedtuple. The request hot path is unchanged unless `status_code`/`response_model` are set.

**4. Robustness** — `processpool` route registration now uses attribute access instead of positional unpacking, so adding `Route` fields can't silently break worker startup.

**5. Docs** — new sections covering the route flags, security/Authorize, and a note that auto-generated params come from **typed annotations** (dynamic `request.query_params` / `request.json()` aren't introspectable — same as FastAPI).

## Issues fixed

- Closes #1124 — datetime return crashes OpenAPI generation
- Closes #1073 — container types not rendered in request bodies
- Closes #1257 — support multiple/return responses
- Closes #1122 — Swagger "Authorize" content empty
- Closes #1339 — empty "Available authorizations" popup
- Addresses #1333 — query/body/path docs (typed-param support + docs; dynamic `request.*` is non-introspectable by design)

## Supersedes (close after merge)

These are folded into this PR with deeper implementations + integration/unit tests:

- #1373 multiple responses → `responses=`
- #1370 `response_model`
- #1369 `deprecated` / `include_in_schema`
- #1368 `status_code`
- #1211 security scheme config (#1122)
- #1134 datetime handling (#1124)
- #1054 non-container schema gen

## Test plan

- [x] 30 new unit tests (`unit_tests/test_openapi_consolidated.py`) — schema types, flags, responses, security, prune, runtime helpers
- [x] 7 new integration tests in `test_openapi.py` — validated against a live server (`/openapi.json`)
- [x] existing OpenAPI unit + integration suites pass; auth/post/subrouter suites pass
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced route decorators with OpenAPI metadata: control response status codes, document additional responses, mark routes as deprecated, and exclude routes from API documentation.
  * Improved authentication integration with automatic OpenAPI security scheme registration.

* **Documentation**
  * Added comprehensive guidance on using FastAPI-style decorator flags for OpenAPI integration.
  * Clarified how authentication configuration affects Swagger UI and security scheme rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->