### PR TITLE
fix: batch of quick-win issues (#1099, #1147, #1273, #495, #470, #1192)

### DIFF
--- a/docs_src/src/pages/documentation/en/example_app/modeling_routes.mdx
+++ b/docs_src/src/pages/documentation/en/example_app/modeling_routes.mdx
@@ -86,6 +86,8 @@ def delete_crime(db: Session, crime_id: int):
 
 Batman created various endpoints to manage crime data. These endpoints allowed the Gotham City Police Department to add, update, and retrieve crime data.
 
+> **A note on `def` vs `async def`.** The CRUD helpers above use **synchronous** SQLAlchemy, so the handlers below are deliberately plain `def` functions. Robyn runs synchronous handlers in a worker thread, which means a blocking database call there never stalls the event loop. If you would rather write `async def` handlers, pair them with an **async** database driver (for example SQLAlchemy's `asyncio` extension via `create_async_engine` and `await session.execute(...)`) so the database I/O is genuinely non-blocking. The one combination to avoid is a blocking, synchronous DB call inside an `async def` handler — that ties up the event loop for every other request.
+
 ```python {{ title: 'Setting up Routes' }}
 # __main__.py
 from robyn import Robyn
@@ -95,7 +97,7 @@ from sqlalchemy.orm import Session
 app = Robyn(__file__)
 
 @app.post("/crimes")
-async def add_crime(request):
+def add_crime(request):
     with SessionLocal() as db:
         crime = request.json()
         insertion = crud.create_crime(db, crime)
@@ -109,7 +111,7 @@ async def add_crime(request):
     }
 
 @app.get("/crimes")
-async def get_crimes(request):
+def get_crimes(request):
     with SessionLocal() as db:
         skip = request.query_params.get("skip", "0")
         limit = request.query_params.get("limit", "100")
@@ -118,7 +120,7 @@ async def get_crimes(request):
     return crimes
 
 @app.get("/crimes/:crime_id", auth_required=True)
-async def get_crime(request):
+def get_crime(request):
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:
         crime = crud.get_crime(db, crime_id=crime_id)
@@ -129,7 +131,7 @@ async def get_crime(request):
     return crime
 
 @app.put("/crimes/:crime_id")
-async def update_crime(request):
+def update_crime(request):
     crime = request.json()
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:
@@ -139,7 +141,7 @@ async def update_crime(request):
     return updated_crime
 
 @app.delete("/crimes/{crime_id}")
-async def delete_crime(request):
+def delete_crime(request):
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:
         success = crud.delete_crime(db, crime_id=crime_id)

--- a/docs_src/src/pages/documentation/en/example_app/modeling_routes.mdx
+++ b/docs_src/src/pages/documentation/en/example_app/modeling_routes.mdx
@@ -113,8 +113,8 @@ def add_crime(request):
 @app.get("/crimes")
 def get_crimes(request):
     with SessionLocal() as db:
-        skip = request.query_params.get("skip", "0")
-        limit = request.query_params.get("limit", "100")
+        skip = int(request.query_params.get("skip", "0"))
+        limit = int(request.query_params.get("limit", "100"))
         crimes = crud.get_crimes(db, skip=skip, limit=limit)
 
     return crimes
@@ -140,7 +140,7 @@ def update_crime(request):
         raise Exception("Crime not found")
     return updated_crime
 
-@app.delete("/crimes/{crime_id}")
+@app.delete("/crimes/:crime_id")
 def delete_crime(request):
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:

--- a/docs_src/src/pages/documentation/en/example_app/monitoring_and_logging.mdx
+++ b/docs_src/src/pages/documentation/en/example_app/monitoring_and_logging.mdx
@@ -1,20 +1,56 @@
 
 ## Monitoring and Logging
-To keep an eye on the performance of his application and troubleshoot issues, Batman decided to implement monitoring and logging. He used a third-party library to integrate logging middleware, enabling him to track requests, errors, and performance metrics.
+To keep an eye on the performance of his application and troubleshoot issues, Batman wanted a proper access log — one line per request showing the method, path, status code, and how long the request took.
 
-```python {{ title: 'Monitoring and Logging' }}
-from robyn import Logger
+Robyn builds on Python's standard `logging` module, so you can assemble a request/access log from two middlewares: a `before_request` hook that starts a timer, and an `after_request` hook that emits the log line once the response is ready. The `after_request` hook can receive **both** the `request` and the `response`, which is exactly what you need to log the path and the status code together. And because Robyn shares a `contextvars` context across the `before_request`, handler, and `after_request` hooks, a `ContextVar` is a tidy place to stash the start time.
 
-logger = Logger(app)
+```python {{ title: 'Request / access logging' }}
+import logging
+import time
+from contextvars import ContextVar
+
+from robyn import Request, Response
+
+# A dedicated logger for access logs. It inherits Robyn's logging configuration,
+# so keep the level at INFO or below (running with `--log-level WARN` would hide
+# these lines).
+logging.basicConfig(level=logging.INFO)
+access_logger = logging.getLogger("robyn.access")
+
+_request_start: ContextVar[float] = ContextVar("request_start")
+
 
 @app.before_request()
-async def log_request(request: Request):
-    logger.info(f"Received request: %s", request)
+def start_timer(request: Request):
+    _request_start.set(time.perf_counter())
+    return request
+
 
 @app.after_request()
-async def log_response(response: Response):
-    logger.info(f"Sending response: %s", response)
+def log_request(request: Request, response: Response):
+    start = _request_start.get(None)
+    duration_ms = (time.perf_counter() - start) * 1000 if start is not None else 0.0
+    access_logger.info(
+        "%s %s -> %s (%.2fms)",
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
 ```
+
+With those two hooks registered globally, every request produces a line such as:
+
+```text
+INFO:robyn.access:GET /crimes -> 200 (1.83ms)
+```
+
+A couple of things worth knowing:
+
+- The two-argument `after_request(request, response)` signature is what gives you access to the request alongside the response. If you only need the response, a single-argument `after_request(response)` works too — Robyn picks the calling convention based on your function's parameters.
+- `after_request` hooks always run, even when a `before_request` hook short-circuits the request, so your access log captures every response.
+- Prefer `%s`-style logging arguments (as above) over f-strings so the message is only formatted when the log level is actually enabled.
 
 With monitoring and logging in place, Batman could now easily detect issues and analyze the performance of his web application, ensuring that it was always running optimally and ready to assist him in his fight against crime.
 
@@ -27,5 +63,3 @@ With monitoring and logging in place, Batman could now easily detect issues and 
     children="Deploying the application"
   />
 </div>
-
-

--- a/docs_src/src/pages/documentation/zh/example_app/modeling_routes.mdx
+++ b/docs_src/src/pages/documentation/zh/example_app/modeling_routes.mdx
@@ -108,8 +108,8 @@ def add_crime(request):
 @app.get("/crimes")
 def get_crimes(request):
     with SessionLocal() as db:
-        skip = request.query_params.get("skip", "0")
-        limit = request.query_params.get("limit", "100")
+        skip = int(request.query_params.get("skip", "0"))
+        limit = int(request.query_params.get("limit", "100"))
         crimes = crud.get_crimes(db, skip=skip, limit=limit)
 
     return crimes
@@ -135,7 +135,7 @@ def update_crime(request):
         raise Exception("Crime not found")
     return updated_crime
 
-@app.delete("/crimes/{crime_id}")
+@app.delete("/crimes/:crime_id")
 def delete_crime(request):
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:

--- a/docs_src/src/pages/documentation/zh/example_app/modeling_routes.mdx
+++ b/docs_src/src/pages/documentation/zh/example_app/modeling_routes.mdx
@@ -81,6 +81,8 @@ def delete_crime(db: Session, crime_id: int):
 
 蝙蝠侠为管理犯罪数据创建了多个 API 接口。这些接口允许哥谭市警察局添加、更新和查询犯罪记录。
 
+> **关于 `def` 与 `async def`。** 上面的 CRUD 辅助函数使用的是**同步** SQLAlchemy，因此下面的处理器特意写成普通的 `def` 函数。Robyn 会在工作线程中运行同步处理器，这样其中的阻塞式数据库调用就不会阻塞事件循环。如果你更喜欢 `async def` 处理器，请搭配**异步**数据库驱动（例如 SQLAlchemy 的 `asyncio` 扩展，使用 `create_async_engine` 和 `await session.execute(...)`），让数据库 I/O 真正实现非阻塞。唯一要避免的组合，是在 `async def` 处理器中执行阻塞式的同步数据库调用——那会让事件循环为其他所有请求停滞。
+
 ```python {{ title: 'Setting up Routes' }}
 # __main__.py
 from robyn import Robyn
@@ -90,7 +92,7 @@ from sqlalchemy.orm import Session
 app = Robyn(__file__)
 
 @app.post("/crimes")
-async def add_crime(request):
+def add_crime(request):
     with SessionLocal() as db:
         crime = request.json()
         insertion = crud.create_crime(db, crime)
@@ -104,7 +106,7 @@ async def add_crime(request):
     }
 
 @app.get("/crimes")
-async def get_crimes(request):
+def get_crimes(request):
     with SessionLocal() as db:
         skip = request.query_params.get("skip", "0")
         limit = request.query_params.get("limit", "100")
@@ -113,7 +115,7 @@ async def get_crimes(request):
     return crimes
 
 @app.get("/crimes/:crime_id", auth_required=True)
-async def get_crime(request):
+def get_crime(request):
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:
         crime = crud.get_crime(db, crime_id=crime_id)
@@ -124,7 +126,7 @@ async def get_crime(request):
     return crime
 
 @app.put("/crimes/:crime_id")
-async def update_crime(request):
+def update_crime(request):
     crime = request.json()
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:
@@ -134,7 +136,7 @@ async def update_crime(request):
     return updated_crime
 
 @app.delete("/crimes/{crime_id}")
-async def delete_crime(request):
+def delete_crime(request):
     crime_id = int(request.path_params.get("crime_id"))
     with SessionLocal() as db:
         success = crud.delete_crime(db, crime_id=crime_id)

--- a/docs_src/src/pages/documentation/zh/example_app/monitoring_and_logging.mdx
+++ b/docs_src/src/pages/documentation/zh/example_app/monitoring_and_logging.mdx
@@ -1,20 +1,55 @@
 ## 监控和日志记录
 
-为了更好地监控应用程序的性能并及时解决潜在问题，蝙蝠侠决定实施全面的监控和日志记录机制。他通过集成第三方库来使用日志记录中间件，从而能够跟踪请求、错误和性能指标。
+为了更好地监控应用程序的性能并及时排查问题，蝙蝠侠希望拥有一份规范的访问日志——每个请求一行，记录请求方法、路径、状态码以及耗时。
 
-```python {{ title: '监控和日志记录' }}
-from robyn import Logger
+Robyn 构建在 Python 标准的 `logging` 模块之上，因此你可以用两个中间件来组装请求/访问日志：一个 `before_request` 钩子用于启动计时器，一个 `after_request` 钩子在响应就绪后输出日志行。`after_request` 钩子可以**同时**接收 `request` 和 `response`，这正是你同时记录路径与状态码所需要的。而且由于 Robyn 在 `before_request`、处理器和 `after_request` 钩子之间共享 `contextvars` 上下文，使用 `ContextVar` 来存放开始时间会非常整洁。
 
-logger = Logger(app)
+```python {{ title: '请求 / 访问日志' }}
+import logging
+import time
+from contextvars import ContextVar
+
+from robyn import Request, Response
+
+# 专用于访问日志的 logger。它会继承 Robyn 的日志配置，
+# 因此请将级别保持在 INFO 或更低（使用 `--log-level WARN` 运行会隐藏这些日志）。
+logging.basicConfig(level=logging.INFO)
+access_logger = logging.getLogger("robyn.access")
+
+_request_start: ContextVar[float] = ContextVar("request_start")
+
 
 @app.before_request()
-async def log_request(request: Request):
-    logger.info(f"Received request: %s", request)
+def start_timer(request: Request):
+    _request_start.set(time.perf_counter())
+    return request
+
 
 @app.after_request()
-async def log_response(response: Response):
-    logger.info(f"Sending response: %s", response)
+def log_request(request: Request, response: Response):
+    start = _request_start.get(None)
+    duration_ms = (time.perf_counter() - start) * 1000 if start is not None else 0.0
+    access_logger.info(
+        "%s %s -> %s (%.2fms)",
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
 ```
+
+将这两个钩子注册为全局钩子后，每个请求都会产生如下一行日志：
+
+```text
+INFO:robyn.access:GET /crimes -> 200 (1.83ms)
+```
+
+几点值得注意：
+
+- 双参数的 `after_request(request, response)` 签名让你能在拿到响应的同时访问请求。如果你只需要响应，单参数的 `after_request(response)` 同样可用——Robyn 会根据你的函数参数自动选择调用方式。
+- 即使某个 `before_request` 钩子提前返回了响应，`after_request` 钩子也始终会运行，因此你的访问日志能覆盖每一个响应。
+- 优先使用 `%s` 风格的日志参数（如上所示），而不是 f-string，这样只有在日志级别真正启用时才会进行字符串格式化。
 
 借助监控和日志记录功能，蝙蝠侠现在能够轻松检测应用程序中的问题，分析其性能表现，确保系统始终保持最佳状态，随时准备协助他打击犯罪。
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -746,10 +746,15 @@ def sync_multipart_file_save(request: Request):
 
     saved = {}
     for file_name, content in request.files.items():
-        destination = os.path.join(upload_dir, file_name)
+        # Never trust a client-supplied filename: strip any directory components
+        # so absolute paths or ".." segments can't escape upload_dir.
+        safe_name = os.path.basename(file_name)
+        if not safe_name or safe_name in (".", ".."):
+            continue
+        destination = os.path.join(upload_dir, safe_name)
         with open(destination, "wb") as saved_file:
             saved_file.write(content)
-        saved[file_name] = {"path": destination, "size": len(content)}
+        saved[safe_name] = {"path": destination, "size": len(content)}
 
     return saved
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import pathlib
+import tempfile
 import time
 from collections import defaultdict
 from typing import TypedDict
@@ -179,14 +180,31 @@ async def empty_websocket_on_close(websocket):
 
 # ===== Lifecycle handlers =====
 
+# Observable runtime markers so tests can assert the events actually fired
+# (#470), not merely that the handlers were registered.
+lifecycle_state = {"startup_completed": False}
+
 
 async def startup_handler():
+    lifecycle_state["startup_completed"] = True
     print("Starting up")
 
 
 @app.shutdown_handler
 def shutdown_handler():
+    # Write a marker on graceful shutdown so a test can confirm the event fired.
+    # The default integration harness stops the server with SIGKILL (which cannot
+    # be caught), so this only runs when the process is asked to stop gracefully.
+    marker = os.environ.get("ROBYN_SHUTDOWN_MARKER")
+    if marker:
+        with open(marker, "w") as marker_file:
+            marker_file.write("shut down")
     print("Shutting down")
+
+
+@app.get("/lifecycle/startup")
+def lifecycle_startup_status():
+    return {"startup_completed": lifecycle_state["startup_completed"]}
 
 
 # ===== Middlewares =====
@@ -716,6 +734,24 @@ def sync_multipart_file(request: Request):
     files = request.files
     file_names = files.keys()
     return {"file_names": list(file_names)}
+
+
+@app.post("/sync/multipart-file/save")
+def sync_multipart_file_save(request: Request):
+    # Persist every uploaded file to disk and report where it landed plus its
+    # size, so a test can read the saved bytes back and assert they round-trip
+    # intact (#495).
+    upload_dir = os.path.join(tempfile.gettempdir(), "robyn_upload_test")
+    os.makedirs(upload_dir, exist_ok=True)
+
+    saved = {}
+    for file_name, content in request.files.items():
+        destination = os.path.join(upload_dir, file_name)
+        with open(destination, "wb") as saved_file:
+            saved_file.write(content)
+        saved[file_name] = {"path": destination, "size": len(content)}
+
+    return saved
 
 
 # Queries

--- a/integration_tests/test_lifecycle_events.py
+++ b/integration_tests/test_lifecycle_events.py
@@ -1,0 +1,69 @@
+import os
+import pathlib
+import signal
+import tempfile
+import time
+
+import pytest
+import requests
+
+from integration_tests.conftest import kill_process, spawn_process
+from integration_tests.helpers.http_methods_helpers import get
+
+
+def test_startup_event_fires(session):
+    # The startup handler flips an in-process flag that this endpoint reports,
+    # proving the STARTUP event actually ran at runtime (not just that the
+    # handler was registered) (#470).
+    res = get("/lifecycle/startup")
+    assert res.json() == {"startup_completed": True}
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX signal-based graceful shutdown; Windows uses a different mechanism",
+)
+def test_shutdown_event_fires():
+    # The default test harness stops the server with SIGKILL (uncatchable), so we
+    # start a dedicated server here, ask it to stop gracefully with SIGINT, and
+    # assert the shutdown handler wrote its marker file (#470).
+    domain = "127.0.0.1"
+    port = 8082
+    marker_path = os.path.join(tempfile.gettempdir(), "robyn_shutdown_marker.txt")
+    if os.path.exists(marker_path):
+        os.remove(marker_path)
+
+    base_routes = os.path.join(pathlib.Path(__file__).parent.resolve(), "base_routes.py")
+    env = os.environ.copy()
+    env["ROBYN_HOST"] = domain
+    env["ROBYN_PORT"] = str(port)
+    env["ROBYN_SHUTDOWN_MARKER"] = marker_path
+
+    process = spawn_process(["python3", base_routes])
+    try:
+        # Wait until the server is accepting connections before signalling it.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            try:
+                requests.get(f"http://{domain}:{port}/lifecycle/startup", timeout=2)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise ConnectionError("server under shutdown test never came up")
+
+        os.killpg(os.getpgid(process.pid), signal.SIGINT)
+
+        # Give the graceful shutdown a moment to run the handler and exit.
+        for _ in range(30):
+            if os.path.exists(marker_path):
+                break
+            time.sleep(0.5)
+
+        assert os.path.exists(marker_path), "shutdown handler did not run on SIGINT"
+        with open(marker_path) as marker_file:
+            assert marker_file.read() == "shut down"
+    finally:
+        kill_process(process)
+        if os.path.exists(marker_path):
+            os.remove(marker_path)

--- a/integration_tests/test_lifecycle_events.py
+++ b/integration_tests/test_lifecycle_events.py
@@ -1,13 +1,14 @@
 import os
 import pathlib
 import signal
+import subprocess
 import tempfile
 import time
 
 import pytest
 import requests
 
-from integration_tests.conftest import kill_process, spawn_process
+from integration_tests.conftest import kill_process
 from integration_tests.helpers.http_methods_helpers import get
 
 
@@ -24,9 +25,9 @@ def test_startup_event_fires(session):
     reason="POSIX signal-based graceful shutdown; Windows uses a different mechanism",
 )
 def test_shutdown_event_fires():
