### PR TITLE
feat(auth): async authenticate() + SubRouter auth-handler inheritance

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict
 from typing import TypedDict
 
-from integration_tests.subroutes import di_subrouter, static_router, sub_router
+from integration_tests.subroutes import async_auth_subrouter, di_subrouter, inherited_auth_subrouter, static_router, sub_router
 from robyn import Headers, Request, Response, Robyn, SSEMessage, SSEResponse, WebSocketDisconnect, jsonify, serve_file, serve_html
 from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
 from robyn.robyn import QueryParams, Url
@@ -1837,6 +1837,10 @@ def main():
     app.include_router(sub_router)
     app.include_router(di_subrouter)
     app.include_router(static_router)
+    # async_auth_subrouter has its own async handler; inherited_auth_subrouter
+    # has none and should inherit the app's handler configured below (#1026).
+    app.include_router(async_auth_subrouter)
+    app.include_router(inherited_auth_subrouter)
 
     class BasicAuthHandler(AuthenticationHandler):
         def authenticate(self, request: Request) -> Identity | None:

--- a/integration_tests/subroutes/__init__.py
+++ b/integration_tests/subroutes/__init__.py
@@ -1,11 +1,12 @@
 from robyn import SubRouter, WebSocketDisconnect, jsonify
 
+from .auth_subrouter import async_auth_subrouter, inherited_auth_subrouter
 from .di_subrouter import di_subrouter
 from .file_api import static_router
 
 sub_router = SubRouter(prefix="/sub_router")
 
-__all__ = ["sub_router", "di_subrouter", "static_router"]
+__all__ = ["sub_router", "di_subrouter", "static_router", "async_auth_subrouter", "inherited_auth_subrouter"]
 
 
 @sub_router.websocket("/ws")

--- a/integration_tests/subroutes/auth_subrouter.py
+++ b/integration_tests/subroutes/auth_subrouter.py
@@ -1,0 +1,36 @@
+from robyn import Request, SubRouter
+from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
+
+
+class AsyncAuthHandler(AuthenticationHandler):
+    """An authentication handler with an async authenticate() — exercises the
+    async path used by async ORMs / HTTP clients (#1157, #1296)."""
+
+    async def authenticate(self, request: Request) -> Identity | None:
+        token = self.token_getter.get_token(request)
+        if token == "valid":
+            return Identity(claims={"async_key": "async_value"})
+        return None
+
+
+# A SubRouter that configures its OWN async handler.
+async_auth_subrouter = SubRouter(prefix="/async_auth_sub")
+async_auth_subrouter.configure_authentication(AsyncAuthHandler(token_getter=BearerGetter()))
+
+
+@async_auth_subrouter.get("/protected", auth_required=True)
+async def async_auth_protected(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"async_key": "async_value"}
+    return "async_auth_protected"
+
+
+# A SubRouter with NO handler of its own — it inherits the app's handler (#1026).
+inherited_auth_subrouter = SubRouter(prefix="/inherited_auth_sub")
+
+
+@inherited_auth_subrouter.get("/protected", auth_required=True)
+async def inherited_auth_protected(request: Request):
+    assert request.identity is not None
+    assert request.identity.claims == {"key": "value"}
+    return "inherited_auth_protected"

--- a/integration_tests/test_async_authentication.py
+++ b/integration_tests/test_async_authentication.py
@@ -1,0 +1,43 @@
+import pytest
+
+from integration_tests.helpers.http_methods_helpers import get
+
+
+# --- SubRouter with its own async authenticate() handler (#1157, #1296) ---
+
+
+@pytest.mark.benchmark
+def test_async_auth_handler_valid_token(session):
+    r = get("/async_auth_sub/protected", headers={"Authorization": "Bearer valid"})
+    assert r.text == "async_auth_protected"
+
+
+@pytest.mark.benchmark
+def test_async_auth_handler_invalid_token(session):
+    r = get(
+        "/async_auth_sub/protected",
+        headers={"Authorization": "Bearer invalid"},
+        should_check_response=False,
+    )
+    assert r.status_code == 401
+
+
+@pytest.mark.benchmark
+def test_async_auth_handler_no_token(session):
+    r = get("/async_auth_sub/protected", should_check_response=False)
+    assert r.status_code == 401
+
+
+# --- SubRouter that inherits the app's auth handler (#1026) ---
+
+
+@pytest.mark.benchmark
+def test_inherited_auth_valid_token(session):
+    r = get("/inherited_auth_sub/protected", headers={"Authorization": "Bearer valid"})
+    assert r.text == "inherited_auth_protected"
+
+
+@pytest.mark.benchmark
+def test_inherited_auth_no_token(session):
+    r = get("/inherited_auth_sub/protected", should_check_response=False)
+    assert r.status_code == 401

