### PR TITLE
feat(server): programmatic server config via app.start() (#1275)

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/scaling.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/scaling.mdx
@@ -69,6 +69,30 @@ Within each process, multiple worker threads provide concurrency:
   </Col>
 </Row>
 
+### Programmatic Configuration
+
+<Row>
+  <Col>
+    **Configure in code**: Every scaling option available on the CLI can also be passed directly to `app.start()`, so you can run Robyn without the CLI — from a script, an embedded process, or a test fixture. Explicit arguments take precedence over CLI flags, and `fast` only fills in the values you don't set yourself. Dev mode (hot reload) stays CLI-only, since it relies on the file-watching reloader.
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Programmatic Scaling">
+    ```python
+    from robyn import Robyn
+
+    app = Robyn(__file__)
+
+    if __name__ == "__main__":
+        # Equivalent to: python app.py --processes 4 --workers 2 --log-level WARN
+        app.start(host="0.0.0.0", port=8080, processes=4, workers=2, log_level="WARN")
+
+        # Or let fast mode pick optimal processes/workers/log level
+        # app.start(fast=True)
+    ```
+    </CodeGroup>
+  </Col>
+</Row>
+
 ### Advanced Configuration
 
 <Row>

--- a/docs_src/src/pages/documentation/zh/api_reference/scaling.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/scaling.mdx
@@ -16,6 +16,33 @@
   </Col>
 </Row>
 
+## 以代码方式配置
+
+CLI 上可用的扩展选项同样可以直接传给 `app.start()`，因此无需 CLI 也能运行 Robyn —— 例如在脚本、嵌入式进程或测试 fixture 中。显式传入的参数优先级高于 CLI 标志；`fast` 只会补全你未显式设置的值。开发模式（热重载）依赖文件监听的 reloader，仍仅在 CLI 中可用。
+
+<Row>
+  <Col>
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Request">
+
+      ```python
+      from robyn import Robyn
+
+      app = Robyn(__file__)
+
+      if __name__ == "__main__":
+          # 等价于：python app.py --processes 4 --workers 2 --log-level WARN
+          app.start(host="0.0.0.0", port=8080, processes=4, workers=2, log_level="WARN")
+
+          # 或者让 fast 模式自动选择最优的 processes/workers/日志级别
+          # app.start(fast=True)
+      ```
+    </CodeGroup>
+
+  </Col>
+</Row>
+
 ---
 
 ## 下一步

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -1008,7 +1008,12 @@ class Robyn(BaseRobyn):
             logging.basicConfig(level=self.config.log_level, force=True)
 
         if open_browser is None:
-            open_browser = bool(os.getenv("ROBYN_BROWSER_OPEN", self.config.open_browser))
+            raw_open_browser = os.getenv("ROBYN_BROWSER_OPEN")
+            if raw_open_browser is None:
+                open_browser = bool(self.config.open_browser)
+            else:
+                # Parse as a real boolean -- bool("false")/bool("0") would otherwise be True.
+                open_browser = raw_open_browser.strip().lower() in {"1", "true", "yes", "on"}
 
         if _check_port:
             while self.is_port_in_use(port):

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -961,6 +961,11 @@ class Robyn(BaseRobyn):
         _check_port: bool = True,
         client_timeout: int = 30,
         keep_alive_timeout: int = 20,
+        processes: int | None = None,
+        workers: int | None = None,
+        fast: bool | None = None,
+        log_level: str | None = None,
+        open_browser: bool | None = None,
     ):
         """
         Starts the server
@@ -970,13 +975,40 @@ class Robyn(BaseRobyn):
         :param _check_port bool: represents if the port should be checked if it is already in use
         :param client_timeout int: timeout for client connections in seconds (default: 30)
         :param keep_alive_timeout int: timeout for keep-alive connections in seconds (default: 20)
+        :param processes int | None: number of processes to run; overrides the CLI ``--processes`` value when set
+        :param workers int | None: number of workers per process; overrides the CLI ``--workers`` value when set
+        :param fast bool | None: enable fast mode (optimal processes/workers/log level). Explicit
+            ``processes``/``workers``/``log_level`` arguments still take precedence.
+        :param log_level str | None: log level (e.g. ``"WARN"``); overrides the CLI ``--log-level`` value when set
+        :param open_browser bool | None: open the browser on a successful start; overrides config when set
+
+        Note: dev mode (hot reload) is intentionally not configurable here -- it relies on the
+        file-watching reloader and is only available through the Robyn CLI (``robyn app.py --dev``).
         """
 
         host = os.getenv("ROBYN_HOST", host)
         port = int(os.getenv("ROBYN_PORT", port))
         client_timeout = int(os.getenv("ROBYN_CLIENT_TIMEOUT", client_timeout))
         keep_alive_timeout = int(os.getenv("ROBYN_KEEP_ALIVE_TIMEOUT", keep_alive_timeout))
