### PR TITLE
fix: cast bare before_request returns (#793) + OPTIONS under static mounts (#1130)

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -323,6 +323,35 @@ def short_circuit_handler():
     return "handler should not run"
 
 
+# A before_request may return a bare value that is cast to a short-circuiting
+# Response, instead of constructing a full Response object (#793).
+@app.before_request("/sync/before/bare_dict")
+def before_bare_dict(request: Request):
+    return {"blocked": True}  # bare dict -> JSON 200 response
+
+
+@app.before_request("/sync/before/bare_tuple")
+def before_bare_tuple(request: Request):
+    return ("denied", {}, 403)  # (description, headers, status_code) -> 403
+
+
+@app.get("/sync/before/bare_dict")
+def after_bare_dict():
+    return "should not reach"
+
+
+@app.get("/sync/before/bare_tuple")
+def after_bare_tuple():
+    return "should not reach"
+
+
+# An OPTIONS route registered under a static mount (/test_dir) must reach the
+# router rather than being swallowed by the static file service (#1130).
+@app.options("/test_dir/preflight")
+def options_under_static_mount():
+    return "options-under-static"
+
+
 # --- ContextVar propagation (regression test for #1380) ---
 
 _ctxvar_middleware_value: contextvars.ContextVar = contextvars.ContextVar("ctxvar_middleware_value", default="default")

--- a/integration_tests/test_middlewares.py
+++ b/integration_tests/test_middlewares.py
@@ -45,6 +45,22 @@ def test_multiple_middlewares_on_same_route(session):
 
 
 @pytest.mark.benchmark
+def test_before_request_bare_dict_short_circuits(session):
+    """#793: a bare dict returned from before_request is cast to a JSON Response."""
+    r = get("/sync/before/bare_dict", should_check_response=False)
+    assert r.status_code == 200
+    assert r.json() == {"blocked": True}
+
+
+@pytest.mark.benchmark
+def test_before_request_bare_tuple_short_circuits(session):
+    """#793: a (body, headers, status) tuple from before_request sets the status."""
+    r = get("/sync/before/bare_tuple", should_check_response=False)
+    assert r.status_code == 403
+    assert r.text == "denied"
+
+
+@pytest.mark.benchmark
 def test_after_request_runs_when_before_request_short_circuits(session):
     """When before_request returns a Response, the handler is skipped but the
     after_request chain still runs on that response."""

--- a/integration_tests/test_static_files_with_api_routes.py
+++ b/integration_tests/test_static_files_with_api_routes.py
@@ -8,7 +8,7 @@ to API handlers when a static file service is mounted at the same route.
 
 import pytest
 
-from integration_tests.helpers.http_methods_helpers import get, post
+from integration_tests.helpers.http_methods_helpers import generic_http_helper, get, post
 
 # Notes:
 # 1. The /static route serves the integration_tests having files & directories.
@@ -31,3 +31,11 @@ def test_static_file_still_served_correctly(session):
     assert response.status_code == 200
     # Should serve the index.html file
     assert "html" in response.text.lower()
+
+
+def test_options_route_under_static_mount_reaches_router(session):
+    """#1130: an OPTIONS route under a static mount must reach the router rather
+    than being swallowed by the file service."""
+    response = generic_http_helper("options", "/test_dir/preflight", should_check_response=False)
+    assert response.status_code == 200
+    assert response.text == "options-under-static"

--- a/robyn/router.py
+++ b/robyn/router.py
@@ -444,6 +444,35 @@ class Router(BaseRouter):
         return self.routes
 
 
+def _cast_before_request_return(result):
+    """Cast a ``before_request`` hook's return value.
+
+    Returning a ``Request`` continues processing; returning a ``Response``
+    short-circuits. A bare value (dict/list/str/bytes/3-tuple) is cast to a
+    short-circuiting ``Response`` so users don't have to construct a full
+    ``Response`` object themselves (#793). ``None`` and ``Request``/``Response``
+    are passed through unchanged.
+    """
+    if result is None or isinstance(result, (Request, Response, StreamingResponse)):
+        return result
+    if isinstance(result, (dict, list)):
+        return Response(status_code=status_codes.HTTP_200_OK, headers=_JSON_HEADERS, description=jsonify(result))
+    if isinstance(result, bytes):
+        return Response(status_code=status_codes.HTTP_200_OK, headers=_TEXT_HEADERS, description=result)
+    if isinstance(result, tuple):
+        if len(result) != 3:
+            raise ValueError("A tuple returned from before_request must have 3 elements: (description, headers, status_code)")
+        description, headers, status_code = result
+        if isinstance(description, (dict, list)):
+            body = jsonify(description)
+        elif isinstance(description, bytes):
+            body = description
+        else:
+            body = str(description).encode("utf-8")
+        return Response(status_code=status_code, headers=Headers(headers), description=body)
+    return Response(status_code=status_codes.HTTP_200_OK, headers=_TEXT_HEADERS, description=str(result).encode("utf-8"))
+
+
 class MiddlewareRouter(BaseRouter):
     def __init__(self, dependencies: DependencyMap = DependencyMap()) -> None:
         super().__init__()
@@ -543,14 +572,21 @@ class MiddlewareRouter(BaseRouter):
         # no dependency injection here
         injected_dependencies: dict = {}
 
+        # before_request hooks may return a bare value (dict/str/...) that gets
+        # cast to a short-circuiting Response (#793); after_request hooks return
+        # a Response and are passed through unchanged.
+        cast_return = middleware_type == MiddlewareType.BEFORE_REQUEST
+
         def inner(handler):
             @wraps(handler)
             async def async_inner_handler(*args, **kwargs):
-                return await handler(*args, **kwargs)
+                result = await handler(*args, **kwargs)
+                return _cast_before_request_return(result) if cast_return else result
 
             @wraps(handler)
             def inner_handler(*args, **kwargs):
-                return handler(*args, **kwargs)
+                result = handler(*args, **kwargs)
+                return _cast_before_request_return(result) if cast_return else result
 
             if endpoint is not None:
                 if inspect.iscoroutinefunction(handler):

--- a/src/server.rs
+++ b/src/server.rs
@@ -155,7 +155,15 @@ impl Server {
                     // 3. Just serves the file without any redirection to sub links
                     for directory in directories.iter() {
                         let mut files = Files::new(&directory.route, &directory.directory_path)
-                            .method_guard(guard::fn_guard(|_| true))
+                            // Use a routing-level guard (not method_guard) so an
+                            // OPTIONS request falls THROUGH to the router instead of
+                            // being answered by the file service. This lets an
+                            // OPTIONS route / CORS preflight registered on a path
+                            // under a static mount actually be reached (#1130).
+                            // method_guard would short-circuit with a 4xx here.
+                            .guard(guard::fn_guard(|ctx| {
+                                ctx.head().method != actix_web::http::Method::OPTIONS
+                            }))
                             .redirect_to_slash_directory();
                         if let Some(index_file) = &directory.index_file {
                             files = files.index_file(index_file);


### PR DESCRIPTION
## Summary

Two request/response handling fixes. (The third item from the original "Rust trio", **#954** multipart duplicate keys, is held back — it would change the public `request.form_data` shape from `dict[str, str]` to a multi-value mapping, which needs an explicit API decision.)

### #793 — bare `before_request` returns are cast to a Response

Previously, returning anything other than a `Request`/`Response` from a `before_request` hook raised an extraction error, so you had to construct a full `Response(description=..., status_code=..., headers={})` even for a simple short-circuit. Now a bare value is cast:

```python
@app.before_request("/upload")
def guard(request):
    if request.form_data.get("user_id") is None:
        return {"error": "user_id required"}      # -> JSON 200, short-circuits
        # or: return ("user_id required", {}, 400)  # -> 400, short-circuits
    return request                                  # -> continues as before
```

`Request`/`Response`/`None` pass through unchanged, so this is **non-breaking** (the old behavior was an error).

### #1130 — OPTIONS routes under a static mount

A static mount used actix-files `method_guard`, which **short-circuits with a 4xx** when the method doesn't match — so an `OPTIONS` route (e.g. CORS preflight) registered on a path under a static mount was answered `Request did not meet this resource's requirements.` instead of reaching the router. Switching to a routing-level `guard` lets `OPTIONS` **fall through** to the router, while `GET`/`HEAD`/… still serve files.

## Issues fixed

- Closes #793 — Response not auto-cast when returned in before_request
- Closes #1130 — static mount swallows OPTIONS

## Test plan

- [x] New integration tests: bare-dict (→ JSON 200) and tuple (→ 403) `before_request` short-circuits; `OPTIONS /test_dir/preflight` reaches the router; static `GET` still served.
- [x] Verified live (bare dict/tuple/pass-through; OPTIONS under static now `200`).
- [x] Full **unit (107)** + **integration (361)** suites pass; `ruff` + `isort` + `cargo fmt` clean.

## Deferred for your call: #954 (multipart duplicate keys)
`request.form_data` is `dict[str, str]` (documented in `robyn.pyi`), so duplicate field names currently overwrite. Preserving all values means either changing the type to a multi-value mapping (breaking) or adding a separate `getlist`-style accessor. Happy to implement whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `before_request` middleware to properly handle bare dict and tuple return values, converting them into appropriate HTTP responses.
  * Fixed OPTIONS requests under static file mounts to reach the API router for CORS preflight handling instead of being intercepted by static file serving.

* **Tests**
  * Added integration tests for middleware short-circuiting behavior with bare return values.
  * Added integration tests for OPTIONS request routing under static mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->