### PR TITLE
fix(streaming): support bytes chunks + fix async DB access in generators (#1236, #1219)

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/server_sent_events.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/server_sent_events.mdx
@@ -189,6 +189,68 @@ async def stream_api_events(request):
 
 ---
 
+## Streaming raw bytes (binary data & file downloads)
+
+Not everything Batman streams is an SSE event. To stream **arbitrary bytes** — a large file, a generated archive, an `application/octet-stream` body — he uses `StreamingResponse` directly and yields chunks, without loading the whole payload into memory. Each chunk may be `bytes` (sent as-is) or `str` (UTF-8 encoded).
+
+<Row>
+<Col>
+A sync generator yielding `bytes` chunks, served as a binary download:
+</Col>
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/download">
+
+```python
+from robyn import Robyn, StreamingResponse, Headers
+
+app = Robyn(__file__)
+
+@app.get("/download")
+def download(request):
+    def file_chunks():
+        with open("large_file.bin", "rb") as f:
+            while chunk := f.read(8192):
+                yield chunk  # each chunk is `bytes`
+
+    return StreamingResponse(
+        file_chunks(),
+        media_type="application/octet-stream",
+        headers=Headers({
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": "attachment; filename=large_file.bin",
+        }),
+    )
+```
+
+</CodeGroup>
+</Col>
+</Row>
+
+<Row>
+<Col>
+`StreamingResponse` accepts both sync and async generators. When you use an **async generator**, it runs on the same event loop as your handler, so you can safely `await` async resources — an async database session, an HTTP client — **inside** the generator:
+</Col>
+<Col sticky>
+<CodeGroup title="Request" tag="GET" label="/export">
+
+```python
+@app.get("/export")
+async def export(request):
+    async def rows():
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(select(Record))  # await works here
+            for row in result.scalars():
+                yield f"{row.id},{row.name}\n".encode()
+
+    return StreamingResponse(rows(), media_type="text/csv")
+```
+
+</CodeGroup>
+</Col>
+</Row>
+
+---
+
 ## What's next?
 
 Batman has mastered Server-Sent Events and can now stream real-time updates to his crime dashboard. While SSE is perfect for one-way communication from server to client, Batman realizes he needs bidirectional communication for more interactive features like real-time chat with his allies.

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from typing import TypedDict
 
 from integration_tests.subroutes import async_auth_subrouter, di_subrouter, inherited_auth_subrouter, static_router, sub_router
-from robyn import Headers, Request, Response, Robyn, SSEMessage, SSEResponse, WebSocketDisconnect, jsonify, serve_file, serve_html
+from robyn import Headers, Request, Response, Robyn, SSEMessage, SSEResponse, StreamingResponse, WebSocketDisconnect, jsonify, serve_file, serve_html
 from robyn.authentication import AuthenticationHandler, BearerGetter, Identity
 from robyn.robyn import QueryParams, Url
 from robyn.templating import JinjaTemplate
@@ -1557,6 +1557,37 @@ async def sse_async(request):
             yield SSEMessage(f"Async message {i}", event="async", id=str(i))
 
     return SSEResponse(async_event_generator())
+
+
+@app.get("/stream/bytes")
+def stream_bytes(request):
+    """Stream raw binary chunks (sync generator) — regression test for #1236."""
+
+    def gen():
+        for i in range(3):
+            yield bytes([i]) * 4  # 4 bytes per chunk
+
+    return StreamingResponse(
+        gen(),
+        media_type="application/octet-stream",
+        headers=Headers({"Content-Type": "application/octet-stream"}),
+    )
+
+
+@app.get("/stream/bytes_async")
+async def stream_bytes_async(request):
+    """Stream raw binary chunks from an async generator (#1236 + #1219)."""
+
+    async def gen():
+        for i in range(3):
+            await asyncio.sleep(0)  # exercise the async driver
+            yield bytes([i]) * 4
+
+    return StreamingResponse(
+        gen(),
+        media_type="application/octet-stream",
+        headers=Headers({"Content-Type": "application/octet-stream"}),
+    )
 
 
 @app.get("/sse/streaming_sync")

--- a/integration_tests/test_binary_streaming.py
+++ b/integration_tests/test_binary_streaming.py
@@ -1,0 +1,21 @@
+import requests
+
+BASE_URL = "http://127.0.0.1:8080"
+TIMEOUT = 5
+
+EXPECTED = bytes([0]) * 4 + bytes([1]) * 4 + bytes([2]) * 4
+
+
+def test_stream_bytes_sync(session):
+    """A sync generator yielding bytes streams binary data unchanged (#1236)."""
+    r = requests.get(f"{BASE_URL}/stream/bytes", timeout=TIMEOUT)
+    assert r.status_code == 200
+    assert r.headers.get("Content-Type") == "application/octet-stream"
+    assert r.content == EXPECTED
+
+
+def test_stream_bytes_async(session):
+    """An async generator yielding bytes also streams correctly (#1236 + #1219)."""
+    r = requests.get(f"{BASE_URL}/stream/bytes_async", timeout=TIMEOUT)
+    assert r.status_code == 200
+    assert r.content == EXPECTED

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -1,7 +1,8 @@
 import asyncio
 import mimetypes
 import os
-from typing import AsyncGenerator, Generator
+import threading
+from typing import AsyncGenerator, Generator, Optional, Union
 
 from robyn.robyn import Headers, Response
 
@@ -63,13 +64,40 @@ def serve_file(file_path: str, file_name: str | None = None) -> FileResponse:
 
 
 class AsyncGeneratorWrapper:
-    """Optimized true-streaming wrapper for async generators"""
+    """Drive an async generator through Robyn's synchronous streaming protocol.
 
-    def __init__(self, async_gen: AsyncGenerator[str, None]):
-        self.async_gen = async_gen
-        self._loop = None
-        self._iterator = None
+    The generator is driven on the event loop that was running when the
+    ``StreamingResponse`` was constructed — i.e. the handler's loop. That keeps
+    any async resources created in the handler (DB sessions, HTTP clients) on
+    the loop they are bound to, so ``await``-ing them inside the generator works
+    instead of raising "attached to a different loop" (#1219). When constructed
+    outside an async context (a sync handler), a dedicated background loop is
+    used instead.
+
+    Errors raised by the generator are propagated (not swallowed), so a failing
+    stream surfaces the real traceback in the server logs rather than silently
+    truncating.
+    """
+
+    def __init__(self, async_gen: AsyncGenerator[Union[str, bytes], None]):
+        self._async_gen = async_gen
+        self._iterator: Optional[AsyncGenerator] = None
         self._exhausted = False
+        self._owns_loop = False
+        self._thread: Optional[threading.Thread] = None
+        try:
+            # Constructed inside an async handler -> reuse its running loop.
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Constructed in a sync handler -> drive on a dedicated background loop.
+            self._loop = asyncio.new_event_loop()
+            self._owns_loop = True
+            self._thread = threading.Thread(target=self._run_loop, daemon=True)
+            self._thread.start()
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
 
     def __iter__(self):
         return self
@@ -78,53 +106,33 @@ class AsyncGeneratorWrapper:
         if self._exhausted:
             raise StopIteration
 
-        # Initialize the loop and iterator only once
         if self._iterator is None:
-            self._init_async_iterator()
+            self._iterator = self._async_gen.__aiter__()
 
+        # Schedule one step on the owning loop and block until it yields a value.
+        # run_coroutine_threadsafe is safe to call from the worker thread Robyn
+        # drives the stream on, and works whether or not we own the loop.
+        future = asyncio.run_coroutine_threadsafe(self._iterator.__anext__(), self._loop)
         try:
-            # Get the next value from the async generator
-            # This is the key optimization - we don't buffer, we get one value at a time
-            return self._get_next_value()
-        except StopIteration:
-            self._exhausted = True
+            return future.result()
+        except StopAsyncIteration:
+            self._finish()
+            raise StopIteration
+        except BaseException:
+            # Surface real errors instead of silently ending the stream.
+            self._finish()
             raise
 
-    def _init_async_iterator(self):
-        """Initialize the async iterator with proper loop handling"""
-        try:
-            # Try to get the running event loop
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # No running loop, create a new one
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-
-        # Create the async iterator
-        self._iterator = self.async_gen.__aiter__()
-
-    def _get_next_value(self):
-        """Get the next value from async generator without buffering"""
-        try:
-            # Create a coroutine to get the next value
-            async def get_next():
-                return await self._iterator.__anext__()
-
-            # Run the coroutine to get the next value
-            return self._loop.run_until_complete(get_next())
-        except StopAsyncIteration:
-            # Convert StopAsyncIteration to StopIteration for sync generator protocol
-            raise StopIteration
-        except Exception as e:
-            # Log error and stop iteration
-            print(f"Error in async generator: {e}")
-            raise StopIteration
+    def _finish(self):
+        self._exhausted = True
+        if self._owns_loop:
+            self._loop.call_soon_threadsafe(self._loop.stop)
 
 
 class StreamingResponse:
     def __init__(
         self,
-        content: Generator[str, None, None] | AsyncGenerator[str, None],
+        content: Generator[str | bytes, None, None] | AsyncGenerator[str | bytes, None],
         status_code: int | None = None,
         headers: Headers | None = None,
         media_type: str = "text/event-stream",
@@ -149,7 +157,7 @@ class StreamingResponse:
 
 
 def SSEResponse(
-    content: Generator[str, None, None] | AsyncGenerator[str, None],
+    content: Generator[str | bytes, None, None] | AsyncGenerator[str | bytes, None],
     status_code: int | None = None,
     headers: Headers | None = None,
 ) -> StreamingResponse:

--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -2,6 +2,7 @@ import asyncio
 import mimetypes
 import os
 import threading
+import weakref
 from typing import AsyncGenerator, Generator, Optional, Union
 
 from robyn.robyn import Headers, Response
@@ -85,19 +86,36 @@ class AsyncGeneratorWrapper:
         self._exhausted = False
         self._owns_loop = False
         self._thread: Optional[threading.Thread] = None
+        self._finalizer: Optional[weakref.finalize] = None
         try:
             # Constructed inside an async handler -> reuse its running loop.
             self._loop = asyncio.get_running_loop()
         except RuntimeError:
-            # Constructed in a sync handler -> drive on a dedicated background loop.
+            # Constructed in a sync handler -> drive on a dedicated background
+            # loop. The thread target and finalizer must NOT capture ``self``, or
+            # the running thread would keep the wrapper alive forever and the
+            # finalizer could never fire.
             self._loop = asyncio.new_event_loop()
             self._owns_loop = True
-            self._thread = threading.Thread(target=self._run_loop, daemon=True)
+            self._thread = threading.Thread(target=self._run_loop, args=(self._loop,), daemon=True)
             self._thread.start()
+            # Guarantee the background loop is stopped even if iteration ends
+            # early (client disconnect, unsupported chunk type) and _finish() is
+            # never reached — otherwise the daemon loop thread would leak.
+            self._finalizer = weakref.finalize(self, self._stop_loop, self._loop)
 
-    def _run_loop(self):
-        asyncio.set_event_loop(self._loop)
-        self._loop.run_forever()
+    @staticmethod
+    def _run_loop(loop):
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    @staticmethod
+    def _stop_loop(loop):
+        if not loop.is_closed():
+            loop.call_soon_threadsafe(loop.stop)
 
     def __iter__(self):
         return self
@@ -125,8 +143,10 @@ class AsyncGeneratorWrapper:
 
     def _finish(self):
         self._exhausted = True
-        if self._owns_loop:
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._finalizer is not None:
+            # Stops the background loop now; idempotent and also runs on GC if
+            # the stream is dropped before exhaustion.
+            self._finalizer()
 
 
 class StreamingResponse:

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -129,7 +129,20 @@ fn create_python_stream(
                 let gen = generator.bind(py);
 
                 match gen.call_method0("__next__") {
-                    Ok(value) => value.extract::<String>().ok().map(|s| (s, generator)),
+                    Ok(value) => {
+                        // Accept both `bytes` (used as-is) and `str` (UTF-8 encoded)
+                        // chunks, so binary streaming works too (#1236).
+                        if let Ok(py_bytes) = value.downcast::<PyBytes>() {
+                            Some((py_bytes.as_bytes().to_vec(), generator))
+                        } else if let Ok(s) = value.extract::<String>() {
+                            Some((s.into_bytes(), generator))
+                        } else {
+                            log::error!(
+                                "StreamingResponse generator yielded a value that is neither str nor bytes; ending stream"
+                            );
+                            None
+                        }
+                    }
                     Err(e) => {
                         if !e.is_instance_of::<pyo3::exceptions::PyStopIteration>(py) {
                             log::error!("Generator error: {}", e);
@@ -141,7 +154,7 @@ fn create_python_stream(
         })
         .await
         {
-            Ok(Some((string_value, generator))) => Some((Ok(Bytes::from(string_value)), generator)),
+            Ok(Some((bytes_value, generator))) => Some((Ok(Bytes::from(bytes_value)), generator)),
             _ => None,
         }
     }))

--- a/unit_tests/test_streaming_response.py
+++ b/unit_tests/test_streaming_response.py
@@ -70,3 +70,26 @@ def test_wrapper_supports_bytes_chunks():
 
     wrapper = AsyncGeneratorWrapper(gen())
     assert list(wrapper) == [b"\x00\x01", b"\x02"]
+
+
+def test_owned_loop_thread_is_cleaned_up_when_dropped_early():
+    """The background loop thread must not leak if the stream is abandoned
+    before exhaustion (e.g. a client disconnect)."""
+    import gc
+
+    async def gen():
+        yield "a"
+        yield "b"
+        yield "c"
+
+    wrapper = AsyncGeneratorWrapper(gen())  # sync context -> owns a background loop
+    assert wrapper._owns_loop is True
+    thread = wrapper._thread
+    assert thread.is_alive()
+
+    assert next(wrapper) == "a"  # consume one chunk, then abandon the rest
+    del wrapper
+    gc.collect()
+
+    thread.join(timeout=3)
+    assert not thread.is_alive()

--- a/unit_tests/test_streaming_response.py
+++ b/unit_tests/test_streaming_response.py
@@ -1,0 +1,72 @@
+import asyncio
+
+import pytest
+
+from robyn.responses import AsyncGeneratorWrapper
+
+
+def test_wrapper_drives_generator_on_constructing_loop():
+    """The async generator must run on the loop that was active at construction
+    (the handler's loop), so async resources bound to it work (#1219)."""
+    captured = {}
+
+    async def gen():
+        captured["loop"] = asyncio.get_running_loop()
+        yield "a"
+        yield "b"
+
+    async def main():
+        wrapper = AsyncGeneratorWrapper(gen())  # constructed on THIS loop
+        # Robyn drives __next__ from a worker thread, not the loop thread.
+        chunks = await asyncio.to_thread(lambda: list(wrapper))
+        return chunks, asyncio.get_running_loop()
+
+    chunks, handler_loop = asyncio.run(main())
+    assert chunks == ["a", "b"]
+    assert captured["loop"] is handler_loop
+
+
+def test_wrapper_propagates_generator_errors():
+    """Errors inside the generator are raised, not silently swallowed."""
+
+    async def gen():
+        yield "ok"
+        raise ValueError("boom")
+
+    async def main():
+        wrapper = AsyncGeneratorWrapper(gen())
+
+        def drive():
+            collected = []
+            with pytest.raises(ValueError, match="boom"):
+                for chunk in wrapper:
+                    collected.append(chunk)
+            return collected
+
+        return await asyncio.to_thread(drive)
+
+    assert asyncio.run(main()) == ["ok"]
+
+
+def test_wrapper_without_running_loop_uses_background_loop():
+    """When constructed outside an async context (sync handler), the wrapper
+    runs the generator on its own background loop."""
+
+    async def gen():
+        yield "x"
+        yield "y"
+
+    wrapper = AsyncGeneratorWrapper(gen())  # no running loop here
+    assert wrapper._owns_loop is True
+    assert list(wrapper) == ["x", "y"]
+
+
+def test_wrapper_supports_bytes_chunks():
+    """The wrapper passes bytes chunks through unchanged (Rust encodes them)."""
+
+    async def gen():
+        yield b"\x00\x01"
+        yield b"\x02"
+
+    wrapper = AsyncGeneratorWrapper(gen())
+    assert list(wrapper) == [b"\x00\x01", b"\x02"]


### PR DESCRIPTION
Fixes two related `StreamingResponse` bugs that came out of user reports.

## #1236 — yielding `bytes` crashed

Streaming binary data (`yield b"..."`) raised `'bytes' object cannot be converted to 'PyString'` because the Rust stream driver only extracted `str`. It now downcasts `PyBytes` first (used as-is) and falls back to UTF-8-encoding `str`, so file downloads / `application/octet-stream` work. A value that's neither `str` nor `bytes` is logged and ends the stream instead of being silently dropped.

```python
@app.get("/download")
def download(request):
    def gen():
        with open(path, "rb") as f:
            while chunk := f.read(8192):
                yield chunk
    return StreamingResponse(gen(), media_type="application/octet-stream")
```

## #1219 — awaiting async DB inside a generator crashed

`await session.execute(...)` (async SQLAlchemy) inside a streaming generator raised `Task ... attached to a different loop`. `AsyncGeneratorWrapper` drove the generator on a **freshly-created** event loop and **swallowed every error** (`print` + `raise StopIteration`), so the stream silently truncated.

It now drives the generator on the loop that was running when the `StreamingResponse` was constructed — i.e. the handler's loop, where the async resources are bound — via `run_coroutine_threadsafe`, falling back to a dedicated background loop only for sync handlers. Generator errors now propagate (and show up in the server logs) instead of disappearing.

## Tests

- **4 unit tests** (`unit_tests/test_streaming_response.py`): generator runs on the constructing loop, errors propagate, background-loop fallback for sync handlers, bytes pass-through.
- **2 integration tests** (`integration_tests/test_binary_streaming.py`): sync and async `bytes` streaming.
- Existing SSE suite still green (the wrapper rewrite doesn't regress async SSE).

`ruff` / `ruff format` / `isort` / `cargo fmt --check` all clean.

Supersedes #1308 (which fixed only the bytes case) — happy to close that in favour of this.

Closes #1236
Closes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming responses now support yielding raw `bytes` (including async streaming) for binary downloads.
  * Added binary streaming endpoints for both sync and async byte streams.
* **Documentation**
  * Updated Server-Sent Events docs with examples for streaming arbitrary raw bytes via `StreamingResponse`.
* **Bug Fixes**
  * Async streaming now propagates exceptions to the consumer instead of silently terminating.
* **Tests**
  * Added integration tests for sync/async byte streaming and unit tests covering async wrapper behavior and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->