### PR TITLE
feat(websockets): real binary frame support (#1148)

### DIFF
--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -154,6 +154,18 @@ def echo_websocket_on_close(websocket):
     return ""
 
 
+# --- WebSocket binary echo endpoint (#1148) ---
+@app.websocket("/web_socket_binary")
+async def binary_websocket_endpoint(websocket):
+    try:
+        while True:
+            data = await websocket.receive_bytes()
+            # Echo the raw bytes straight back as a binary frame.
+            await websocket.send_bytes(data)
+    except WebSocketDisconnect:
+        pass
+
+
 # --- WebSocket with empty returns ---
 @app.websocket("/web_socket_empty_returns")
 async def empty_websocket_endpoint(websocket):

--- a/integration_tests/test_web_sockets.py
+++ b/integration_tests/test_web_sockets.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from websocket import create_connection
+from websocket import ABNF, create_connection
 
 BASE_URL = "ws://127.0.0.1:8080"
 
@@ -103,3 +103,17 @@ def test_websocket_empty_returns(session):
     # We can verify this by closing the connection gracefully
     ws.close()
     # If we got here without exceptions, the test passed
+
+
+def test_websocket_binary_echo(session):
+    """Binary frames reach the handler as raw bytes and can be echoed back as a
+    binary frame, including arbitrary non-UTF-8 payloads (#1148)."""
+    ws = create_connection(f"{BASE_URL}/web_socket_binary")
+    try:
+        payload = b"\x00\x01\x02\xff\xfe robyn binary \x80\x81"
+        ws.send_binary(payload)
+        opcode, data = ws.recv_data()
+        assert opcode == ABNF.OPCODE_BINARY
+        assert data == payload
+    finally:
+        ws.close()

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -584,6 +584,40 @@ class WebSocketConnector:
             message (str): The message to send
         """
         pass
+    async def async_send_bytes_to(self, recipient_id: str, data: bytes) -> None:
+        """
+        Sends a binary frame to a specific client.
+
+        Args:
+            recipient_id (str): The id of the recipient
+            data (bytes): The binary payload to send
+        """
+        pass
+    def sync_send_bytes_to(self, recipient_id: str, data: bytes) -> None:
+        """
+        Sends a binary frame to a specific client.
+
+        Args:
+            recipient_id (str): The id of the recipient
+            data (bytes): The binary payload to send
+        """
+        pass
+    async def async_broadcast_bytes(self, data: bytes) -> None:
+        """
+        Broadcasts a binary frame to all clients.
+
+        Args:
+            data (bytes): The binary payload to broadcast
+        """
+        pass
+    def sync_broadcast_bytes(self, data: bytes) -> None:
+        """
+        Broadcasts a binary frame to all clients.
+
+        Args:
+            data (bytes): The binary payload to broadcast
+        """
+        pass
     def close(self) -> None:
         """
         Closes the connection.

--- a/robyn/ws.py
+++ b/robyn/ws.py
@@ -33,9 +33,9 @@ class WebSocketAdapter:
         self._connector = websocket_connector
         self._channel = channel
 
-    async def receive_text(self) -> str:
-        """Receive the next text message. Blocks until a message arrives.
-        Raises WebSocketDisconnect when the connection is closed."""
+    async def _receive(self):
+        """Receive the next raw message — ``str`` for text frames, ``bytes`` for
+        binary frames. Raises WebSocketDisconnect when the connection is closed."""
         if self._channel is None:
             raise WebSocketDisconnect(reason="No message channel available")
         result = await self._channel.receive()
@@ -43,32 +43,43 @@ class WebSocketAdapter:
             raise WebSocketDisconnect()
         return result
 
+    async def receive_text(self) -> str:
+        """Receive the next message as text. Blocks until a message arrives.
+        A binary frame is decoded as UTF-8. Raises WebSocketDisconnect when the
+        connection is closed."""
+        result = await self._receive()
+        return result if isinstance(result, str) else bytes(result).decode("utf-8")
+
     async def receive_bytes(self) -> bytes:
-        """Receive binary data (decoded from text)."""
-        text = await self.receive_text()
-        return text.encode("utf-8")
+        """Receive the next message as raw bytes. A text frame is encoded as
+        UTF-8. Raises WebSocketDisconnect when the connection is closed."""
+        result = await self._receive()
+        return result if isinstance(result, (bytes, bytearray)) else result.encode("utf-8")
 
     async def receive_json(self):
-        """Receive and decode JSON data.
+        """Receive and decode JSON data (from a text or binary frame).
         Raises WebSocketDisconnect when the connection is closed."""
-        text = await self.receive_text()
-        return orjson.loads(text)
+        return orjson.loads(await self._receive())
 
     async def send_text(self, data: str):
         """Send text data to this WebSocket client."""
         await self._connector.async_send_to(self._connector.id, data)
 
     async def send_bytes(self, data: bytes):
-        """Send binary data (as text) to this WebSocket client."""
-        await self._connector.async_send_to(self._connector.id, data.decode("utf-8"))
+        """Send a binary frame to this WebSocket client."""
+        await self._connector.async_send_bytes_to(self._connector.id, data)
 
     async def send_json(self, data):
         """Send JSON data to this WebSocket client."""
         await self.send_text(orjson.dumps(data).decode())
 
-    async def broadcast(self, data: str):
-        """Broadcast text data to all connected WebSocket clients on this endpoint."""
-        await self._connector.async_broadcast(data)
+    async def broadcast(self, data):
+        """Broadcast to all connected WebSocket clients on this endpoint.
+        ``bytes`` are sent as a binary frame, ``str`` as a text frame."""
+        if isinstance(data, (bytes, bytearray)):
+            await self._connector.async_broadcast_bytes(bytes(data))
+        else:
+            await self._connector.async_broadcast(data)
 
     async def close(self):
         """Close the WebSocket connection."""

--- a/src/websockets/mod.rs
+++ b/src/websockets/mod.rs
@@ -3,7 +3,7 @@ pub mod registry;
 use crate::executors::web_socket_executors::execute_ws_function;
 use crate::types::function_info::FunctionInfo;
 use crate::types::multimap::QueryParams;
-use registry::{Close, SendMessageToAll, SendText};
+use registry::{Close, SendBinary, SendBinaryToAll, SendMessageToAll, SendText};
 
 use actix::prelude::*;
 use actix::{Actor, AsyncContext, StreamHandler};
@@ -24,26 +24,40 @@ use crate::runtime;
 use registry::{Register, WebSocketRegistry};
 use std::collections::HashMap;
 
+/// A single WebSocket payload — UTF-8 text or raw binary bytes.
+pub enum WsPayload {
+    Text(String),
+    Binary(Vec<u8>),
+}
+
 /// A Rust-backed channel receiver exposed to Python.
 /// Python handlers call `await channel.receive()` to get the next message.
-/// Returns the message string, or None when the connection is closed.
+/// Returns a `str` for text frames, `bytes` for binary frames, or None when
+/// the connection is closed.
 #[pyclass]
 pub struct WebSocketChannel {
-    receiver: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<Option<String>>>>,
+    receiver: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<Option<WsPayload>>>>,
 }
 
 #[pymethods]
 impl WebSocketChannel {
     /// Await the next message from the WebSocket.
-    /// Returns the message string, or None if the connection was closed.
+    /// Returns a `str` (text frame) or `bytes` (binary frame), or None if the
+    /// connection was closed.
     fn receive<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let receiver = self.receiver.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let mut rx = receiver.lock().await;
-            match rx.recv().await {
-                Some(Some(msg)) => Ok(Some(msg)),
-                Some(None) | None => Ok(None),
-            }
+            let next = rx.recv().await;
+            Python::with_gil(|py| match next {
+                Some(Some(WsPayload::Text(text))) => {
+                    Ok(Some(text.into_pyobject(py)?.into_any().unbind()))
+                }
+                Some(Some(WsPayload::Binary(bytes))) => Ok(Some(
+                    pyo3::types::PyBytes::new(py, &bytes).into_any().unbind(),
+                )),
+                Some(None) | None => Ok(None::<Py<PyAny>>),
+            })
         })
     }
 }
@@ -57,7 +71,7 @@ pub struct WebSocketConnector {
     pub registry_addr: Addr<WebSocketRegistry>,
     pub query_params: QueryParams,
     /// Sender side of the message channel (stays in the Actix actor).
-    pub message_sender: Option<mpsc::UnboundedSender<Option<String>>>,
+    pub message_sender: Option<mpsc::UnboundedSender<Option<WsPayload>>>,
     /// Receiver side exposed to Python via WebSocketChannel.
     pub message_channel: Option<Py<WebSocketChannel>>,
 }
@@ -73,7 +87,7 @@ impl Actor for WebSocketConnector {
             addr: addr.clone(),
         });
 
-        let (tx, rx) = mpsc::unbounded_channel::<Option<String>>();
+        let (tx, rx) = mpsc::unbounded_channel::<Option<WsPayload>>();
         self.message_sender = Some(tx);
         self.message_channel = Python::with_gil(|py| {
             Some(
@@ -138,6 +152,16 @@ impl Handler<SendText> for WebSocketConnector {
     }
 }
 
+impl Handler<SendBinary> for WebSocketConnector {
+    type Result = ();
+
+    fn handle(&mut self, msg: SendBinary, ctx: &mut Self::Context) {
+        if self.id == msg.recipient_id {
+            ctx.binary(msg.data);
+        }
+    }
+}
+
 /// Handler for ws::Message message
 impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebSocketConnector {
     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
@@ -152,22 +176,15 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebSocketConnecto
             Ok(ws::Message::Text(text)) => {
                 debug!("Text message received {:?}", text);
                 if let Some(ref sender) = self.message_sender {
-                    let _ = sender.send(Some(text.to_string()));
+                    let _ = sender.send(Some(WsPayload::Text(text.to_string())));
                 }
             }
             Ok(ws::Message::Binary(bin)) => {
+                debug!("Binary message received ({} bytes)", bin.len());
                 if let Some(ref sender) = self.message_sender {
-                    match String::from_utf8(bin.to_vec()) {
-                        Ok(text) => {
-                            let _ = sender.send(Some(text));
-                        }
-                        Err(_) => {
-                            debug!("Received non-UTF-8 binary WebSocket frame, echoing back");
-                            ctx.binary(bin);
-                        }
-                    }
-                } else {
-                    ctx.binary(bin);
+                    // Forward the raw bytes to the Python handler as-is, so
+                    // arbitrary (non-UTF-8) binary frames are delivered intact.
+                    let _ = sender.send(Some(WsPayload::Binary(bin.to_vec())));
                 }
             }
             Ok(ws::Message::Close(_close_reason)) => {
@@ -255,6 +272,84 @@ impl WebSocketConnector {
             match registry.try_send(SendMessageToAll { message, sender_id }) {
                 Ok(_) => log::debug!("Broadcast sent successfully"),
                 Err(e) => log::error!("Failed to broadcast message: {}", e),
+            }
+            Ok(())
+        })?;
+
+        Ok(awaitable.into_pyobject(py)?.into_any().into())
+    }
+
+    pub fn sync_send_bytes_to(&self, recipient_id: String, data: Vec<u8>) {
+        let recipient_id = match Uuid::parse_str(&recipient_id) {
+            Ok(id) => id,
+            Err(e) => {
+                log::error!("Invalid recipient_id '{}': {}", recipient_id, e);
+                return;
+            }
+        };
+
+        match self.registry_addr.try_send(SendBinary {
+            data,
+            sender_id: self.id,
+            recipient_id,
+        }) {
+            Ok(_) => log::debug!("Binary message sent successfully"),
+            Err(e) => log::error!("Failed to send binary message: {}", e),
+        }
+    }
+
+    pub fn async_send_bytes_to(
+        &self,
+        py: Python,
+        recipient_id: String,
+        data: Vec<u8>,
+    ) -> PyResult<Py<PyAny>> {
+        let registry = self.registry_addr.clone();
+        let recipient_id = match Uuid::parse_str(&recipient_id) {
+            Ok(id) => id,
+            Err(e) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Invalid recipient_id '{}': {}",
+                    recipient_id, e
+                )));
+            }
+        };
+        let sender_id = self.id;
+
+        let awaitable = runtime::future_into_py(py, async move {
+            match registry.try_send(SendBinary {
+                data,
+                sender_id,
+                recipient_id,
+            }) {
+                Ok(_) => log::debug!("Binary message sent successfully"),
+                Err(e) => log::error!("Failed to send binary message: {}", e),
+            }
+            Ok(())
+        })?;
+
+        Ok(awaitable.into_pyobject(py)?.into_any().into())
+    }
+
+    pub fn sync_broadcast_bytes(&self, data: Vec<u8>) {
+        let registry = self.registry_addr.clone();
+        match registry.try_send(SendBinaryToAll {
+            data,
+            sender_id: self.id,
+        }) {
+            Ok(_) => log::debug!("Binary broadcast sent successfully"),
+            Err(e) => log::error!("Failed to broadcast binary message: {}", e),
+        }
+    }
+
+    pub fn async_broadcast_bytes(&self, py: Python, data: Vec<u8>) -> PyResult<Py<PyAny>> {
+        let registry = self.registry_addr.clone();
+        let sender_id = self.id;
+
+        let awaitable = runtime::future_into_py(py, async move {
+            match registry.try_send(SendBinaryToAll { data, sender_id }) {
+                Ok(_) => log::debug!("Binary broadcast sent successfully"),
+                Err(e) => log::error!("Failed to broadcast binary message: {}", e),
             }
             Ok(())
         })?;

--- a/src/websockets/registry.rs
+++ b/src/websockets/registry.rs
@@ -99,6 +99,55 @@ impl Handler<SendMessageToAll> for WebSocketRegistry {
     }
 }
 
+// Send binary data to a specific client
+pub struct SendBinary {
+    pub recipient_id: Uuid,
+    pub data: Vec<u8>,
+    pub sender_id: Uuid,
+}
+
+impl Message for SendBinary {
+    type Result = ();
+}
+
+impl Handler<SendBinary> for WebSocketRegistry {
+    type Result = ();
+
+    fn handle(&mut self, msg: SendBinary, _ctx: &mut Self::Context) {
+        let recipient_id = msg.recipient_id;
+
+        if let Some(client_addr) = self.clients.get(&recipient_id) {
+            client_addr.do_send(msg);
+        } else {
+            log::warn!("No client found for id: {}", recipient_id);
+        }
+    }
+}
+
+// Broadcast binary data to every connected client
+pub struct SendBinaryToAll {
+    pub data: Vec<u8>,
+    pub sender_id: Uuid,
+}
+
+impl Message for SendBinaryToAll {
+    type Result = ();
+}
+
+impl Handler<SendBinaryToAll> for WebSocketRegistry {
+    type Result = ();
+
+    fn handle(&mut self, msg: SendBinaryToAll, _ctx: &mut Self::Context) {
+        for (id, client) in &self.clients {
+            client.do_send(SendBinary {
+                recipient_id: *id,
+                data: msg.data.clone(),
+                sender_id: msg.sender_id,
+            });
+        }
+    }
+}
+
 pub struct Close {
     pub id: Uuid,
 }


### PR DESCRIPTION
## Problem

Binary WebSocket frames weren't really supported. `receive_bytes()` just re-encoded received **text** to UTF-8, `send_bytes()` **decoded** bytes to a text frame, and non-UTF-8 binary frames were silently echoed back instead of reaching the handler. So arbitrary binary payloads (`application/octet-stream`, protobuf, images, …) were impossible.

## Change

- The receive channel now carries a `WsPayload::Text | Binary` enum. Binary frames are forwarded to the Python handler as raw bytes, so `channel.receive()` returns `bytes` for binary and `str` for text.
- `receive_bytes()` returns the bytes intact; `receive_text()` decodes a binary frame as UTF-8; `receive_json()` accepts either.
- New `SendBinary` / `SendBinaryToAll` registry messages + a `Handler<SendBinary>` that emits `ctx.binary(...)`, plus connector methods `async_send_bytes_to` / `sync_send_bytes_to` / `async_broadcast_bytes` / `sync_broadcast_bytes`.
- `send_bytes()` now sends a true binary frame; `broadcast(data)` sends a binary frame for `bytes` and a text frame for `str`.

This also covers the binary `send_to` / `broadcast` (sync + async) variants called out as missing in the issue.

## Tests

- New `test_websocket_binary_echo` round-trips a non-UTF-8 payload (`b"\\x00\\x01\\x02\\xff\\xfe …"`) through a binary echo endpoint and asserts the reply is a binary frame with identical bytes.
- All existing websocket tests (text / json / DI / large-payload / empty-returns) still pass.

`ruff` / `isort` / `ruff format` / `cargo fmt` / `clippy` clean.

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket binary frame support with send, receive, and broadcast capabilities for binary data.
  * New binary messaging methods for targeted sends and broadcasting to all connected clients.

* **Tests**
  * Added integration test for binary WebSocket echo functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->