-    # The default test harness stops the server with SIGKILL (uncatchable), so we
-    # start a dedicated server here, ask it to stop gracefully with SIGINT, and
-    # assert the shutdown handler wrote its marker file (#470).
+    # Start a dedicated server, ask it to stop gracefully with SIGINT, and assert
+    # the shutdown handler wrote its marker file (#470). The default harness stops
+    # servers with SIGKILL (uncatchable), so shutdown can only be observed here.
     domain = "127.0.0.1"
     port = 8082
     marker_path = os.path.join(tempfile.gettempdir(), "robyn_shutdown_marker.txt")
@@ -39,7 +40,9 @@ def test_shutdown_event_fires():
     env["ROBYN_PORT"] = str(port)
     env["ROBYN_SHUTDOWN_MARKER"] = marker_path
 
-    process = spawn_process(["python3", base_routes])
+    # Spawn directly (not via the conftest helper) so we can pass `env` and put the
+    # child in its own process group for a clean SIGINT.
+    process = subprocess.Popen(["python3", base_routes], env=env, preexec_fn=os.setsid)
     try:
         # Wait until the server is accepting connections before signalling it.
         deadline = time.time() + 15
@@ -55,7 +58,7 @@ def test_shutdown_event_fires():
         os.killpg(os.getpgid(process.pid), signal.SIGINT)
 
         # Give the graceful shutdown a moment to run the handler and exit.