--- a/integration_tests/test_async_authentication.py
+++ b/integration_tests/test_async_authentication.py
@@ -2,7 +2,6 @@ import pytest
 
 from integration_tests.helpers.http_methods_helpers import get
 
-
 # --- SubRouter with its own async authenticate() handler (#1157, #1296) ---
 
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -802,6 +802,27 @@ class BaseRobyn(ABC):
 
         self.dependencies.merge_dependencies(router)
 
+        # Let the freshly-included SubRouter (and its nested SubRouters) inherit
+        # an authentication handler if they don't have their own (#1026), so
+        # auth_required routes on them work without a per-SubRouter
+        # configure_authentication() call.
+        self._propagate_authentication_handler()
+
+    def _propagate_authentication_handler(self) -> None:
+        """Share this router's authentication handler with included SubRouters
+        that don't have their own, recursing into nested SubRouters.
+
+        A SubRouter that configured its own handler keeps it (and passes *that*
+        one down to its descendants); SubRouters without a handler inherit the
+        nearest ancestor's. Idempotent, so it's safe to call from both
+        ``configure_authentication`` and ``include_router`` regardless of order.
+        """
+        for router in self.included_routers:
+            if router.authentication_handler is None and self.authentication_handler is not None:
+                router.authentication_handler = self.authentication_handler
+                router.middleware_router.set_authentication_handler(self.authentication_handler)
+            router._propagate_authentication_handler()
+
     def configure_authentication(self, authentication_handler: AuthenticationHandler):
         """
         Configures the authentication handler for the application.
@@ -810,6 +831,9 @@ class BaseRobyn(ABC):
         """
         self.authentication_handler = authentication_handler
         self.middleware_router.set_authentication_handler(authentication_handler)
+
+        # Propagate to any already-included SubRouters lacking their own handler.
+        self._propagate_authentication_handler()
 
         # Auto-register a matching OpenAPI security scheme so Swagger UI's
         # "Authorize" button works out of the box for auth_required routes

--- a/robyn/authentication.py
+++ b/robyn/authentication.py
@@ -66,8 +66,13 @@ class AuthenticationHandler(ABC):
     def authenticate(self, request: Request) -> Identity | None:
         """
         Authenticates the user.
+
+        May be implemented as a regular method or as an ``async def`` coroutine;
+        when async, Robyn awaits it automatically, so the authentication logic
+        can use async ORMs, HTTP clients, or any other async I/O.
+
         :param request: The request object.
-        :return: The identity of the user.
+        :return: The identity of the user, or ``None`` to reject the request.
         """
         raise NotImplementedError()
 

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -485,16 +485,24 @@ class MiddlewareRouter(BaseRouter):
     def add_auth_middleware(self, endpoint: str, route_type: HttpMethod):
         """
         This method adds an authentication middleware to the specified endpoint.
+
+        The wrapper is async so that ``AuthenticationHandler.authenticate()`` may
+        be either a regular method or an ``async def`` coroutine — the latter
+        lets authentication use async ORMs / HTTP clients (#1157, #1296). A
+        synchronous ``authenticate()`` is awaited only if it returns an
+        awaitable, so it carries no extra cost.
         """
 
         injected_dependencies: dict = {}
 
         def decorator(handler):
             @wraps(handler)
-            def inner_handler(request: Request, *args):
+            async def inner_handler(request: Request, *args):
                 if not self.authentication_handler:
                     raise AuthenticationNotConfiguredError()
                 identity = self.authentication_handler.authenticate(request)
+                if inspect.isawaitable(identity):
+                    identity = await identity
                 if identity is None:
                     return self.authentication_handler.unauthorized_response
                 request.identity = identity