-        open_browser = bool(os.getenv("ROBYN_BROWSER_OPEN", self.config.open_browser))
+
+        # Programmatic overrides: explicit start() arguments take precedence over CLI flags.
+        # `fast` only fills in the values the caller did not set explicitly.
+        if fast:
+            cpu_count = os.cpu_count() or 1
+            processes = processes if processes is not None else (cpu_count * 2) + 1
+            workers = workers if workers is not None else 2
+            log_level = log_level if log_level is not None else "WARNING"
+
+        if processes is not None:
+            self.config.processes = processes
+        if workers is not None:
+            self.config.workers = workers
+        if log_level is not None:
+            self.config.log_level = log_level
+            logging.basicConfig(level=self.config.log_level, force=True)
+
+        if open_browser is None:
+            open_browser = bool(os.getenv("ROBYN_BROWSER_OPEN", self.config.open_browser))
 
         if _check_port:
             while self.is_port_in_use(port):

--- a/unit_tests/test_programmatic_config.py
+++ b/unit_tests/test_programmatic_config.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+from robyn import Robyn
+from robyn.argument_parser import Config
+
+
+def _make_app():
+    return Robyn(__file__, config=Config())
+
+
+def test_start_overrides_processes_and_workers():
+    """processes/workers passed to start() override config and reach run_processes."""
+    app = _make_app()
+    with patch("robyn.run_processes") as mock_run:
+        app.start(processes=4, workers=3, _check_port=False)
+
+    assert app.config.processes == 4
+    assert app.config.workers == 3
+    # run_processes(host, port, ..., workers, processes, ...) -> workers at index 9, processes at index 10
+    call_args = mock_run.call_args.args
+    assert call_args[9] == 3
+    assert call_args[10] == 4
+
+
+def test_start_fast_fills_gaps_but_explicit_args_win():
+    """fast supplies optimal defaults, but an explicit processes argument still wins."""
+    app = _make_app()
+    with patch("robyn.run_processes"), patch("robyn.os.cpu_count", return_value=4):
+        app.start(fast=True, processes=2, _check_port=False)
+
+    assert app.config.processes == 2  # explicit value wins over fast's (cpu*2+1)
+    assert app.config.workers == 2  # filled in by fast
+    assert app.config.log_level == "WARNING"  # filled in by fast
+
+
+def test_start_log_level_override():
+    """log_level passed to start() overrides the config value."""
+    app = _make_app()
+    with patch("robyn.run_processes"):
+        app.start(log_level="WARN", _check_port=False)
+
+    assert app.config.log_level == "WARN"
+
+
+def test_start_without_overrides_leaves_config_untouched():
+    """Calling start() with no server overrides keeps the existing config (backwards compatible)."""
+    app = _make_app()
+    app.config.processes = 1
+    app.config.workers = 1
+    with patch("robyn.run_processes") as mock_run:
+        app.start(_check_port=False)
+
+    assert app.config.processes == 1
+    assert app.config.workers == 1
+    assert mock_run.call_count == 1

--- a/unit_tests/test_programmatic_config.py
+++ b/unit_tests/test_programmatic_config.py
@@ -53,3 +53,35 @@ def test_start_without_overrides_leaves_config_untouched():
     assert app.config.processes == 1
     assert app.config.workers == 1
     assert mock_run.call_count == 1