-        for _ in range(30):
+        for _ in range(16):
             if os.path.exists(marker_path):
                 break
             time.sleep(0.5)

--- a/integration_tests/test_multipart_data.py
+++ b/integration_tests/test_multipart_data.py
@@ -2,6 +2,10 @@ import pytest
 
 from integration_tests.helpers.http_methods_helpers import multipart_post
 
+# Binary payload with bytes that are not valid UTF-8, to prove the upload is
+# saved verbatim rather than being mangled by text decoding (#495).
+UPLOAD_CONTENT = b"robyn binary upload \x00\x01\x02\xff\xfe contents"
+
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("function_type", ["sync"])
@@ -15,3 +19,16 @@ def test_form_data(function_type: str, session):
 def test_multipart_file(function_type: str, session):
     res = multipart_post(f"/{function_type}/multipart-file", files={"hello": "world"})
     assert "hello" in res.text
+
+
+def test_multipart_file_save(session):
+    # Upload a file, have the server persist it, then read the saved bytes back
+    # and assert they round-trip exactly (#495).
+    res = multipart_post("/sync/multipart-file/save", files={"report.bin": UPLOAD_CONTENT})
+
+    saved = res.json()
+    assert "report.bin" in saved
+    assert saved["report.bin"]["size"] == len(UPLOAD_CONTENT)
+
+    with open(saved["report.bin"]["path"], "rb") as saved_file:
+        assert saved_file.read() == UPLOAD_CONTENT

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -170,6 +170,36 @@ class QueryParams:
         """
         pass
 
+    def keys(self) -> list[str]:
+        """
+        Returns:
+            A list of all query parameter names.
+        """
+        pass
+
+    def values(self) -> list[str]:
+        """
+        Returns:
+            The last value of each query parameter (consistent with ``get``).
+        """
+        pass
+
+    def items(self) -> list[tuple[str, str]]:
+        """
+        Returns:
+            ``(key, value)`` pairs using the last value of each key (consistent
+            with ``get``), one pair per key.
+        """
+        pass
+
+    def multi_items(self) -> list[tuple[str, str]]:
+        """
+        Returns:
+            ``(key, value)`` pairs for every value, preserving duplicate keys
+            (e.g. ``?tag=a&tag=b`` -> ``[("tag", "a"), ("tag", "b")]``).
+        """
+        pass
+
     def __contains__(self, key: str) -> bool:
         pass
 
@@ -339,6 +369,36 @@ class Headers:
 
         Returns:
             dict[str, str]: All present headers as a flat dictionary.
+        """
+        pass
+
+    def keys(self) -> list[str]:
+        """
+        Returns:
+            A list of all header names.
+        """
+        pass
+
+    def values(self) -> list[str]:
+        """
+        Returns:
+            The last value of each header (consistent with ``get``).
+        """
+        pass
+
+    def items(self) -> list[tuple[str, str]]:
+        """
+        Returns:
+            ``(name, value)`` pairs using the last value of each header
+            (consistent with ``get``), one pair per header name.
+        """
+        pass
+
+    def multi_items(self) -> list[tuple[str, str]]:
+        """
+        Returns:
+            ``(name, value)`` pairs for every value, preserving headers that
+            appear more than once.
         """
         pass
 

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -326,6 +326,22 @@ class Headers:
         """
         pass
 
+    def to_dict(self) -> dict[str, str]:
+        """
+        Returns all headers as a flat dictionary mapping each header name to its
+        value. Headers that appear more than once have their values joined with
+        ", " (per RFC 7230).
+
+        This is handy when you want the regular ``dict`` ergonomics, e.g. supplying
+        a default for a missing header::
+
+            content_type = request.headers.to_dict().get("content-type", "text/plain")
+
+        Returns:
+            dict[str, str]: All present headers as a flat dictionary.
+        """
+        pass
+
     def populate_from_dict(self, headers: dict[str, str]) -> None:
         """
         Populates the headers from a dictionary.

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -106,6 +106,40 @@ impl Headers {
         dict.into()
     }
 
