### PR TITLE
fix(reloader): make hot reload work when launched as a module (#654)

### DIFF
--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -126,6 +126,12 @@ class EventHandler(FileSystemEventHandler):
             os.kill(self.process.pid, signal.SIGTERM)  # Stop the subprocess using os.kill()
 
     def reload(self) -> None:
+        """Restart the app subprocess, relaunching from the resolved app file path.
+
+        Reloading works regardless of how Robyn was started (console script,
+        ``python -m robyn ...``, or as a module) because the relaunch uses the
+        resolved absolute file path rather than rebuilding it from argv. See #654.
+        """
         self.stop_server()
         print("Reloading the server")
 
@@ -133,13 +139,22 @@ class EventHandler(FileSystemEventHandler):
         new_env["IS_RELOADER_RUNNING"] = "True"  # This is used to check if a reloader is already running
         # IS_RELOADER_RUNNING is specifically used for IPC between the reloader and the server
 
-        # Relaunch from the resolved absolute path of the app file so hot reload works
-        # regardless of how Robyn was started -- console script, `python -m robyn ...`,
-        # or as a module (`python -m your_app`). Rebuilding the command from sys.argv[1:]
-        # previously dropped the launch form (breaking module invocation) and reused the
-        # file token as typed (breaking relative paths / a changed cwd). See issue #654.
+        # Forward the original CLI flags to the restarted process, but strip the
+        # `--dev` flag and the single app-file token -- it is replaced below by the
+        # resolved absolute path so hot reload works regardless of how Robyn was
+        # started (console script, `python -m robyn ...`, or as a module). Only the
+        # first matching token is dropped, so a later user arg that happens to
+        # resolve to the same path is preserved. See issue #654.
         app_file = os.path.realpath(self.file_path)
-        forwarded_args = [arg for arg in sys.argv[1:] if not arg.startswith("--dev") and os.path.realpath(arg) != app_file]
+        forwarded_args = []
+        removed_app_token = False
+        for arg in sys.argv[1:]:
+            if arg == "--dev":
+                continue
+            if not removed_app_token and os.path.realpath(arg) == app_file:
+                removed_app_token = True
+                continue
+            forwarded_args.append(arg)
 
         clean_rust_binaries(self.built_rust_binaries)
         self.built_rust_binaries = compile_rust_files(self.directory_path)

--- a/robyn/reloader.py
+++ b/robyn/reloader.py
@@ -133,7 +133,13 @@ class EventHandler(FileSystemEventHandler):
         new_env["IS_RELOADER_RUNNING"] = "True"  # This is used to check if a reloader is already running
         # IS_RELOADER_RUNNING is specifically used for IPC between the reloader and the server
 
-        arguments = [arg for arg in sys.argv[1:] if not arg.startswith("--dev")]
+        # Relaunch from the resolved absolute path of the app file so hot reload works
+        # regardless of how Robyn was started -- console script, `python -m robyn ...`,
+        # or as a module (`python -m your_app`). Rebuilding the command from sys.argv[1:]
+        # previously dropped the launch form (breaking module invocation) and reused the
+        # file token as typed (breaking relative paths / a changed cwd). See issue #654.
+        app_file = os.path.realpath(self.file_path)
+        forwarded_args = [arg for arg in sys.argv[1:] if not arg.startswith("--dev") and os.path.realpath(arg) != app_file]
 
         clean_rust_binaries(self.built_rust_binaries)
         self.built_rust_binaries = compile_rust_files(self.directory_path)
@@ -143,7 +149,7 @@ class EventHandler(FileSystemEventHandler):
             prev_process.kill()
 
         self.process = subprocess.Popen(
-            [sys.executable, *arguments],
+            [sys.executable, app_file, *forwarded_args],
             env=new_env,
         )
 

--- a/unit_tests/test_reloader.py
+++ b/unit_tests/test_reloader.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from unittest.mock import patch
+
+from robyn.reloader import EventHandler
+
+
+def _capture_reload_command(file_path, argv):
+    """Run EventHandler.reload() with a faked sys.argv and return the relaunch command."""
+    handler = EventHandler(file_path=file_path, directory_path=os.path.dirname(file_path))
+    with (
+        patch("robyn.reloader.subprocess.Popen") as mock_popen,
+        patch("robyn.reloader.compile_rust_files", return_value=[]),
+        patch("robyn.reloader.clean_rust_binaries"),
+        patch.object(sys, "argv", argv),
+    ):
+        handler.reload()
+
+    assert mock_popen.call_count == 1
+    return mock_popen.call_args.args[0]
+
+
+def test_reload_uses_absolute_path_when_run_as_module(tmp_path):
+    """Issue #654: reloading must work when launched via `python -m ...`.
+
+    The launcher token is absent from sys.argv[1:] and the file is passed as a
+    relative path, so the relaunch must rely on the resolved absolute file path.
+    """
+    app = tmp_path / "app.py"
+    app.write_text("")
+    app_path = os.path.realpath(str(app))
+
+    previous_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        # Simulates `python -m robyn app.py --dev` started from the app directory.
+        command = _capture_reload_command(app_path, ["/usr/lib/python/robyn/__main__.py", "app.py", "--dev"])
+    finally:
+        os.chdir(previous_cwd)
+
+    assert command[0] == sys.executable
+    assert command[1] == app_path  # absolute path, not the typed "app.py" token
+    assert "--dev" not in command
+    assert "app.py" not in command  # the relative token must not survive
+    assert command.count(app_path) == 1  # and must not be duplicated
+
+
+def test_reload_forwards_extra_flags_and_strips_dev(tmp_path):
+    """Non-file CLI flags are forwarded to the reloaded process; --dev is stripped."""
+    app = tmp_path / "app.py"
+    app.write_text("")
+    app_path = os.path.realpath(str(app))
+
+    command = _capture_reload_command(
+        app_path,
+        ["robyn", app_path, "--dev", "--processes", "4", "--log-level", "WARN"],
+    )
+
+    assert command == [sys.executable, app_path, "--processes", "4", "--log-level", "WARN"]

--- a/unit_tests/test_reloader.py
+++ b/unit_tests/test_reloader.py
@@ -57,3 +57,14 @@ def test_reload_forwards_extra_flags_and_strips_dev(tmp_path):
     )
 
     assert command == [sys.executable, app_path, "--processes", "4", "--log-level", "WARN"]