--- a/unit_tests/test_auth_propagation.py
+++ b/unit_tests/test_auth_propagation.py
@@ -1,0 +1,85 @@
+"""Unit tests for authentication-handler propagation to SubRouters (#1026).
+
+A SubRouter without its own handler should inherit one from the router that
+includes it, including through nested SubRouters and regardless of whether
+configure_authentication() is called before or after include_router().
+"""
+
+from robyn import Robyn, SubRouter
+from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
+
+
+class _Handler(AuthenticationHandler):
+    def authenticate(self, request):
+        return Identity(claims={"k": "v"})
+
+
+def _mw(router):
+    return router.middleware_router.authentication_handler
+
+
+def test_configure_then_include_propagates():
+    app = Robyn(__file__)
+    handler = _Handler(token_getter=BearerGetter())
+    app.configure_authentication(handler)
+
+    sub = SubRouter(prefix="/sub")
+    app.include_router(sub)
+
+    assert sub.authentication_handler is handler
+    assert _mw(sub) is handler
+
+
+def test_include_then_configure_propagates():
+    app = Robyn(__file__)
+    sub = SubRouter(prefix="/sub")
+    app.include_router(sub)
+
+    handler = _Handler(token_getter=BearerGetter())
+    app.configure_authentication(handler)
+
+    assert sub.authentication_handler is handler
+    assert _mw(sub) is handler
+
+
+def test_nested_subrouters_inherit():
+    app = Robyn(__file__)
+    parent = SubRouter(prefix="/parent")
+    child = SubRouter(prefix="/child")
+    parent.include_router(child)
+    app.include_router(parent)
+
+    handler = _Handler(token_getter=BearerGetter())
+    app.configure_authentication(handler)
+
+    # both levels inherit the app handler
+    assert parent.authentication_handler is handler
+    assert child.authentication_handler is handler
+
+
+def test_subrouter_keeps_its_own_handler():
+    app = Robyn(__file__)
+    own = _Handler(token_getter=BearerGetter())
+    sub = SubRouter(prefix="/sub")
+    sub.configure_authentication(own)
+
+    app_handler = _Handler(token_getter=BearerGetter())
+    app.configure_authentication(app_handler)
+    app.include_router(sub)
+
+    # the SubRouter's own handler must not be overridden by the app's
+    assert sub.authentication_handler is own
+
+
+def test_subrouter_own_handler_passes_down_to_descendant():
+    app = Robyn(__file__)
+    parent = SubRouter(prefix="/parent")
+    parent_handler = _Handler(token_getter=BearerGetter())
+    parent.configure_authentication(parent_handler)
+
+    child = SubRouter(prefix="/child")
+    parent.include_router(child)
+    app.include_router(parent)
+
+    # child had no handler -> inherits the parent SubRouter's, not the app's (app has none)
+    assert child.authentication_handler is parent_handler


### PR DESCRIPTION
## Summary

Two related authentication gaps, reimplemented cleanly. (Supersedes the abandoned #1331, which bundled unrelated CI/release changes and whose handler propagation didn't recurse into nested SubRouters.)

### 1. Async `authenticate()` (#1157, #1296)

`AuthenticationHandler.authenticate()` may now be an `async def` coroutine — so authentication can do async ORM lookups, async HTTP calls, etc. The auth middleware wrapper is `async` and awaits the result only if it's awaitable, so a synchronous `authenticate()` is unaffected.

```python
class MyAuth(AuthenticationHandler):
    async def authenticate(self, request):
        user = await db.fetch_user(self.token_getter.get_token(request))   # async ORM
        return Identity(claims={"id": user.id}) if user else None
```

### 2. SubRouter auth-handler inheritance (#1026)

A SubRouter without its own handler now inherits one from the router that includes it, via a recursive `_propagate_authentication_handler()` called from **both** `configure_authentication()` and `include_router()`. So it works regardless of call order **and** through nested SubRouters. A SubRouter that configured its own handler keeps it (and passes that one down to its descendants).

```python
app.configure_authentication(MyAuth(token_getter=BearerGetter()))
app.include_router(users_router)   # @users_router.get(..., auth_required=True) now works
```

## Issues fixed

- Closes #1157 — auth middleware couldn't `await` an async `authenticate()` (async ORMs)
- Closes #1296 — async authentication handler / async ORM support
- Closes #1026 — `auth_required` on SubRouter routes failed without a per-SubRouter `configure_authentication()`

## Test plan

- [x] Unit tests (`test_auth_propagation.py`): propagation with configure-then-include, include-then-configure, nested SubRouters, own-handler-not-overridden, and own-handler-passed-to-descendant.
- [x] Integration tests (`test_async_authentication.py`): async-handler SubRouter (valid/invalid/no token) and an inheriting SubRouter (valid/no token).
- [x] Existing auth suite still green (21 auth tests pass), full unit suite green (107).
- [x] `ruff` clean. Pure-Python change — no Rust rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SubRouters now support asynchronous authentication handlers.
  * Added authentication handler inheritance so included/nested subrouters automatically use the parent handler when they don’t define one.
* **Tests**
  * Added integration coverage for async and inherited authentication (valid/invalid/missing Bearer tokens).
  * Added unit tests validating propagation across include order and nested router hierarchies.
* **Documentation**
  * Clarified that authentication handlers may be synchronous or `async def`, and Robyn will await async implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->