### PR TITLE
Improve handling of file uploads via MultiPart Form Data

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/cheatsheet.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/cheatsheet.mdx
@@ -75,7 +75,7 @@ def inspect(request):
     data = request.json()                  # parsed JSON body -> dict / list
     raw = request.body                     # raw body (str | bytes)
     form = request.form_data               # dict[str, str]
-    files = request.files                  # dict[str, bytes]
+    files = request.files                  # dict[str, [UploadedFile]]
     content_type = request.headers.get("Content-Type")
     return {
         "method": request.method,

--- a/docs_src/src/pages/documentation/en/api_reference/file-uploads.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/file-uploads.mdx
@@ -48,8 +48,7 @@ Batman scaled his application across multiple cores for better performance. He u
 
     @app.post("/sync/multipart-file")
     def sync_multipart_file(request: Request):
-        files = request.files
-        file_names = files.keys()
+        file_names = set(file.name for field_name, files in request.files.items() for file in files)
         return {"file_names": list(file_names)}
     ```
 

--- a/docs_src/src/pages/documentation/zh/api_reference/cheatsheet.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/cheatsheet.mdx
@@ -75,7 +75,7 @@ def inspect(request):
     data = request.json()                  # 解析后的 JSON 请求体 -> dict / list
     raw = request.body                     # 原始请求体（str | bytes）
     form = request.form_data               # dict[str, str]
-    files = request.files                  # dict[str, bytes]
+    files = request.files                  # dict[str, [UploadedFile]]
     content_type = request.headers.get("Content-Type")
     return {
         "method": request.method,

--- a/docs_src/src/pages/documentation/zh/api_reference/file-uploads.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/file-uploads.mdx
@@ -47,8 +47,7 @@ export const description =
 
     @app.post("/sync/multipart-file")
     def sync_multipart_file(request: Request):
-        files = request.files
-        file_names = files.keys()
+        file_names = set(file.name for field_name, files in request.files.items() for file in files)
         return {"file_names": list(file_names)}
     ```
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -743,8 +743,7 @@ async def file_download_async():
 
 @app.post("/sync/multipart-file")
 def sync_multipart_file(request: Request):
-    files = request.files
-    file_names = files.keys()
+    file_names = set(file.name for _, files in request.files.items() for file in files)
     return {"file_names": list(file_names)}
 
 
@@ -757,16 +756,17 @@ def sync_multipart_file_save(request: Request):
     os.makedirs(upload_dir, exist_ok=True)
 
     saved = {}
-    for file_name, content in request.files.items():
-        # Never trust a client-supplied filename: strip any directory components
-        # so absolute paths or ".." segments can't escape upload_dir.
-        safe_name = os.path.basename(file_name)
-        if not safe_name or safe_name in (".", ".."):
-            continue
-        destination = os.path.join(upload_dir, safe_name)
-        with open(destination, "wb") as saved_file:
-            saved_file.write(content)
-        saved[safe_name] = {"path": destination, "size": len(content)}
+    for field_name, files in request.files.items():
+        for file in files:
+            # Never trust a client-supplied filename: strip any directory components
+            # so absolute paths or ".." segments can't escape upload_dir.
+            safe_name = os.path.basename(file.name)
+            if not safe_name or safe_name in (".", ".."):
+                continue
+            destination = os.path.join(upload_dir, safe_name)
+            with open(destination, "wb") as saved_file:
+                saved_file.write(file.content)
+            saved[safe_name] = {"path": destination, "size": len(file.content)}
 
     return saved
 

--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -23,7 +23,7 @@ from robyn.openapi import OpenAPI, RouteOpenAPIMeta
 from robyn.processpool import run_processes
 from robyn.reloader import compile_rust_files
 from robyn.responses import SSEMessage, SSEResponse, StreamingResponse, html, serve_file, serve_html
-from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, WebSocketConnector, get_version
+from robyn.robyn import FunctionInfo, Headers, HttpMethod, Request, Response, WebSocketConnector, get_version, UploadedFile
 from robyn.router import MiddlewareRouter, MiddlewareType, Router, WebSocketRouter
 from robyn.session import Session, SessionManager
 from robyn.testing import TestClient
@@ -1194,4 +1194,5 @@ __all__ = [
     "RequestURL",
     "Session",
     "SessionManager",
+    "UploadedFile",
 ]

--- a/robyn/robyn.pyi
+++ b/robyn/robyn.pyi
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, overload
+from typing import Any, Callable, List, overload
+
+from robyn.robyn import UploadedFile
 
 def get_version() -> str:
     pass
@@ -465,7 +467,7 @@ class Request:
     method: str
     url: Url
     form_data: dict[str, str]
-    files: dict[str, bytes]
+    files: dict[str, List[UploadedFile]]
     ip_addr: str | None
     identity: Identity | None
     session: Any | None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use types::{
     identity::Identity,
     multimap::QueryParams,
     request::PyRequest,
+    request::PyUploadedFile,
     response::{PyResponse, PyStreamingResponse},
     HttpMethod, Url,
 };
@@ -51,6 +52,7 @@ pub fn robyn(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FunctionInfo>()?;
     m.add_class::<Identity>()?;
     m.add_class::<PyRequest>()?;
+    m.add_class::<PyUploadedFile>()?;
     m.add_class::<PyResponse>()?;
     m.add_class::<PyStreamingResponse>()?;
     m.add_class::<Url>()?;

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -5,13 +5,69 @@ use actix_web::{
 };
 use futures_util::StreamExt as _;
 use pyo3::types::{PyBytes, PyDict, PyList, PyString};
-use pyo3::{exceptions::PyValueError, prelude::*, IntoPyObject};
+use pyo3::{exceptions::{PyTypeError, PyValueError}, prelude::*, IntoPyObject};
 use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::types::{check_body_type, get_body_from_pyobject, Url};
 
 use super::{headers::Headers, identity::Identity, multimap::QueryParams};
+
+#[pyclass(name = "UploadedFile")]
+#[derive(Clone, Debug)]
+pub struct PyUploadedFile {
+    #[pyo3(get)]
+    pub name: String,
+    #[pyo3(get)]
+    pub content: Py<PyBytes>,
+}
+
+#[pymethods]
+impl PyUploadedFile {
+    #[new]
+    pub fn new(name: String, content: Vec<u8>, py: Python) -> Self {
+        Self {
+            name,
+            content: PyBytes::new(py, &content).into(),
+        }
+    }
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let content_bound = self.content.bind(py);
+        let len = content_bound.len()?;
+        Ok(format!(
+            "UploadedFile(name={}, content=<{}> bytes)",
+            self.name, len
+        ))
+    }
+}
+
+pub fn get_files_from_pyobject(value: &Bound<'_, PyAny>) -> PyResult<Option<HashMap<String, Vec<(String, Vec<u8>)>>>> {
+    if let Ok(dict) = value.downcast::<PyDict>() {
+        let mut files = HashMap::new();
+
+        for (key, val) in dict.iter() {
+            if let Ok(key_str) = key.extract::<String>() {
+                if let Ok(list) = val.downcast::<PyList>() {
+                    let mut file_list = Vec::new();
+
+                    for item in list.iter() {
+                        if let Ok(uploaded_file) = item.downcast::<PyUploadedFile>() {
+                            let filename = uploaded_file.borrow().name.clone();
+                            let content = uploaded_file.borrow().content.bind(item.py()).as_bytes().to_vec();
+                            file_list.push((filename, content));
+                        } else if let Ok(tuple) = item.extract::<(String, Vec<u8>)>() {
+                            file_list.push(tuple);
+                        }
+                    }
+                    files.insert(key_str, file_list);
+                }
+            }
+        }
+        Ok(Some(files))
+    } else {
+        Ok(None)
+    }
+}
 
 #[derive(Default, Debug, Clone, FromPyObject)]
 pub struct Request {
@@ -26,7 +82,8 @@ pub struct Request {
     pub ip_addr: Option<String>,
     pub identity: Option<Identity>,
     pub form_data: Option<HashMap<String, String>>,
-    pub files: Option<HashMap<String, Vec<u8>>>,
+    #[pyo3(from_py_with = get_files_from_pyobject)]
+    pub files: Option<HashMap<String, Vec<(String, Vec<u8>)>>>,
     // A Python session object (robyn.session.Session) shared by reference across
     // the before_request / handler / after_request phases, so in-handler mutations
     // are visible when the cookie is written back. Set by configure_sessions().
@@ -65,9 +122,12 @@ impl<'py> IntoPyObject<'py> for Request {
         let files: Py<PyDict> = match self.files {
             Some(data) if !data.is_empty() => {
                 let dict = PyDict::new(py);
-                for (key, value) in data {
-                    let bytes = PyBytes::new(py, &value);
-                    dict.set_item(key, bytes)?;
+                for (field_name, file_list) in data {
+                    let list = PyList::new::<Bound<'_, PyAny>, _>(py, [])?;
+                    for (filename, content) in file_list {
+                        list.append(Py::new(py, PyUploadedFile::new(filename, content, py))?)?;
+                    }
+                    dict.set_item(field_name, list)?;
                 }
                 dict.into()
             }
@@ -93,7 +153,7 @@ impl<'py> IntoPyObject<'py> for Request {
 
 async fn handle_multipart(
     mut payload: Multipart,
-    files: &mut HashMap<String, Vec<u8>>,
+    files: &mut HashMap<String, Vec<(String, Vec<u8>)>>,
     form_data: &mut HashMap<String, String>,
     body: &mut Vec<u8>,
 ) -> Result<(), Error> {
@@ -115,7 +175,7 @@ async fn handle_multipart(
         body.extend_from_slice(&data);
 
         if let Some(name) = file_name {
-            files.insert(name, data);
+            files.entry(field_name.to_string()).or_insert_with(Vec::new).push((name, data));
         } else if let Ok(text) = String::from_utf8(data) {
             form_data.insert(field_name.to_string(), text);
         }
@@ -132,7 +192,7 @@ impl Request {
     ) -> Result<Self, Error> {
         let mut query_params: QueryParams = QueryParams::new();
         let mut form_data: HashMap<String, String> = HashMap::new();
-        let mut files = HashMap::new();
+        let mut files: HashMap<String, Vec<(String, Vec<u8>)>> = HashMap::new();
 
         if !req.query_string().is_empty() {
             let split = req.query_string().split('&');


### PR DESCRIPTION
The current implementation of handling files uploaded via MultiPart Form Data is incomplete in the following ways:
1. it looses form field names under which the files are uploaded;
2. it does not allow to upload multiple files with the same name.

This PR aims to fix that by modifying the request.files structure from `{ <filename>: <content> }` dict to `{ <field name>: [ UploadedFile, UploadedFile, ... ] }` where `UploadedFile` object has `.filename` and `.content` attributes with appropriate values.

## PR Checklist

Please ensure that:

- [x] The PR contains a descriptive title
- [x] The PR contains a descriptive summary of the changes
- [x] You build and test your changes before submitting a PR.
- [x] You have added relevant documentation
- [x] You have added relevant tests. We prefer integration tests wherever possible

## Pre-Commit Instructions:

- [x] Ensure that you have run the [pre-commit hooks](https://github.com/sparckles/robyn#%EF%B8%8F-to-develop-locally) on your PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File upload handling now preserves uploaded filenames and supports multiple files per form field.
  * A new top-level `UploadedFile` object is available for working with uploaded files.

* **Bug Fixes**
  * Updated request file data to reflect the correct structure in documentation and examples.
  * File upload examples now return actual uploaded file names instead of form field names.
  * Multipart save examples now handle multiple uploaded files more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->