+    pub fn keys(&self, py: Python) -> Py<PyList> {
+        let keys: Vec<String> = self.headers.iter().map(|e| e.key().clone()).collect();
+        PyList::new(py, keys).expect("keys failed").into()
+    }
+
+    pub fn values(&self, py: Python) -> Py<PyList> {
+        // last value per header, consistent with get()
+        let values: Vec<String> = self
+            .headers
+            .iter()
+            .filter_map(|e| e.value().last().cloned())
+            .collect();
+        PyList::new(py, values).expect("values failed").into()
+    }
+
+    pub fn items(&self) -> Vec<(String, String)> {
+        // (name, last value) pairs, consistent with get()
+        self.headers
+            .iter()
+            .filter_map(|e| e.value().last().map(|v| (e.key().clone(), v.clone())))
+            .collect()
+    }
+
+    pub fn multi_items(&self) -> Vec<(String, String)> {
+        // (name, value) for every value, preserving duplicate header names
+        let mut items = Vec::new();
+        for entry in self.headers.iter() {
+            for value in entry.value() {
+                items.push((entry.key().clone(), value.clone()));
+            }
+        }
+        items
+    }
+
     pub fn contains(&self, key: String) -> bool {
         self.headers.contains_key(&key.to_lowercase())
     }

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -94,6 +94,18 @@ impl Headers {
         dict.into()
     }
 
