### PR TITLE
fix(shutdown): graceful shutdown on SIGTERM (#1324)

### DIFF
--- a/integration_tests/graceful_shutdown_app.py
+++ b/integration_tests/graceful_shutdown_app.py
@@ -1,0 +1,31 @@
+"""Minimal app used by test_graceful_shutdown.py.
+
+Verifies that SIGTERM triggers a graceful shutdown (clean exit + shutdown handler)
+instead of hanging until SIGKILL. See issue #1324.
+"""
+
+import sys
+
+from robyn import Robyn
+
+app = Robyn(__file__)
+
+_sentinel_path = sys.argv[1]
+_port = int(sys.argv[2])
+
+
+@app.get("/")
+def index(request):
+    return "ok"
+
+
+def _on_shutdown():
+    with open(_sentinel_path, "w") as handle:
+        handle.write("shutdown")
+
+
+app.shutdown_handler(_on_shutdown)
+
+
+if __name__ == "__main__":
+    app.start(host="127.0.0.1", port=_port, _check_port=False)

--- a/integration_tests/test_graceful_shutdown.py
+++ b/integration_tests/test_graceful_shutdown.py
@@ -32,24 +32,23 @@ def _wait_until_serving(proc: subprocess.Popen, port: int, timeout: float = 25.0
 @pytest.mark.skipif(sys.platform.startswith("win32"), reason="SIGTERM is not delivered on Windows")
 def test_sigterm_triggers_graceful_shutdown():
     """SIGTERM should stop the server cleanly and run shutdown handlers (regression for #1324)."""
-    sentinel = tempfile.mktemp(prefix="robyn_graceful_")
-    port = _free_port()
-    proc = subprocess.Popen([sys.executable, APP, sentinel, str(port)])
-    try:
-        assert _wait_until_serving(proc, port), "server failed to start"
-
-        proc.terminate()  # SIGTERM
+    with tempfile.TemporaryDirectory(prefix="robyn_graceful_") as tmpdir:
+        sentinel = os.path.join(tmpdir, "shutdown.sentinel")
+        port = _free_port()
+        proc = subprocess.Popen([sys.executable, APP, sentinel, str(port)])
         try:
-            returncode = proc.wait(timeout=15)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            pytest.fail("server hung after SIGTERM instead of shutting down (#1324)")
+            assert _wait_until_serving(proc, port), "server failed to start"
 
-        assert returncode == 0, f"expected a clean exit on SIGTERM, got returncode={returncode}"
-        assert os.path.exists(sentinel), "shutdown handler did not run on SIGTERM"
-    finally:
-        if proc.poll() is None:
-            proc.kill()
-            proc.wait(timeout=5)
-        if os.path.exists(sentinel):
-            os.remove(sentinel)
+            proc.terminate()  # SIGTERM
+            try:
+                returncode = proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                pytest.fail("server hung after SIGTERM instead of shutting down (#1324)")
+
+            assert returncode == 0, f"expected a clean exit on SIGTERM, got returncode={returncode}"
+            assert os.path.exists(sentinel), "shutdown handler did not run on SIGTERM"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)

--- a/integration_tests/test_graceful_shutdown.py
+++ b/integration_tests/test_graceful_shutdown.py
@@ -1,0 +1,55 @@
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+
+APP = os.path.join(os.path.dirname(__file__), "graceful_shutdown_app.py")
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_until_serving(proc: subprocess.Popen, port: int, timeout: float = 25.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return False
+        try:
+            with socket.create_connection(("127.0.0.1", port), 0.3):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+@pytest.mark.skipif(sys.platform.startswith("win32"), reason="SIGTERM is not delivered on Windows")
+def test_sigterm_triggers_graceful_shutdown():
+    """SIGTERM should stop the server cleanly and run shutdown handlers (regression for #1324)."""
+    sentinel = tempfile.mktemp(prefix="robyn_graceful_")
+    port = _free_port()
+    proc = subprocess.Popen([sys.executable, APP, sentinel, str(port)])
+    try:
+        assert _wait_until_serving(proc, port), "server failed to start"
+
+        proc.terminate()  # SIGTERM
+        try:
+            returncode = proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            pytest.fail("server hung after SIGTERM instead of shutting down (#1324)")
+
+        assert returncode == 0, f"expected a clean exit on SIGTERM, got returncode={returncode}"
+        assert os.path.exists(sentinel), "shutdown handler did not run on SIGTERM"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+        if os.path.exists(sentinel):
+            os.remove(sentinel)

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import os
 import signal
 import sys
@@ -25,9 +26,13 @@ def _graceful_shutdown_timeout() -> float:
     Configurable via the ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT environment variable.
     """
     try:
-        return max(0.0, float(os.getenv("ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT", "10")))
+        timeout = float(os.getenv("ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT", "10"))
     except ValueError:
         return 10.0
+    if not math.isfinite(timeout):
+        # A non-finite timeout (inf/nan) would leave the force-kill fallback unreachable.
+        return 10.0
+    return max(0.0, timeout)
 
 
 def run_processes(
@@ -72,7 +77,10 @@ def run_processes(
     def terminating_signal_handler(_sig, _frame):
         nonlocal shutting_down
         if shutting_down:
-            # A second signal during shutdown -- let the default disposition hard-stop us.
+            # On a second signal, restore the default disposition and re-send it so a user
+            # can force-stop a shutdown that is taking too long.
+            signal.signal(_sig, signal.SIG_DFL)
+            os.kill(os.getpid(), _sig)
             return
         shutting_down = True
         logger.info("Terminating server!!", bold=True)

--- a/robyn/processpool.py
+++ b/robyn/processpool.py
@@ -1,6 +1,8 @@
 import asyncio
+import os
 import signal
 import sys
+import time
 import webbrowser
 
 from multiprocess import Process  # type: ignore
@@ -10,6 +12,22 @@ from robyn.logger import logger
 from robyn.robyn import FunctionInfo, Headers, Server, SocketHeld
 from robyn.router import GlobalMiddleware, Route, RouteMiddleware
 from robyn.types import Directory
+
+
+def _raise_keyboard_interrupt(_sig, _frame):
+    """SIGTERM handler that re-uses the working SIGINT/Ctrl+C shutdown path."""
+    raise KeyboardInterrupt
+
+
+def _graceful_shutdown_timeout() -> float:
+    """Seconds to wait for workers to exit on shutdown before force-killing them.
+
+    Configurable via the ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT environment variable.
+    """
+    try:
+        return max(0.0, float(os.getenv("ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT", "10")))
+    except ValueError:
+        return 10.0
 
 
 def run_processes(
@@ -49,10 +67,29 @@ def run_processes(
         keep_alive_timeout,
     )
 
+    shutting_down = False
+
     def terminating_signal_handler(_sig, _frame):
+        nonlocal shutting_down
+        if shutting_down:
+            # A second signal during shutdown -- let the default disposition hard-stop us.
+            return
+        shutting_down = True
         logger.info("Terminating server!!", bold=True)
+
+        # Ask each worker to shut down gracefully (SIGTERM -> KeyboardInterrupt in the
+        # worker, see spawn_process), so registered shutdown handlers run. Force-kill
+        # only the workers that overrun the timeout.
         for process in process_pool:
-            process.kill()
+            process.terminate()
+
+        deadline = time.monotonic() + _graceful_shutdown_timeout()
+        for process in process_pool:
+            process.join(max(0.0, deadline - time.monotonic()))
+
+        for process in process_pool:
+            if process.is_alive():
+                process.kill()
 
     signal.signal(signal.SIGINT, terminating_signal_handler)
     signal.signal(signal.SIGTERM, terminating_signal_handler)
@@ -177,6 +214,14 @@ def spawn_process(
     """
 
     loop = initialize_event_loop()
+
+    # Make SIGTERM behave like Ctrl+C: raise KeyboardInterrupt in the main thread so it
+    # propagates out of the blocking Rust `server.start()` loop and lets registered
+    # shutdown handlers run before exit. Without this, SIGTERM (multiprocessing
+    # terminate(), `docker stop`, Kubernetes) is ignored by the Python side and the
+    # process hangs until SIGKILL. POSIX only -- Windows has no SIGTERM delivery. See #1324.
+    if not sys.platform.startswith("win32"):
+        signal.signal(signal.SIGTERM, _raise_keyboard_interrupt)
 
     server = Server()
 


### PR DESCRIPTION
## What

Closes #1324 — Robyn now shuts down **gracefully on SIGTERM**. Previously, sending SIGTERM (e.g. `multiprocessing.Process.terminate()`, `docker stop`, a Kubernetes pod stop) to a single-process server **hung** until SIGKILL, and registered `shutdown_handler`s never ran. The reporter saw a pytest fixture's `proc.terminate()` leave the process running forever.

## Root cause

`server.start()` is a blocking call into the Rust runtime (`run_forever`). SIGINT works only because CPython installs a C-level SIGINT handler that raises `KeyboardInterrupt`, which propagates out of that blocking call → the Rust runtime runs the shutdown handler → `exit(0)`.

But in single-process mode (`processes == 1`, the default — and always on Windows) Robyn installed **no Python SIGTERM handler**: the parent's signal handlers were only registered in the multi-process path. So SIGTERM was left at its default and the Python main thread, blocked inside Rust, was never interrupted → hang.

## Fix (Python-only, no Rust changes)

- **`spawn_process()`**: register a SIGTERM handler that raises `KeyboardInterrupt` (POSIX only), *before* the blocking `server.start()`. SIGTERM now follows the exact same working path as Ctrl+C → shutdown handlers run → clean exit. This fixes the reported single-process hang and also makes every worker exit gracefully.
- **Multi-process parent handler**: replaced the immediate `process.kill()` (SIGKILL) with graceful **terminate → join(timeout) → force-kill stragglers**, so worker shutdown handlers run on multi-process shutdown too. Includes a re-entry guard for a second signal during shutdown.
- **Timeout** is configurable via `ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT` (default `10`s).

I verified actix-web's own signal handling does **not** clobber the Python handler (it chains via `signal_hook_registry`), so no Rust `.disable_signals()` change is needed.

## Verification

Manually reproduced the issue and confirmed the fix against the current build: a single-process app sent SIGTERM now exits **rc=0 immediately** and the shutdown handler runs (writes its sentinel), instead of hanging.

## Tests

`integration_tests/test_graceful_shutdown.py` (+ `graceful_shutdown_app.py`): spawns the server on a free port, waits until it's serving, sends SIGTERM, and asserts:
- the process exits with **returncode 0** within a timeout (fails loudly if it hangs — a direct regression guard for #1324), and
- the `shutdown_handler` ran.

Skipped on Windows (no SIGTERM delivery).

## Notes

This supersedes the stale PRs #1396 and #1349 with a clean implementation. #1349's single-process fix (`loop.add_signal_handler(SIGTERM, loop.stop)`) was placed *after* the blocking `server.start()`, so it never ran while serving and didn't fix the reported path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown for worker processes: workers now receive a time window to exit cleanly before any forceful termination occurs.
  * Added support for graceful shutdown timeouts via `ROBYN_GRACEFUL_SHUTDOWN_TIMEOUT` (with safe fallback behavior).
  * On non-Windows systems, termination signals now trigger the existing shutdown/cleanup flow reliably.
* **Tests**
  * Added an integration test app and a new SIGTERM-based test to confirm shutdown handlers execute and the process exits successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->