+
+
+def test_reload_drops_only_the_first_app_token(tmp_path):
+    """Only the first app-file token is stripped; a later arg resolving to the same path survives."""
+    app = tmp_path / "app.py"
+    app.write_text("")
+    app_path = os.path.realpath(str(app))
+
+    command = _capture_reload_command(app_path, ["robyn", app_path, "--dev", "--watch", app_path])
+
+    assert command == [sys.executable, app_path, "--watch", app_path]


### PR DESCRIPTION
## What

Fixes #654 — live reloading fails when the app is started as a module (`python -m ...`) instead of through the console script.

## Why

`EventHandler.reload()` rebuilt the relaunch command from `sys.argv[1:]`:

```python
arguments = [arg for arg in sys.argv[1:] if not arg.startswith("--dev")]
self.process = subprocess.Popen([sys.executable, *arguments], env=new_env)
```

Two problems:
1. **Launch form is lost.** When started via `python -m robyn ...` (or any module form), `sys.argv[1:]` no longer carries a runnable launcher, so the rebuilt command doesn't reproduce the original invocation.
2. **File token reused as typed.** The app file was re-passed exactly as the user typed it (often relative), so a relative path or a changed working directory breaks the relaunch.

The `EventHandler` is already handed the **resolved absolute file path** (`setup_reloader` passes `absolute_file_path`), so we can relaunch from that directly.

## How

- Relaunch as `[sys.executable, <absolute app file>, *forwarded_args]`.
- Forward every CLI flag except `--dev`, and drop the original file token (matched by resolved path) so it isn't duplicated.
- Behaviour for the normal `robyn app.py --dev` path is unchanged.

## Tests

Adds `unit_tests/test_reloader.py`:
- `test_reload_uses_absolute_path_when_run_as_module` — module launch with a relative file token relaunches from the absolute path and strips `--dev`.
- `test_reload_forwards_extra_flags_and_strips_dev` — extra flags (`--processes`, `--log-level`) are forwarded; `--dev` is stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app hot-reload so the relaunched process consistently uses the resolved absolute app entry path.
  * Updated reload CLI handling to forward relevant flags, remove only the dev-only flag, and drop only the first matching app-path token while keeping later matches.

* **Tests**
  * Added new unit tests covering relaunch command construction across different invocation styles and repeated app-path arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->