+
+
+# run_processes(host, port, ..., open_browser, ...) -> open_browser is positional index 13
+_OPEN_BROWSER_ARG = 13
+
+
+def test_open_browser_env_false_is_parsed_as_false(monkeypatch):
+    """ROBYN_BROWSER_OPEN='false' must not open the browser (real boolean parsing, not bool('false'))."""
+    app = _make_app()
+    monkeypatch.setenv("ROBYN_BROWSER_OPEN", "false")
+    with patch("robyn.run_processes") as mock_run:
+        app.start(_check_port=False)
+
+    assert mock_run.call_args.args[_OPEN_BROWSER_ARG] is False
+
+
+def test_open_browser_env_true_is_parsed_as_true(monkeypatch):
+    app = _make_app()
+    monkeypatch.setenv("ROBYN_BROWSER_OPEN", "true")
+    with patch("robyn.run_processes") as mock_run:
+        app.start(_check_port=False)
+
+    assert mock_run.call_args.args[_OPEN_BROWSER_ARG] is True
+
+
+def test_open_browser_explicit_arg_overrides_env(monkeypatch):
+    app = _make_app()
+    monkeypatch.setenv("ROBYN_BROWSER_OPEN", "true")
+    with patch("robyn.run_processes") as mock_run:
+        app.start(_check_port=False, open_browser=False)
+
+    assert mock_run.call_args.args[_OPEN_BROWSER_ARG] is False


### PR DESCRIPTION
## What

Closes #1275 — lets you configure server options **in code** instead of only through CLI flags. `app.start()` now accepts `processes`, `workers`, `fast`, `log_level`, and `open_browser`.

```python
app = Robyn(__file__)

if __name__ == "__main__":
    # equivalent to: python app.py --processes 4 --workers 2 --log-level WARN
    app.start(host="0.0.0.0", port=8080, processes=4, workers=2, log_level="WARN")

    # or let fast mode pick optimal values
    app.start(fast=True)
```

## Why

Previously every server option could only be set via the CLI; `app.start()` took just `host`/`port`/timeouts. This blocked running Robyn from a script, an embedded process, or a pytest fixture with the right process/worker counts.

Notably, the **scaling docs already showed** `app.start(processes=..., workers=..., log_level=...)` (scaling.mdx) — but that example would raise `TypeError`, because `start()` didn't accept those kwargs. This PR makes the documented API real.

## How

- New optional kwargs on `Robyn.start()`: `processes`, `workers`, `fast`, `log_level`, `open_browser`. Each overrides the corresponding `Config` value **only when provided**, so existing behaviour (CLI flags / defaults) is unchanged when they're omitted.
- `fast` is handled cleanly: it computes its presets into the local arguments, filling in only the values the caller didn't set explicitly — so `app.start(fast=True, processes=2)` keeps `processes=2` but still gets `workers=2` / `log_level=WARNING`.
- **`dev` is intentionally not exposed here** and documented as such — hot reload relies on the file-watching reloader and remains CLI-only (`robyn app.py --dev`).

## Tests

`unit_tests/test_programmatic_config.py` (patches `run_processes`, no real server):
- overrides for `processes`/`workers` reach `run_processes`
- `fast` fills gaps but explicit `processes` wins
- `log_level` override
- no overrides → config untouched (backwards compatible)

## Docs

Adds a "Programmatic Configuration" section to the scaling page in **English and Chinese**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added programmatic startup configuration for scaling-related settings, including `processes`, `workers`, `log_level`, `fast`, and `open_browser`, with documented precedence over CLI/config.
  * When `fast` is enabled, defaults are filled only for values you don’t explicitly set.
* **Documentation**
  * Updated scaling docs with a new “Programmatic Configuration” section, including English and Chinese examples and environment-to-argument precedence details.
* **Tests**
  * Added tests covering override behavior (`fast` vs explicit values), log level handling, and `open_browser` parsing/overrides from environment strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->