+    pub fn to_dict(&self, py: Python) -> Py<PyDict> {
+        // return as a flat dict {key: value}; when a header appears multiple
+        // times its values are joined with ", " (per RFC 7230), mirroring the
+        // ergonomics of QueryParams.to_dict so callers can use `.get(key, default)`.
+        let dict = PyDict::new(py);
+        for iter in self.headers.iter() {
+            let (key, values) = iter.pair();
+            dict.set_item(key, values.join(", ")).unwrap();
+        }
+        dict.into()
+    }
+
     pub fn contains(&self, key: String) -> bool {
         self.headers.contains_key(&key.to_lowercase())
     }

--- a/src/types/multimap.rs
+++ b/src/types/multimap.rs
@@ -51,6 +51,37 @@ impl QueryParams {
         self.queries.get(&key).cloned()
     }
 
+    pub fn keys(&self) -> Vec<String> {
+        self.queries.keys().cloned().collect()
+    }
+
+    pub fn values(&self) -> Vec<String> {
+        // last value per key, consistent with get()
+        self.queries
+            .values()
+            .filter_map(|values| values.last().cloned())
+            .collect()
+    }
+
+    pub fn items(&self) -> Vec<(String, String)> {
+        // (key, last value) pairs, consistent with get()
+        self.queries
+            .iter()
+            .filter_map(|(key, values)| values.last().map(|v| (key.clone(), v.clone())))
+            .collect()
+    }
+
+    pub fn multi_items(&self) -> Vec<(String, String)> {
+        // (key, value) for every value, preserving duplicate keys
+        let mut items = Vec::new();
+        for (key, values) in self.queries.iter() {
+            for value in values {
+                items.push((key.clone(), value.clone()));
+            }
+        }
+        items
+    }
+
     pub fn extend(&mut self, other: &mut Self) {
         for (key, values) in other.queries.iter_mut() {
             for value in values.iter() {

--- a/unit_tests/test_headers.py
+++ b/unit_tests/test_headers.py
@@ -1,0 +1,32 @@
+from robyn.robyn import Headers
+
+
+def test_to_dict_returns_flat_dict():
+    headers = Headers({"Content-Type": "application/json"})
+    result = headers.to_dict()
+
+    assert isinstance(result, dict)
+    # keys are normalised to lowercase, like the rest of the Headers API
+    assert result["content-type"] == "application/json"
+
+
+def test_to_dict_joins_duplicate_values():
+    headers = Headers({"X-Forwarded-For": ["10.0.0.1", "10.0.0.2"]})
+    result = headers.to_dict()
+
+    assert result["x-forwarded-for"] == "10.0.0.1, 10.0.0.2"
+
+
+def test_to_dict_supports_get_with_default():
+    # The whole point of #1099: a real dict so callers can supply a default
+    # for a missing header instead of always getting None.
+    headers = Headers({"Content-Type": "application/json"})
+    result = headers.to_dict()
+
+    assert result.get("content-type", "text/plain") == "application/json"
+    assert result.get("x-missing", "fallback") == "fallback"
+
+
+def test_to_dict_empty_headers():
+    headers = Headers(None)
+    assert headers.to_dict() == {}

--- a/unit_tests/test_headers.py
+++ b/unit_tests/test_headers.py
@@ -1,4 +1,4 @@
-from robyn.robyn import Headers
+from robyn.robyn import Headers, QueryParams
 
 
 def test_to_dict_returns_flat_dict():
@@ -30,3 +30,50 @@ def test_to_dict_supports_get_with_default():
 def test_to_dict_empty_headers():
     headers = Headers(None)
     assert headers.to_dict() == {}
+
+
+# --- dict-like accessors (#1192) -------------------------------------------
+
+
+def test_headers_keys_values_items():
+    headers = Headers({"Content-Type": "application/json", "Accept": "text/html"})
+
+    assert sorted(headers.keys()) == ["accept", "content-type"]
+    assert sorted(headers.values()) == ["application/json", "text/html"]
+    assert sorted(headers.items()) == [
+        ("accept", "text/html"),
+        ("content-type", "application/json"),
+    ]
+
+
+def test_headers_items_use_last_value():
+    headers = Headers({"X-Trace": ["a", "b"]})
+    # keys()/values()/items() collapse to the last value, like get()
+    assert headers.get("X-Trace") == "b"
+    assert headers.items() == [("x-trace", "b")]
+    assert headers.values() == ["b"]
+
+
+def test_headers_multi_items_preserves_duplicates():
+    headers = Headers({"X-Trace": ["a", "b"]})
+    assert sorted(headers.multi_items()) == [("x-trace", "a"), ("x-trace", "b")]
+
+
+def test_query_params_keys_values_items():
+    params = QueryParams()
+    params.set("q", "robyn")
+    params.set("page", "1")
+
+    assert sorted(params.keys()) == ["page", "q"]
+    assert sorted(params.values()) == ["1", "robyn"]
+    assert sorted(params.items()) == [("page", "1"), ("q", "robyn")]
+
+
+def test_query_params_multi_items_preserves_duplicates():
+    params = QueryParams()
+    params.set("tag", "a")
+    params.set("tag", "b")
+
+    # items() collapses to the last value; multi_items() keeps every value
+    assert params.items() == [("tag", "b")]
+    assert sorted(params.multi_items()) == [("tag", "a"), ("tag", "b")]


### PR DESCRIPTION
Knocks out a batch of small, verified issues.

## Code
- **#1099** — `Headers.to_dict()` returns a flat `{name: value}` dict (duplicate values joined with `", "` per RFC 7230) so callers get normal dict ergonomics (`.get(key, default)`).
- **#1192** — dict-like accessors `keys()` / `values()` / `items()` / `multi_items()` on **QueryParams** and **Headers**. `keys/values/items` use last-value semantics (consistent with `get()`); `multi_items()` preserves duplicate keys (e.g. `?tag=a&tag=b`).

## Docs
- **#1147** — the example app called blocking sync SQLAlchemy inside `async def` handlers; switched them to `def` (Robyn runs sync handlers off the event loop) with a note on using an async driver if you prefer `async def`. (en + zh)
- **#1273** — the logging example used `Logger(app)`, which doesn't exist (`Logger.__init__` takes no args) — that's why request logs "didn't work". Replaced with a working access-log recipe using `before_request`/`after_request(request, response)` + a `ContextVar` timer. (en + zh)

## Tests
- **#495** — added a route that saves an uploaded file and a test asserting the saved bytes round-trip exactly (binary, non-UTF-8 payload).
- **#470** — added runtime lifecycle tests: `test_startup_event_fires` (asserts the startup event actually ran via an endpoint) and `test_shutdown_event_fires` (sends SIGINT to a dedicated server and asserts the shutdown handler ran).

All unit tests (9) and the new integration tests pass locally; `ruff`/`isort`/`ruff format`/`cargo fmt` clean.

Closes #1099
Closes #1147
Closes #1273
Closes #495
Closes #470
Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query-parameter and header accessor methods (`keys`, `values`, `items`, `multi_items`) for enumerating and handling duplicates
  * Added `Headers.to_dict()` for a flat header dictionary
  * Enhanced lifecycle visibility for startup/shutdown behavior
* **Documentation**
  * Updated CRUD route examples to prefer synchronous `def` with the shown SQLAlchemy approach
  * Rewrote monitoring/logging documentation with request/access logging middleware guidance
* **Tests**
  * Added unit tests for `Headers` and query/header accessor behaviors
  * Extended integration coverage for lifecycle events and multipart file saving
<!-- end of auto-generated comment: release notes by coderabbit.ai -->