### PR TITLE
feat: first-party signed-cookie sessions via request.session (#945)

### DIFF
--- a/docs_src/src/components/documentation/Navigation.jsx
+++ b/docs_src/src/components/documentation/Navigation.jsx
@@ -253,6 +253,10 @@ export const navigation = [
         title: 'Authentication',
       },
       {
+        href: '/documentation/en/api_reference/sessions',
+        title: 'Sessions',
+      },
+      {
         href: '/documentation/en/api_reference/const_requests',
         title: 'Const Requests and Multi Core Scaling',
       },

--- a/docs_src/src/pages/documentation/en/api_reference/sessions.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/sessions.mdx
@@ -1,0 +1,85 @@
+export const description =
+  'On this page, you’ll learn how to store per-user state across requests using Robyn’s signed-cookie sessions.'
+
+Once the Gotham Police Department could authenticate, Batman wanted each officer's dashboard to remember small bits of state between requests — the theme they picked, a CSRF token, the last case they viewed — without standing up a database for it. So he reached for Robyn's sessions.
+
+## Sessions
+
+Robyn provides signed-cookie sessions. The session is a small dictionary that is stored on the client inside a tamper-proof cookie (an HMAC-SHA256 signature over the data). No server-side store is required, and the signature means a client cannot modify the contents without invalidating it.
+
+<b>
+  Note: the session is signed, not encrypted. The data is encoded, so the client can read it — never store secrets (passwords, raw tokens) in the session.
+</b>
+
+Enable sessions once on your app with `configure_sessions`, then read or write the session inside any handler through `request.session` — exactly like `request.identity` for authentication.
+
+<Row>
+<Col>
+Call `configure_sessions` with a `secret_key`. Keep this key secret and stable across restarts and across all your worker processes — it is what signs and verifies every session cookie.
+</Col>
+  <Col sticky>
+    <CodeGroup title="Setup">
+
+    ```python
+    from robyn import Robyn
+
+    app = Robyn(__file__)
+
+    app.configure_sessions(secret_key="keep-me-secret")
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<Row>
+<Col>
+Inside a handler, `request.session` is a dictionary-like `Session` object. Read it like a `dict`, and mutate it like a `dict`. Robyn writes the updated session back to the response cookie automatically — but only when the session was actually modified, so read-only requests do not send a `Set-Cookie`.
+</Col>
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/visits">
+
+    ```python
+    @app.get("/visits")
+    def visits(request):
+        request.session["count"] = request.session.get("count", 0) + 1
+        return f"You have visited {request.session['count']} times"
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+<Row>
+<Col>
+To log a user out, or otherwise drop their state, clear the session. Emptying the session expires the cookie in the browser.
+</Col>
+  <Col sticky>
+    <CodeGroup title="Request" tag="POST" label="/logout">
+
+    ```python
+    @app.post("/logout")
+    def logout(request):
+        request.session.clear()
+        return "logged out"
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+## Configuration
+
+`configure_sessions` accepts the following keyword arguments to control the cookie:
+
+- `secret_key` (required) — key used to sign the cookie.
+- `cookie_name` — name of the session cookie. Defaults to `"session"`.
+- `max_age` — session lifetime in seconds, also used as the cookie `Max-Age`. Defaults to 14 days. Pass `None` for a cookie that lasts only for the browser session.
+- `path` — cookie `Path`. Defaults to `"/"`.
+- `domain` — cookie `Domain`. Defaults to `None`.
+- `secure` — only send the cookie over HTTPS. Defaults to `False`; set it to `True` in production.
+- `http_only` — hide the cookie from JavaScript. Defaults to `True`.
+- `same_site` — `"Strict"`, `"Lax"`, or `"None"`. Defaults to `"Lax"`.
+
+## How it works
+
+Under the hood, `configure_sessions` registers a global `before_request` middleware that loads and verifies the cookie into a `Session` and attaches it to `request.session`, and a global `after_request` middleware that signs and writes the session back to the response when it has been modified. Because `request.session` is the same object across the `before_request`, handler, and `after_request` phases, your in-handler changes are exactly what gets written back.
+
+If you want explicit control instead of the automatic middleware, you can use the `SessionManager` directly with `manager.load(request)` and `manager.save(session, response)`.

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -810,6 +810,30 @@ def cookie_overwrite():
     return response
 
 
+# signed-cookie sessions (configured in main() via app.configure_sessions)
+@app.get("/sessions/get")
+def session_get(request):
+    return {"value": request.session.get("value")}
+
+
+@app.post("/sessions/set")
+def session_set(request):
+    request.session["value"] = request.json().get("value")
+    return {"stored": request.session["value"]}
+
+
+@app.get("/sessions/counter")
+async def session_counter(request):
+    request.session["count"] = request.session.get("count", 0) + 1
+    return {"count": request.session["count"]}
+
+
+@app.get("/sessions/clear")
+def session_clear(request):
+    request.session.clear()
+    return {"cleared": True}
+
+
 # --- POST ---
 
 # dict
@@ -1882,6 +1906,10 @@ def main():
             return None
 
     app.configure_authentication(BasicAuthHandler(token_getter=BearerGetter()))
+
+    # Signed-cookie sessions, used by the /sessions/* routes and test_sessions.py.
+    # Distinct cookie name so it never collides with the /cookie/* tests.
+    app.configure_sessions(secret_key="integration-test-secret", cookie_name="robyn_session")
 
     # Read port from environment variable if set, otherwise default to 8080
     port = int(os.getenv("ROBYN_PORT", "8080"))

--- a/integration_tests/test_sessions.py
+++ b/integration_tests/test_sessions.py
@@ -1,0 +1,65 @@
+import requests
+
+BASE_URL = "http://127.0.0.1:8080"
+COOKIE_NAME = "robyn_session"
+
+
+def test_session_is_empty_by_default(session):
+    r = requests.get(f"{BASE_URL}/sessions/get")
+    assert r.status_code == 200
+    assert r.json()["value"] is None
+    # No session cookie is set when nothing is stored.
+    assert COOKIE_NAME not in r.cookies
+
+
+def test_session_persists_across_requests(session):
+    client = requests.Session()
+
+    r = client.post(f"{BASE_URL}/sessions/set", json={"value": "hello"})
+    assert r.json()["stored"] == "hello"
+    assert COOKIE_NAME in r.cookies  # cookie written on modification
+
+    # A later request on the same client sees the stored value.
+    r = client.get(f"{BASE_URL}/sessions/get")
+    assert r.json()["value"] == "hello"
+
+
+def test_session_counter_increments_per_client(session):
+    client = requests.Session()
+    counts = [client.get(f"{BASE_URL}/sessions/counter").json()["count"] for _ in range(3)]
+    assert counts == [1, 2, 3]
+
+    # A fresh client starts its own session from scratch.
+    other = requests.Session()
+    assert other.get(f"{BASE_URL}/sessions/counter").json()["count"] == 1
+
+
+def test_session_cookie_is_http_only(session):
+    client = requests.Session()
+    r = client.post(f"{BASE_URL}/sessions/set", json={"value": "x"})
+    set_cookie = r.headers.get("Set-Cookie", "")
+    assert COOKIE_NAME in set_cookie
+    assert "HttpOnly" in set_cookie
+
+
+def test_tampered_session_cookie_is_rejected(session):
+    client = requests.Session()
+    # Establish a session (count = 1).
+    client.get(f"{BASE_URL}/sessions/counter")
+    original = client.cookies.get(COOKIE_NAME)
+    assert original is not None
+
+    # Flip the tail of the signed value; the HMAC no longer matches.
+    tampered = original[:-3] + ("aaa" if not original.endswith("aaa") else "bbb")
+    r = requests.get(f"{BASE_URL}/sessions/counter", cookies={COOKIE_NAME: tampered})
+    # Tampered cookie -> treated as empty session -> counter restarts at 1.
+    assert r.json()["count"] == 1
+
+
+def test_session_clear_removes_data(session):
+    client = requests.Session()
+    client.post(f"{BASE_URL}/sessions/set", json={"value": "to-be-cleared"})
+    assert client.get(f"{BASE_URL}/sessions/get").json()["value"] == "to-be-cleared"
+
+    client.get(f"{BASE_URL}/sessions/clear")
+    assert client.get(f"{BASE_URL}/sessions/get").json()["value"] is None

--- a/integration_tests/test_sessions.py
+++ b/integration_tests/test_sessions.py
@@ -2,10 +2,11 @@ import requests
 
 BASE_URL = "http://127.0.0.1:8080"
 COOKIE_NAME = "robyn_session"
+TIMEOUT = 5  # seconds; keep tests from hanging if the server becomes unresponsive
 
 
 def test_session_is_empty_by_default(session):
-    r = requests.get(f"{BASE_URL}/sessions/get")
+    r = requests.get(f"{BASE_URL}/sessions/get", timeout=TIMEOUT)
     assert r.status_code == 200
     assert r.json()["value"] is None
     # No session cookie is set when nothing is stored.
@@ -15,28 +16,28 @@ def test_session_is_empty_by_default(session):
 def test_session_persists_across_requests(session):
     client = requests.Session()
 
-    r = client.post(f"{BASE_URL}/sessions/set", json={"value": "hello"})
+    r = client.post(f"{BASE_URL}/sessions/set", json={"value": "hello"}, timeout=TIMEOUT)
     assert r.json()["stored"] == "hello"
     assert COOKIE_NAME in r.cookies  # cookie written on modification
 
     # A later request on the same client sees the stored value.
-    r = client.get(f"{BASE_URL}/sessions/get")
+    r = client.get(f"{BASE_URL}/sessions/get", timeout=TIMEOUT)
     assert r.json()["value"] == "hello"
 
 
 def test_session_counter_increments_per_client(session):
     client = requests.Session()
-    counts = [client.get(f"{BASE_URL}/sessions/counter").json()["count"] for _ in range(3)]
+    counts = [client.get(f"{BASE_URL}/sessions/counter", timeout=TIMEOUT).json()["count"] for _ in range(3)]
     assert counts == [1, 2, 3]
 
     # A fresh client starts its own session from scratch.
     other = requests.Session()
-    assert other.get(f"{BASE_URL}/sessions/counter").json()["count"] == 1
+    assert other.get(f"{BASE_URL}/sessions/counter", timeout=TIMEOUT).json()["count"] == 1
 
 
 def test_session_cookie_is_http_only(session):
     client = requests.Session()
-    r = client.post(f"{BASE_URL}/sessions/set", json={"value": "x"})
+    r = client.post(f"{BASE_URL}/sessions/set", json={"value": "x"}, timeout=TIMEOUT)
     set_cookie = r.headers.get("Set-Cookie", "")
     assert COOKIE_NAME in set_cookie
     assert "HttpOnly" in set_cookie
@@ -45,21 +46,21 @@ def test_session_cookie_is_http_only(session):
 def test_tampered_session_cookie_is_rejected(session):
     client = requests.Session()
     # Establish a session (count = 1).
-    client.get(f"{BASE_URL}/sessions/counter")
+    client.get(f"{BASE_URL}/sessions/counter", timeout=TIMEOUT)
     original = client.cookies.get(COOKIE_NAME)
     assert original is not None
 
     # Flip the tail of the signed value; the HMAC no longer matches.
     tampered = original[:-3] + ("aaa" if not original.endswith("aaa") else "bbb")
-    r = requests.get(f"{BASE_URL}/sessions/counter", cookies={COOKIE_NAME: tampered})
+    r = requests.get(f"{BASE_URL}/sessions/counter", cookies={COOKIE_NAME: tampered}, timeout=TIMEOUT)
     # Tampered cookie -> treated as empty session -> counter restarts at 1.
     assert r.json()["count"] == 1
 
 
 def test_session_clear_removes_data(session):
     client = requests.Session()
-    client.post(f"{BASE_URL}/sessions/set", json={"value": "to-be-cleared"})
-    assert client.get(f"{BASE_URL}/sessions/get").json()["value"] == "to-be-cleared"
+    client.post(f"{BASE_URL}/sessions/set", json={"value": "to-be-cleared"}, timeout=TIMEOUT)
+    assert client.get(f"{BASE_URL}/sessions/get", timeout=TIMEOUT).json()["value"] == "to-be-cleared"
 
-    client.get(f"{BASE_URL}/sessions/clear")
-    assert client.get(f"{BASE_URL}/sessions/get").json()["value"] is None
+    client.get(f"{BASE_URL}/sessions/clear", timeout=TIMEOUT)
+    assert client.get(f"{BASE_URL}/sessions/get", timeout=TIMEOUT).json()["value"] is None

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -25,6 +25,7 @@ from robyn.reloader import compile_rust_files
 from robyn.responses import SSEMessage, SSEResponse, StreamingResponse, html, serve_file, serve_html
 from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, WebSocketConnector, get_version
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
+from robyn.session import Session, SessionManager
 from robyn.testing import TestClient
 from robyn.types import Directory, JsonBody, RequestBody, RequestMethod, RequestURL
 from robyn.ws import WebSocketAdapter, WebSocketDisconnect, create_websocket_decorator
@@ -136,6 +137,7 @@ class BaseRobyn(ABC):
         self.event_handlers: dict = {}
         self.exception_handler: Callable | None = None
         self.authentication_handler: AuthenticationHandler | None = None
+        self.session_manager: SessionManager | None = None
         self.included_routers: list[SubRouter] = []
         self._mcp_app: MCPApp | None = None
         self._added_routes: set[str] = set()
@@ -850,6 +852,69 @@ class BaseRobyn(ABC):
                     {"type": "apiKey", "in": "header", "name": "Authorization"},
                 )
 
+    def configure_sessions(
+        self,
+        secret_key: str,
+        *,
+        cookie_name: str = "session",
+        max_age: int | None = 14 * 24 * 60 * 60,
+        path: str = "/",
+        domain: str | None = None,
+        secure: bool = False,
+        http_only: bool = True,
+        same_site: str = "Lax",
+    ) -> SessionManager:
+        """
+        Enable signed-cookie sessions for the application.
+
+        Registers global ``before_request`` / ``after_request`` middleware that
+        load the session from the incoming cookie and write it back to the
+        response (only when the session was modified). Inside any handler, read
+        or write the session via ``request.session`` (a dict-like
+        :class:`Session`).
+
+        The session is stored client-side in a tamper-proof signed cookie, so no
+        server-side store is needed. The payload is signed, not encrypted — do
+        not store secrets in it.
+
+        :param secret_key: key used to sign the session cookie. Keep it secret and stable across restarts.
+        :param cookie_name: name of the session cookie (default ``"session"``).
+        :param max_age: session lifetime in seconds, also used as the cookie ``Max-Age``. ``None`` for a browser-session cookie.
+        :param path: cookie ``Path`` attribute.
+        :param domain: cookie ``Domain`` attribute.
+        :param secure: only send the cookie over HTTPS.
+        :param http_only: hide the cookie from JavaScript (recommended).
+        :param same_site: ``"Strict"``, ``"Lax"`` or ``"None"``.
+        :returns: the configured :class:`SessionManager`.
+        """
+        manager = SessionManager(
+            secret_key,
+            cookie_name=cookie_name,
+            max_age=max_age,
+            path=path,
+            domain=domain,
+            secure=secure,
+            http_only=http_only,
+            same_site=same_site,
+        )
+        self.session_manager = manager
+
+        @self.before_request()
+        def _robyn_load_session(request: Request):
+            # request.session is shared by reference through the request phases,
+            # so handler mutations are visible when we save it below.
+            request.session = manager.load(request)
+            return request
+
+        @self.after_request()
+        def _robyn_save_session(request: Request, response: Response):
+            session = request.session
+            if session is not None:
+                manager.save(session, response)
+            return response
+
+        return manager
+
     @property
     def mcp(self):
         """
@@ -1120,4 +1185,6 @@ __all__ = [
     "RequestMethod",
     "RequestBody",
     "RequestURL",
+    "Session",
+    "SessionManager",
 ]

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -886,7 +886,14 @@ class BaseRobyn(ABC):
         :param http_only: hide the cookie from JavaScript (recommended).
         :param same_site: ``"Strict"``, ``"Lax"`` or ``"None"``.
         :returns: the configured :class:`SessionManager`.
+        :raises RuntimeError: if sessions are already configured on this app.
         """
+        if self.session_manager is not None:
+            raise RuntimeError(
+                "Sessions are already configured on this app; configure_sessions() may only be called once "
+                "(calling it again would register duplicate session middleware)."
+            )
+
         manager = SessionManager(
             secret_key,
             cookie_name=cookie_name,

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, overload
+from typing import Any, Callable, overload
 
 def get_version() -> str:
     pass
@@ -378,6 +378,8 @@ class Request:
         files (dict[str, bytes]): The files of the request. e.g. {"file": b"file"}
         ip_addr (str | None): The IP Address of the client
         identity (Identity | None): The identity of the client
+        session (Any | None): The session for the request (a robyn.session.Session),
+            populated when app.configure_sessions(...) is enabled.
     """
 
     query_params: QueryParams
@@ -390,6 +392,7 @@ class Request:
     files: dict[str, bytes]
     ip_addr: str | None
     identity: Identity | None
+    session: Any | None
 
     def json(self) -> dict | list:
         """

--- a/robyn/session.py
+++ b/robyn/session.py
@@ -91,17 +91,40 @@ class Session(MutableMapping):
     A dict-like session object.
 
     Behaves like a normal ``dict`` (``session["k"] = v``, ``session.get("k")``,
-    ``del session["k"]``, ``in``, iteration, ``update``, ``pop`` ...). Any
-    mutation flips :attr:`modified`, which is what tells Robyn to re-write the
-    cookie after the handler returns.
+    ``del session["k"]``, ``in``, iteration, ``update``, ``pop`` ...).
+
+    Robyn re-writes the cookie after the handler only when the session changed.
+    Top-level mutations flip :attr:`modified` directly; *nested* mutations (e.g.
+    ``session["items"].append(x)``) are still caught because :meth:`is_modified`
+    also compares the current contents against a snapshot taken at load time. You
+    can also force a write by setting ``session.modified = True``.
     """
 
-    __slots__ = ("_data", "modified")
+    __slots__ = ("_data", "modified", "_snapshot")
 
     def __init__(self, data: Optional[dict] = None) -> None:
         self._data: dict = dict(data) if data else {}
-        #: True once the session has been mutated during this request.
+        #: True once the session has been explicitly mutated during this request.
         self.modified: bool = False
+        # Canonical snapshot of the loaded data, used to detect nested mutations
+        # that bypass __setitem__/__delitem__.
+        self._snapshot: Optional[str] = self._canonical()
+
+    def _canonical(self) -> Optional[str]:
+        """Order-independent JSON of the data, or None if it is not serializable."""
+        try:
+            return json.dumps(self._data, sort_keys=True, separators=(",", ":"))
+        except TypeError:
+            # Non-serializable content -> treat as changed so save() runs and
+            # surfaces a clear error rather than silently dropping the write.
+            return None
+
+    def is_modified(self) -> bool:
+        """True if the session changed this request (top-level or nested)."""
+        if self.modified:
+            return True
+        current = self._canonical()
+        return current is None or current != self._snapshot
 
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
@@ -164,6 +187,10 @@ class SessionManager:
         self.secure = secure
         self.http_only = http_only
         self.same_site = _normalize_same_site(same_site)
+        # Browsers reject SameSite=None cookies that are not also Secure, which
+        # silently breaks the session. Fail loudly at configuration time instead.
+        if self.same_site == "None" and not self.secure:
+            raise ValueError("same_site='None' requires secure=True (browsers reject SameSite=None cookies without the Secure attribute)")
 
     # -- serialization ---------------------------------------------------
 
@@ -190,7 +217,9 @@ class SessionManager:
         if not isinstance(envelope, dict) or not isinstance(envelope.get("d"), dict):
             return Session()
         exp = envelope.get("exp")
-        if exp is not None and exp < time.time():
+        # exp must be numeric; a non-numeric value (corrupt/forged-but-unsigned
+        # payload that somehow parsed) is treated as invalid rather than raising.
+        if exp is not None and (not isinstance(exp, (int, float)) or isinstance(exp, bool) or exp < time.time()):
             return Session()
         return Session(envelope["d"])
 
@@ -204,8 +233,8 @@ class SessionManager:
         return self.loads(raw)
 
     def save(self, session: Session, response) -> None:
-        """Write ``session`` back onto ``response`` as a cookie, if it was modified."""
-        if not session.modified:
+        """Write ``session`` back onto ``response`` as a cookie, if it changed."""
+        if not session.is_modified():
             return
         if len(session) == 0:
             # Session was emptied/cleared -> expire the cookie in the browser.

--- a/robyn/session.py
+++ b/robyn/session.py
@@ -1,0 +1,260 @@
+"""
+First-party signed-cookie sessions for Robyn.
+
+The session is stored entirely on the client inside a tamper-proof signed
+cookie (an HMAC-SHA256 signature over a base64url-encoded JSON payload), so no
+server-side store is required. Signing protects the payload against
+*modification*, not against *reading* — the data is encoded, not encrypted, so
+never put secrets in the session.
+
+Enable it once on the app::
+
+    app.configure_sessions(secret_key="change-me")
+
+and read or write the session from inside any request handler via
+``request.session`` (a dict-like :class:`Session`)::
+
+    @app.get("/")
+    def index(request):
+        request.session["views"] = request.session.get("views", 0) + 1
+        return f"views: {request.session['views']}"
+
+The cookie is (re)written automatically after the handler runs, but only when
+the session was actually modified. The :class:`Session` is shared by reference
+across the request phases through ``request.session``, so this works on every
+supported Python version with no ``contextvars`` dependency.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import time
+from collections.abc import MutableMapping
+from typing import Any, Optional
+
+_logger = logging.getLogger(__name__)
+
+# Largest cookie most browsers will store (4 KB) minus headroom for the cookie
+# name and attributes. Sessions larger than this are silently dropped by the
+# browser, so we warn instead of failing.
+_MAX_COOKIE_SIZE = 4093
+
+__all__ = [
+    "Session",
+    "SessionManager",
+]
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+class _Signer:
+    """itsdangerous-style HMAC-SHA256 signer, stdlib only."""
+
+    def __init__(self, secret_key: str, salt: bytes = b"robyn.session") -> None:
+        # Derive a fixed-length key so arbitrary secret_key lengths are fine.
+        self._key = hashlib.sha256(salt + secret_key.encode("utf-8")).digest()
+
+    def _signature(self, value: bytes) -> str:
+        return _b64encode(hmac.new(self._key, value, hashlib.sha256).digest())
+
+    def sign(self, payload: bytes) -> str:
+        value = _b64encode(payload)
+        return f"{value}.{self._signature(value.encode('ascii'))}"
+
+    def unsign(self, signed: str) -> Optional[bytes]:
+        """Verify and decode ``signed``; return the payload bytes, or None if invalid."""
+        try:
+            value, signature = signed.rsplit(".", 1)
+        except ValueError:
+            return None
+        expected = self._signature(value.encode("ascii"))
+        # Constant-time comparison to avoid signature-timing leaks.
+        if not hmac.compare_digest(expected, signature):
+            return None
+        try:
+            return _b64decode(value)
+        except (ValueError, base64.binascii.Error):
+            return None
+
+
+class Session(MutableMapping):
+    """
+    A dict-like session object.
+
+    Behaves like a normal ``dict`` (``session["k"] = v``, ``session.get("k")``,
+    ``del session["k"]``, ``in``, iteration, ``update``, ``pop`` ...). Any
+    mutation flips :attr:`modified`, which is what tells Robyn to re-write the
+    cookie after the handler returns.
+    """
+
+    __slots__ = ("_data", "modified")
+
+    def __init__(self, data: Optional[dict] = None) -> None:
+        self._data: dict = dict(data) if data else {}
+        #: True once the session has been mutated during this request.
+        self.modified: bool = False
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._data[key] = value
+        self.modified = True
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
+        self.modified = True
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
+    def clear(self) -> None:
+        """Remove all data from the session (marks it modified)."""
+        if self._data:
+            self.modified = True
+        self._data.clear()
+
+    def __repr__(self) -> str:
+        return f"Session({self._data!r})"
+
+
+class SessionManager:
+    """
+    Serializes, signs, reads, and writes :class:`Session` cookies.
+
+    This is the lower-level primitive behind :meth:`Robyn.configure_sessions`.
+    It can also be used directly (``load(request)`` / ``save(session, response)``)
+    when you want explicit control instead of the automatic middleware.
+    """
+
+    def __init__(
+        self,
+        secret_key: str,
+        *,
+        cookie_name: str = "session",
+        max_age: Optional[int] = 14 * 24 * 60 * 60,
+        path: str = "/",
+        domain: Optional[str] = None,
+        secure: bool = False,
+        http_only: bool = True,
+        same_site: str = "Lax",
+    ) -> None:
+        if not secret_key:
+            raise ValueError("configure_sessions() requires a non-empty secret_key")
+        self._signer = _Signer(secret_key)
+        self.cookie_name = cookie_name
+        self.max_age = max_age
+        self.path = path
+        self.domain = domain
+        self.secure = secure
+        self.http_only = http_only
+        self.same_site = _normalize_same_site(same_site)
+
+    # -- serialization ---------------------------------------------------
+
+    def dumps(self, session: Session) -> str:
+        """Serialize and sign ``session`` into a cookie value."""
+        envelope: dict = {"d": dict(session)}
+        if self.max_age is not None:
+            envelope["exp"] = int(time.time()) + self.max_age
+        try:
+            payload = json.dumps(envelope, separators=(",", ":")).encode("utf-8")
+        except TypeError as exc:
+            raise TypeError(f"Session data must be JSON-serializable to fit in a signed cookie: {exc}") from exc
+        return self._signer.sign(payload)
+
+    def loads(self, raw: str) -> Session:
+        """Verify and decode a cookie value into a :class:`Session` (empty if invalid/expired)."""
+        payload = self._signer.unsign(raw)
+        if payload is None:
+            return Session()
+        try:
+            envelope = json.loads(payload)
+        except ValueError:
+            return Session()
+        if not isinstance(envelope, dict) or not isinstance(envelope.get("d"), dict):
+            return Session()
+        exp = envelope.get("exp")
+        if exp is not None and exp < time.time():
+            return Session()
+        return Session(envelope["d"])
+
+    # -- request/response integration ------------------------------------
+
+    def load(self, request) -> Session:
+        """Build the :class:`Session` for ``request`` from its signed cookie."""
+        raw = _read_cookie(request, self.cookie_name)
+        if raw is None:
+            return Session()
+        return self.loads(raw)
+
+    def save(self, session: Session, response) -> None:
+        """Write ``session`` back onto ``response`` as a cookie, if it was modified."""
+        if not session.modified:
+            return
+        if len(session) == 0:
+            # Session was emptied/cleared -> expire the cookie in the browser.
+            response.set_cookie(
+                key=self.cookie_name,
+                value="",
+                path=self.path,
+                domain=self.domain,
+                max_age=0,
+                secure=self.secure,
+                http_only=self.http_only,
+                same_site=self.same_site,
+            )
+            return
+        value = self.dumps(session)
+        if len(value) > _MAX_COOKIE_SIZE:
+            _logger.warning(
+                "Robyn session cookie is %d bytes, larger than the ~4KB most browsers store; it may be dropped. Store less data in the session.",
+                len(value),
+            )
+        response.set_cookie(
+            key=self.cookie_name,
+            value=value,
+            path=self.path,
+            domain=self.domain,
+            max_age=self.max_age,
+            secure=self.secure,
+            http_only=self.http_only,
+            same_site=self.same_site,
+        )
+
+
+def _normalize_same_site(value: Optional[str]) -> Optional[str]:
+    """Normalize SameSite to the capitalization Robyn's cookie layer expects."""
+    if value is None:
+        return None
+    normalized = value.strip().capitalize()
+    if normalized not in ("Strict", "Lax", "None"):
+        raise ValueError(f"same_site must be one of 'Strict', 'Lax', 'None' (got {value!r})")
+    return normalized
+
+
+def _read_cookie(request, name: str) -> Optional[str]:
+    """Extract a single cookie value from the request's ``Cookie`` header."""
+    header = request.headers.get("Cookie")
+    if not header:
+        return None
+    for part in header.split(";"):
+        key, _, value = part.partition("=")
+        if key.strip() == name:
+            return value.strip()
+    return None

--- a/robyn/session.py
+++ b/robyn/session.py
@@ -30,6 +30,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import time
 from collections.abc import MutableMapping
 from typing import Any, Optional
@@ -217,9 +218,11 @@ class SessionManager:
         if not isinstance(envelope, dict) or not isinstance(envelope.get("d"), dict):
             return Session()
         exp = envelope.get("exp")
-        # exp must be numeric; a non-numeric value (corrupt/forged-but-unsigned
-        # payload that somehow parsed) is treated as invalid rather than raising.
-        if exp is not None and (not isinstance(exp, (int, float)) or isinstance(exp, bool) or exp < time.time()):
+        # exp must be a finite number. A non-numeric value, a bool, or a
+        # non-finite float (NaN/Infinity — which json.loads accepts and which
+        # slip past a plain ``exp < now`` comparison) is treated as invalid
+        # rather than raising or being trusted as a never-expiring session.
+        if exp is not None and (not isinstance(exp, (int, float)) or isinstance(exp, bool) or not math.isfinite(exp) or exp < time.time()):
             return Session()
         return Session(envelope["d"])
 

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -27,6 +27,10 @@ pub struct Request {
     pub identity: Option<Identity>,
     pub form_data: Option<HashMap<String, String>>,
     pub files: Option<HashMap<String, Vec<u8>>>,
+    // A Python session object (robyn.session.Session) shared by reference across
+    // the before_request / handler / after_request phases, so in-handler mutations
+    // are visible when the cookie is written back. Set by configure_sessions().
+    pub session: Option<Py<PyAny>>,
 }
 
 impl<'py> IntoPyObject<'py> for Request {
@@ -81,6 +85,7 @@ impl<'py> IntoPyObject<'py> for Request {
             identity: self.identity,
             form_data,
             files,
+            session: self.session,
         };
         Ok(Py::new(py, request)?.into_bound(py).into_any())
     }
@@ -189,6 +194,7 @@ impl Request {
             identity: None,
             form_data: Some(form_data),
             files: Some(files),
+            session: None,
         })
     }
 }
@@ -216,11 +222,14 @@ pub struct PyRequest {
     pub form_data: Py<PyDict>,
     #[pyo3(get, set)]
     pub files: Py<PyDict>,
+    #[pyo3(get, set)]
+    pub session: Option<Py<PyAny>>,
 }
 
 #[pymethods]
 impl PyRequest {
     #[new]
+    #[pyo3(signature = (query_params, headers, path_params, body, method, url, form_data, files, identity, ip_addr, session=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         query_params: QueryParams,
@@ -233,6 +242,7 @@ impl PyRequest {
         files: Py<PyDict>,
         identity: Option<Identity>,
         ip_addr: Option<String>,
+        session: Option<Py<PyAny>>,
     ) -> Self {
         Self {
             query_params,
@@ -245,6 +255,7 @@ impl PyRequest {
             form_data,
             files,
             ip_addr,
+            session,
         }
     }
 

--- a/unit_tests/test_sessions.py
+++ b/unit_tests/test_sessions.py
@@ -1,0 +1,236 @@
+import pytest
+
+from robyn.robyn import Headers, QueryParams, Request, Url
+from robyn.session import Session, SessionManager, _read_cookie, _Signer
+
+# --- helpers ---------------------------------------------------------------
+
+
+class _FakeHeaders:
+    def __init__(self, data: dict):
+        self._data = {k.lower(): v for k, v in data.items()}
+
+    def get(self, key: str):
+        return self._data.get(key.lower())
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict):
+        self.headers = _FakeHeaders(headers)
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.cookies = {}
+
+    def set_cookie(self, key, value, **kwargs):
+        self.cookies[key] = (value, kwargs)
+
+
+# --- signer ----------------------------------------------------------------
+
+
+def test_signer_roundtrip():
+    signer = _Signer("secret")
+    assert signer.unsign(signer.sign(b"hello")) == b"hello"
+
+
+def test_signer_rejects_tampered_payload():
+    signer = _Signer("secret")
+    signed = signer.sign(b"hello")
+    value, sig = signed.rsplit(".", 1)
+    tampered = f"{value}x.{sig}"
+    assert signer.unsign(tampered) is None
+
+
+def test_signer_rejects_wrong_key():
+    signed = _Signer("key-a").sign(b"hello")
+    assert _Signer("key-b").unsign(signed) is None
+
+
+def test_signer_rejects_garbage():
+    assert _Signer("k").unsign("not-a-signed-value") is None
+
+
+# --- Session ---------------------------------------------------------------
+
+
+def test_session_starts_unmodified():
+    assert Session().modified is False
+    assert Session({"a": 1}).modified is False
+
+
+def test_session_mutation_marks_modified():
+    s = Session()
+    s["a"] = 1
+    assert s.modified is True
+
+
+def test_session_delete_marks_modified():
+    s = Session({"a": 1})
+    del s["a"]
+    assert s.modified is True
+
+
+def test_session_behaves_like_dict():
+    s = Session({"a": 1})
+    assert s["a"] == 1
+    assert s.get("missing", "default") == "default"
+    assert "a" in s
+    assert list(s) == ["a"]
+    assert len(s) == 1
+    assert dict(s) == {"a": 1}
+
+
+def test_session_update_and_pop_mark_modified():
+    s = Session({"a": 1})
+    s.update({"b": 2})
+    assert s["b"] == 2 and s.modified
+    s2 = Session({"a": 1})
+    assert s2.pop("a") == 1 and s2.modified
+
+
+def test_session_clear_marks_modified_only_when_nonempty():
+    empty = Session()
+    empty.clear()
+    assert empty.modified is False
+    full = Session({"a": 1})
+    full.clear()
+    assert full.modified is True and len(full) == 0
+
+
+# --- SessionManager serialization -----------------------------------------
+
+
+def test_manager_requires_secret_key():
+    with pytest.raises(ValueError):
+        SessionManager("")
+
+
+def test_manager_roundtrip_preserves_data_and_resets_modified():
+    manager = SessionManager("k")
+    loaded = manager.loads(manager.dumps(Session({"user": "alice", "n": 3})))
+    assert dict(loaded) == {"user": "alice", "n": 3}
+    assert loaded.modified is False
+
+
+def test_manager_rejects_tampered_cookie():
+    manager = SessionManager("k")
+    cookie = manager.dumps(Session({"admin": False}))
+    tampered = cookie[:-3] + ("aaa" if not cookie.endswith("aaa") else "bbb")
+    assert dict(manager.loads(tampered)) == {}
+
+
+def test_manager_rejects_cookie_signed_with_other_key():
+    foreign = SessionManager("other-key").dumps(Session({"admin": True}))
+    assert dict(SessionManager("k").loads(foreign)) == {}
+
+
+def test_manager_expired_session_is_empty():
+    manager = SessionManager("k", max_age=-1)  # exp = now - 1 -> already expired
+    assert dict(manager.loads(manager.dumps(Session({"a": 1})))) == {}
+
+
+def test_manager_no_expiry_when_max_age_none():
+    manager = SessionManager("k", max_age=None)
+    assert dict(manager.loads(manager.dumps(Session({"a": 1})))) == {"a": 1}
+
+
+def test_manager_non_serializable_raises():
+    with pytest.raises(TypeError):
+        SessionManager("k").dumps(Session({"bad": object()}))
+
+
+# --- request/response integration -----------------------------------------
+
+
+def test_read_cookie_parses_target_cookie():
+    request = _FakeRequest({"Cookie": "a=1; robyn_session=abc.def; b=2"})
+    assert _read_cookie(request, "robyn_session") == "abc.def"
+    assert _read_cookie(request, "missing") is None
+
+
+def test_read_cookie_no_header():
+    assert _read_cookie(_FakeRequest({}), "robyn_session") is None
+
+
+def test_load_reads_signed_cookie():
+    manager = SessionManager("k", cookie_name="robyn_session")
+    cookie = manager.dumps(Session({"x": 9}))
+    request = _FakeRequest({"Cookie": f"robyn_session={cookie}"})
+    assert dict(manager.load(request)) == {"x": 9}
+
+
+def test_load_missing_cookie_returns_empty_session():
+    assert dict(SessionManager("k").load(_FakeRequest({}))) == {}
+
+
+def test_save_skips_unmodified_session():
+    manager = SessionManager("k", cookie_name="robyn_session")
+    response = _FakeResponse()
+    manager.save(manager.load(_FakeRequest({})), response)
+    assert response.cookies == {}
+
+
+def test_save_writes_signed_cookie_when_modified():
+    manager = SessionManager("k", cookie_name="robyn_session")
+    response = _FakeResponse()
+    session = Session()
+    session["user"] = "bob"
+    manager.save(session, response)
+    assert "robyn_session" in response.cookies
+    value, kwargs = response.cookies["robyn_session"]
+    # round-trips back through the manager
+    assert dict(manager.loads(value)) == {"user": "bob"}
+    assert kwargs["http_only"] is True
+
+
+def test_save_emptied_session_expires_cookie():
+    manager = SessionManager("k", cookie_name="robyn_session")
+    response = _FakeResponse()
+    session = Session({"a": 1})
+    session.clear()
+    manager.save(session, response)
+    value, kwargs = response.cookies["robyn_session"]
+    assert value == "" and kwargs["max_age"] == 0
+
+
+# --- same_site validation --------------------------------------------------
+
+
+@pytest.mark.parametrize("value,expected", [("lax", "Lax"), ("STRICT", "Strict"), ("none", "None")])
+def test_same_site_is_normalized(value, expected):
+    assert SessionManager("k", same_site=value).same_site == expected
+
+
+def test_invalid_same_site_raises():
+    with pytest.raises(ValueError):
+        SessionManager("k", same_site="bogus")
+
+
+# --- request.session attribute (real Rust Request) -------------------------
+
+
+def _make_request(headers: dict):
+    return Request(QueryParams(), Headers(headers), {}, "", "GET", Url("http", "testhost", "/"), {}, {}, None, None)
+
+
+def test_request_session_attribute_defaults_to_none():
+    assert _make_request({}).session is None
+
+
+def test_request_session_roundtrips_through_manager():
+    manager = SessionManager("k", cookie_name="robyn_session")
+
+    # A handler would mutate request.session; emulate that here.
+    request = _make_request({})
+    request.session = Session({"n": 1})
+    request.session["n"] += 1  # in-place mutation on the shared object
+
+    response = _FakeResponse()
+    manager.save(request.session, response)
+    cookie_value = response.cookies["robyn_session"][0]
+
+    # A later request carrying that cookie loads the same data back.
+    next_request = _make_request({"Cookie": f"robyn_session={cookie_value}"})
+    assert dict(manager.load(next_request)) == {"n": 2}

--- a/unit_tests/test_sessions.py
+++ b/unit_tests/test_sessions.py
@@ -256,6 +256,16 @@ def test_non_numeric_exp_is_treated_as_invalid():
     assert dict(manager.loads(forged)) == {}
 
 
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+def test_non_finite_exp_is_treated_as_invalid(token):
+    # json.loads accepts NaN/Infinity as floats, and a plain ``exp < now``
+    # comparison never expires them — so a non-finite exp must be rejected
+    # rather than trusted as a never-expiring session.
+    manager = SessionManager("k")
+    forged = manager._signer.sign(('{"d":{"a":1},"exp":%s}' % token).encode("utf-8"))
+    assert dict(manager.loads(forged)) == {}
+
+
 # --- request.session attribute (real Rust Request) -------------------------
 
 

--- a/unit_tests/test_sessions.py
+++ b/unit_tests/test_sessions.py
@@ -200,12 +200,60 @@ def test_save_emptied_session_expires_cookie():
 
 @pytest.mark.parametrize("value,expected", [("lax", "Lax"), ("STRICT", "Strict"), ("none", "None")])
 def test_same_site_is_normalized(value, expected):
-    assert SessionManager("k", same_site=value).same_site == expected
+    # secure=True so the SameSite=None case is accepted (see guard below).
+    assert SessionManager("k", same_site=value, secure=True).same_site == expected
 
 
 def test_invalid_same_site_raises():
     with pytest.raises(ValueError):
         SessionManager("k", same_site="bogus")
+
+
+def test_same_site_none_requires_secure():
+    with pytest.raises(ValueError):
+        SessionManager("k", same_site="None")  # secure defaults to False
+    # Allowed when secure=True.
+    assert SessionManager("k", same_site="None", secure=True).same_site == "None"
+
+
+# --- change detection: nested mutations & exp guard ------------------------
+
+
+def test_unmodified_session_is_not_modified():
+    assert SessionManager("k").loads(SessionManager("k").dumps(Session({"a": 1}))).is_modified() is False
+
+
+def test_nested_mutation_is_detected():
+    session = Session({"items": [1]})
+    assert session.is_modified() is False
+    session["items"].append(2)  # bypasses __setitem__, modified flag stays False
+    assert session.modified is False
+    assert session.is_modified() is True
+
+
+def test_nested_mutation_triggers_save():
+    manager = SessionManager("k", cookie_name="robyn_session")
+    session = Session({"items": [1]})
+    session["items"].append(2)
+    response = _FakeResponse()
+    manager.save(session, response)
+    assert "robyn_session" in response.cookies
+    assert dict(manager.loads(response.cookies["robyn_session"][0])) == {"items": [1, 2]}
+
+
+def test_key_reorder_is_not_a_false_positive():
+    session = Session({"a": 1, "b": 2})
+    # Rebuilding the same data in a different order must not count as a change.
+    session._data = {"b": 2, "a": 1}
+    assert session.is_modified() is False
+
+
+def test_non_numeric_exp_is_treated_as_invalid():
+    import json
+
+    manager = SessionManager("k")
+    forged = manager._signer.sign(json.dumps({"d": {"a": 1}, "exp": "whenever"}).encode("utf-8"))
+    assert dict(manager.loads(forged)) == {}
 
 
 # --- request.session attribute (real Rust Request) -------------------------


### PR DESCRIPTION
## What

Adds **HTTP sessions** to Robyn — the one item from the "Missing Features" wishlist (#1165) that genuinely did not exist. (Input validation, data serialization, and authentication already ship via the Pydantic integration, orjson, and `AuthenticationHandler`.)

The session is a dict-like object stored entirely client-side in a tamper-proof **signed cookie** (HMAC-SHA256 over a base64url JSON payload), so there is no server-side store to run. It is accessed via **`request.session`**, mirroring Robyn's existing `request.identity`:

```python
app.configure_sessions(secret_key="keep-me-secret")

@app.get("/visits")
def visits(request):
    request.session["count"] = request.session.get("count", 0) + 1
    return f"You have visited {request.session['count']} times"
```

## How it works

- **`src/types/request.rs`** — adds a `session` field to `Request`/`PyRequest`, exactly mirroring `identity`. It carries the Python `Session` object **by reference** across `before_request → handler → after_request`, so in-handler mutations are visible when the cookie is written back. This works on **every supported Python version** (no `contextvars` dependency).
- **`robyn/session.py`** — `Session` (a `MutableMapping` that tracks whether it was modified), a stdlib HMAC signer, and `SessionManager` (load/save + serialize/verify with expiry).
- **`Robyn.configure_sessions()`** registers a global `before_request` that loads + verifies the cookie into `request.session`, and a global `after_request` that signs and writes it back **only when modified** (read-only requests send no `Set-Cookie`).

## Behaviour / safety

- Cookie is `HttpOnly` + `SameSite=Lax` by default; all attributes (`secure`, `max_age`, `path`, `domain`, `same_site`, `cookie_name`) are configurable.
- Clearing the session expires the cookie in the browser.
- Tampered, expired, or foreign-key-signed cookies decode to an **empty** session (never an error, never trusted).
- The payload is signed, **not encrypted** — documented clearly; don't store secrets in it.

## Tests

- **30 unit tests** (`unit_tests/test_sessions.py`): signing round-trip/tamper/wrong-key, `Session` dict semantics + modified-tracking, serialization, expiry, cookie read/write, `same_site` normalization, and a real `request.session` round-trip.
- **6 integration tests** (`integration_tests/test_sessions.py`): cross-request persistence, per-client isolation, `HttpOnly`, tamper rejection, clear/logout.

`ruff check`, `ruff format`, standalone `isort`, and `cargo fmt --check` all clean. Regression-swept auth/identity, middlewares, cookies, multipart, and direct `Request(...)` construction (65 tests) — green.

## Docs

New **Sessions** page under API Reference plus a nav entry.

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added signed-cookie session support via `configure_sessions()`.
  * Exposed sessions to request handlers via `request.session`, persisting across requests when modified.
  * Session cookies are created with secure defaults (including `HttpOnly`) and configurable cookie settings.

* **Documentation**
  * Added a new “Sessions” API reference page and updated documentation navigation.

* **Tests**
  * Added unit and integration tests covering persistence, per-client behavior, cookie flags, tamper detection, expiration, and clearing sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->