### PR TITLE
feat(templating): add render() shortcut for the local templates folder (#1223)

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/templating.mdx
@@ -58,6 +58,29 @@ Batman was excited to learn that he could add events as functions as well as dec
 </Row>
 
 
+## A quick `render` shortcut
+
+Batman didn't always want to construct a `JinjaTemplate` by hand. Robyn told him that for the common case — a `templates` folder next to his application file — he can use the `render` shortcut instead.
+
+<Row>
+<Col>
+`render` resolves the `templates` directory relative to the file that calls it, so there is no need to wire up paths with `pathlib`. If you keep your templates elsewhere, point at it with the `templates_dir` argument.
+</Col>
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/template_render">
+
+    ```python
+    from robyn.templating import render
+
+    @app.get("/template_render")
+    def template_render():
+        return render("test.html", framework="Robyn", templating_engine="Jinja2")
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
+
 ## Supporting Custom Templating Engines
 
 Batman was also super excited to know that Robyn allows the support of custom templating engines.

--- a/docs_src/src/pages/documentation/en/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/templating.mdx
@@ -64,7 +64,7 @@ Batman didn't always want to construct a `JinjaTemplate` by hand. Robyn told him
 
 <Row>
 <Col>
-`render` resolves the `templates` directory relative to the file that calls it, so there is no need to wire up paths with `pathlib`. If you keep your templates elsewhere, point at it with the `templates_dir` argument.
+`render` resolves the `templates` directory relative to the file that calls it, so there is no need to wire up paths with `pathlib`. It renders with Jinja2 by default; pass a different `templates_dir` to point at another folder, or a custom `TemplateInterface` via `template_engine` to use a different templating engine.
 </Col>
   <Col sticky>
     <CodeGroup title="Request" tag="GET" label="/template_render">
@@ -74,7 +74,8 @@ Batman didn't always want to construct a `JinjaTemplate` by hand. Robyn told him
 
     @app.get("/template_render")
     def template_render():
-        return render("test.html", framework="Robyn", templating_engine="Jinja2")
+        # Jinja2 is the default templating engine
+        return render("test.html", name="Batman")
     ```
     </CodeGroup>
   </Col>

--- a/docs_src/src/pages/documentation/en/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/templating.mdx
@@ -75,7 +75,7 @@ Batman didn't always want to construct a `JinjaTemplate` by hand. Robyn told him
     @app.get("/template_render")
     def template_render():
         # Jinja2 is the default templating engine
-        return render("test.html", name="Batman")
+        return render("index.html", name="Batman")
     ```
     </CodeGroup>
   </Col>

--- a/docs_src/src/pages/documentation/en/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/templating.mdx
@@ -1,5 +1,5 @@
 export const description =
-  'On this page, we’ll dive into the different conversation endpoints you can use to manage conversations programmatically.'
+  'On this page, we’ll dive into rendering HTML templates in Robyn with Jinja2 or a custom templating engine.'
 
 
 

--- a/docs_src/src/pages/documentation/zh/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/templating.mdx
@@ -1,5 +1,5 @@
 export const description =
-  '在此页面中，我们将深入探讨如何通过不同的接口实现符合预期的交互。'
+  '在此页面中，我们将深入探讨如何在 Robyn 中使用 Jinja2 或自定义模板引擎渲染 HTML 模板。'
 
 ## 模板
 
@@ -55,6 +55,30 @@ export const description =
 
   </Col>
 </Row>
+
+## 快捷的 `render` 函数
+
+蝙蝠侠并不总是想手动构造 `JinjaTemplate`。Robyn 告诉他，对于常见场景——应用文件旁边有一个 `templates` 文件夹——可以直接使用 `render` 快捷函数。
+
+<Row>
+<Col>
+`render` 会相对于调用它的文件解析 `templates` 目录，因此无需再用 `pathlib` 拼接路径。它默认使用 Jinja2 渲染；可以通过 `templates_dir` 指向其他文件夹，或通过 `template_engine` 传入自定义的 `TemplateInterface` 来使用其他模板引擎。
+</Col>
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/template_render">
+
+    ```python
+    from robyn.templating import render
+
+    @app.get("/template_render")
+    def template_render():
+        # Jinja2 是默认的模板引擎
+        return render("test.html", name="Batman")
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
 
 ## 自定义模板引擎
 

--- a/docs_src/src/pages/documentation/zh/api_reference/templating.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/templating.mdx
@@ -73,7 +73,7 @@ export const description =
     @app.get("/template_render")
     def template_render():
         # Jinja2 是默认的模板引擎
-        return render("test.html", name="Batman")
+        return render("index.html", name="Batman")
     ```
     </CodeGroup>
   </Col>

--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -1,4 +1,7 @@
+import inspect
+import os
 from abc import ABC, abstractmethod
+from functools import lru_cache
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -71,4 +74,42 @@ class JinjaTemplate(TemplateInterface):
         )
 
 
-__all__ = ["TemplateInterface", "JinjaTemplate"]
+@lru_cache(maxsize=None)
+def _cached_jinja_template(directory: str) -> JinjaTemplate:
+    """Builds and caches a JinjaTemplate per directory so repeated render() calls reuse the environment."""
+    return JinjaTemplate(directory)
+
+
+def render(template_name: str, *, templates_dir: str = "templates", **kwargs) -> Response:
+    """Renders a template from a local ``templates`` directory.
+
+    Convenience wrapper around :class:`JinjaTemplate` that resolves ``templates_dir``
+    relative to the file calling ``render`` (defaulting to a ``templates`` folder next
+    to it), so simple apps don't have to construct a :class:`JinjaTemplate` by hand::
+
+        from robyn.templating import render
+
+        @app.get("/frontend")
+        async def get_frontend(request):
+            return render("index.html", framework="Robyn")
+
+    Args:
+        template_name (str): The template file to render, e.g. ``"index.html"``.
+        templates_dir (str): Directory holding the templates. Resolved relative to the
+            caller's file when not absolute. Defaults to ``"templates"``.
+        **kwargs: Variables passed to the template.
+
+    Returns:
+        Response: The rendered template as a Robyn Response object.
+    """
+    if not os.path.isabs(templates_dir):
+        frame = inspect.currentframe()
+        caller = frame.f_back if frame is not None else None
+        caller_file = caller.f_globals.get("__file__") if caller is not None else None
+        base_dir = os.path.dirname(os.path.abspath(caller_file)) if caller_file else os.getcwd()
+        templates_dir = os.path.join(base_dir, templates_dir)
+
+    return _cached_jinja_template(templates_dir).render_template(template_name, **kwargs)
+
+
+__all__ = ["TemplateInterface", "JinjaTemplate", "render"]

--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -75,28 +75,38 @@ class JinjaTemplate(TemplateInterface):
 
 
 @lru_cache(maxsize=None)
-def _cached_jinja_template(directory: str) -> JinjaTemplate:
-    """Builds and caches a JinjaTemplate per directory so repeated render() calls reuse the environment."""
-    return JinjaTemplate(directory)
+def _cached_template_engine(engine: type[TemplateInterface], directory: str) -> TemplateInterface:
+    """Instantiates and caches a templating engine per (engine, directory) so render() reuses it."""
+    return engine(directory)
 
 
-def render(template_name: str, *, templates_dir: str = "templates", **kwargs) -> Response:
+def render(
+    template_name: str,
+    *,
+    templates_dir: str = "templates",
+    template_engine: type[TemplateInterface] = JinjaTemplate,
+    **kwargs,
+) -> Response:
     """Renders a template from a local ``templates`` directory.
 
-    Convenience wrapper around :class:`JinjaTemplate` that resolves ``templates_dir``
-    relative to the file calling ``render`` (defaulting to a ``templates`` folder next
-    to it), so simple apps don't have to construct a :class:`JinjaTemplate` by hand::
+    Convenience wrapper that resolves ``templates_dir`` relative to the file calling
+    ``render`` (defaulting to a ``templates`` folder next to it) and renders it with a
+    templating engine -- Jinja2 by default, or any :class:`TemplateInterface` passed via
+    ``template_engine`` -- so simple apps don't have to construct one by hand::
 
         from robyn.templating import render
 
         @app.get("/frontend")
         async def get_frontend(request):
-            return render("index.html", framework="Robyn")
+            return render("index.html", name="Batman")
 
     Args:
         template_name (str): The template file to render, e.g. ``"index.html"``.
         templates_dir (str): Directory holding the templates. Resolved relative to the
             caller's file when not absolute. Defaults to ``"templates"``.
+        template_engine (type[TemplateInterface]): The templating engine to render with.
+            Defaults to :class:`JinjaTemplate` (Jinja2). Pass a custom
+            :class:`TemplateInterface` subclass to use a different engine.
         **kwargs: Variables passed to the template.
 
     Returns:
@@ -109,7 +119,7 @@ def render(template_name: str, *, templates_dir: str = "templates", **kwargs) ->
         base_dir = os.path.dirname(os.path.abspath(caller_file)) if caller_file else os.getcwd()
         templates_dir = os.path.join(base_dir, templates_dir)
 
-    return _cached_jinja_template(templates_dir).render_template(template_name, **kwargs)
+    return _cached_template_engine(template_engine, templates_dir).render_template(template_name, **kwargs)
 
 
 __all__ = ["TemplateInterface", "JinjaTemplate", "render"]

--- a/robyn/templating.py
+++ b/robyn/templating.py
@@ -115,7 +115,11 @@ def render(
     if not os.path.isabs(templates_dir):
         frame = inspect.currentframe()
         caller = frame.f_back if frame is not None else None
-        caller_file = caller.f_globals.get("__file__") if caller is not None else None
+        try:
+            caller_file = caller.f_globals.get("__file__") if caller is not None else None
+        finally:
+            # Drop the frame references promptly to avoid a reference cycle (see inspect docs).
+            del frame, caller
         base_dir = os.path.dirname(os.path.abspath(caller_file)) if caller_file else os.getcwd()
         templates_dir = os.path.join(base_dir, templates_dir)
 

--- a/unit_tests/test_templating.py
+++ b/unit_tests/test_templating.py
@@ -42,3 +42,20 @@ def test_render_autoescapes_html(tmp_path):
 
     assert "<script>" not in response.description
     assert "&lt;script&gt;" in response.description
+
+
+def test_render_uses_custom_template_engine(tmp_path):
+    """A custom TemplateInterface can be supplied via template_engine; Jinja stays the default."""
+    from robyn.robyn import Headers, Response
+    from robyn.templating import TemplateInterface
+
+    class EchoEngine(TemplateInterface):
+        def __init__(self, directory):
+            self.directory = directory
+
+        def render_template(self, template_name, **kwargs):
+            return Response(status_code=200, headers=Headers({}), description=f"{template_name}|{kwargs.get('who')}")
+
+    response = render("x.html", templates_dir=str(tmp_path), template_engine=EchoEngine, who="Batman")
+
+    assert response.description == "x.html|Batman"

--- a/unit_tests/test_templating.py
+++ b/unit_tests/test_templating.py
@@ -1,0 +1,44 @@
+import importlib.util
+
+from robyn.templating import render
+
+
+def test_render_with_explicit_templates_dir(tmp_path):
+    """render() uses an absolute templates_dir as-is and returns an HTML 200 Response."""
+    templates_dir = tmp_path / "tpl"
+    templates_dir.mkdir()
+    (templates_dir / "page.html").write_text("<h1>{{ title }}</h1>")
+
+    response = render("page.html", templates_dir=str(templates_dir), title="Hello")
+
+    assert response.status_code == 200
+    assert "<h1>Hello</h1>" in response.description
+    assert response.headers.get("Content-Type") == "text/html; charset=utf-8"
+
+
+def test_render_resolves_templates_relative_to_caller(tmp_path):
+    """A relative templates_dir is resolved next to the *calling* module, not the cwd."""
+    (tmp_path / "templates").mkdir()
+    (tmp_path / "templates" / "index.html").write_text("Hello {{ name }}")
+
+    module_file = tmp_path / "app_module.py"
+    module_file.write_text("from robyn.templating import render\n\n\ndef view():\n    return render('index.html', name='Robyn')\n")
+
+    spec = importlib.util.spec_from_file_location("app_module_under_test", module_file)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    response = module.view()
+    assert "Hello Robyn" in response.description
+
+
+def test_render_autoescapes_html(tmp_path):
+    """Autoescaping is inherited from JinjaTemplate, so user values are escaped."""
+    templates_dir = tmp_path / "tpl"
+    templates_dir.mkdir()
+    (templates_dir / "page.html").write_text("{{ value }}")
+
+    response = render("page.html", templates_dir=str(templates_dir), value="<script>")
+
+    assert "<script>" not in response.description
+    assert "&lt;script&gt;" in response.description


### PR DESCRIPTION
## What

Closes #1223 — adds a `render` shortcut so simple apps don't have to construct a `JinjaTemplate` (and wire up `pathlib`) just to render a template.

Before:

```python
import pathlib, os
from robyn.templating import JinjaTemplate

current_file_path = pathlib.Path(__file__).parent.resolve()
jinja_template = JinjaTemplate(os.path.join(current_file_path, "templates"))

@app.get("/frontend")
async def get_frontend(request):
    return jinja_template.render_template("index.html", name="Batman")
```

After:

```python
from robyn.templating import render

@app.get("/frontend")
async def get_frontend(request):
    return render("index.html", name="Batman")
```

## How

- New `render(template_name, *, templates_dir="templates", template_engine=JinjaTemplate, **kwargs)` in `robyn/templating.py`.
- `templates_dir` is resolved **relative to the file that calls `render`** (using the caller's `__file__`), so it points at a `templates/` folder next to the app by default. Absolute paths and a custom `templates_dir` are respected.
- **The templating engine is selectable, defaulting to Jinja2.** Pass any `TemplateInterface` subclass via `template_engine` to render with a different engine.
- The engine instance (and, for Jinja, its `Environment`) is cached per `(engine, directory)` via `lru_cache`, so repeated calls don't rebuild it. Autoescaping carries over from `JinjaTemplate`.
- `jinja2` stays an optional dependency — `render` lives in `robyn.templating` and isn't imported at package import time.

## Tests

`unit_tests/test_templating.py`:
- `test_render_with_explicit_templates_dir` — absolute `templates_dir`, asserts HTML 200 + content type.
- `test_render_resolves_templates_relative_to_caller` — loads a module from a temp dir and confirms `render` finds the `templates/` folder next to *that* module.
- `test_render_autoescapes_html` — confirms user input is escaped.
- `test_render_uses_custom_template_engine` — confirms a custom `TemplateInterface` is used when passed.

## Docs

- Adds a "quick `render` shortcut" section to the templating API reference, in **both English and Chinese** (`en` and `zh`).
- Fixes the boilerplate page `description` metadata on both pages (they previously described "conversation endpoints" instead of templating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `render()` helper to simplify returning rendered HTML templates as responses.
  * Added support for custom template engines and automatic reuse of cached engine instances per templates directory.
* **Bug Fixes**
  * Improved handling of relative `templates_dir` by resolving it relative to the calling module (with a safe fallback).
  * Enabled template autoescaping to prevent unsafe HTML rendering.
* **Documentation**
  * Updated templating API reference (EN and ZH) with a new “quick `render` shortcut” section and example.
* **Tests**
  * Added unit tests covering absolute/relative `templates_dir`, autoescaping behavior, and custom engine rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->