### PR TITLE
ci(lint): don't build the Rust extension just to lint

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -31,6 +31,10 @@ jobs:
       run: |
         uv pip install ruff isort black
     - name: Run linters
+      # Invoke the tools directly rather than via `uv run`, which would sync the
+      # project and compile the Rust extension (maturin -> cargo) just to lint
+      # pure-Python source. That build is unnecessary for static analysis and
+      # makes linting fail on transient crates.io network errors.
       run: |
-        uv run ruff check .
-        uv run isort --check-only --diff .
+        ruff check .
+        isort --check-only --diff .


### PR DESCRIPTION
## Problem

The `Lint PR` job runs `uv run ruff check .`. Because `uv run` syncs the project first, it compiles the Rust extension (maturin → cargo, downloading actix and friends) **before** ruff even starts. Linting is pure-Python static analysis and never needs the compiled extension, so this build is wasted work — and it makes lint fail on transient `crates.io` network errors that have nothing to do with the code:

```
error: failed to get `actix_derive` as a dependency of package `actix v0.13.5`
  Caused by: download of ac/ti/actix_derive failed
  Caused by: curl failed
  Caused by: [16] Error in the HTTP2 framing layer
💥 maturin failed
```

## Fix

Invoke `ruff` / `isort` directly (they're already installed via `uv pip install` onto the system Python) instead of through `uv run`. Linting no longer triggers a project sync, so it doesn't need the Rust toolchain or the network, and is immune to crates.io flakes.

No change to what is linted: `ruff check .` and `isort --check-only --diff .` pass on the repo source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the linting workflow to improve reliability and reduce build time by invoking code quality checks directly, avoiding unnecessary compilation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->