### PR TITLE
feat: add opt-in response compression via ROBYN_COMPRESSION

### DIFF
--- a/docs_src/src/pages/documentation/en/api_reference/robyn_env.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/robyn_env.mdx
@@ -22,6 +22,9 @@ Batman wanted to configure the server through an environment file. Changing code
  - `ROBYN_MAX_PAYLOAD_SIZE`: Sets the maximum payload size for HTTP requests and WebSocket messages in bytes.
     - Default: `1000000` bytes
     - Example: `ROBYN_MAX_PAYLOAD_SIZE=1000000`
+ - `ROBYN_COMPRESSION`: Enables automatic gzip/brotli/zstd compression of responses, negotiated via the request's `Accept-Encoding` header. Streaming responses (SSE) always opt out of compression to preserve real-time delivery.
+    - Default: `False`
+    - Example: `ROBYN_COMPRESSION=True`
 
 You can have a `robyn.env` file to load them automatically in your environment.
 
@@ -45,6 +48,7 @@ RANDOM_ENV=123
 ROBYN_BROWSER_OPEN=True
 ROBYN_DEV_MODE=True
 ROBYN_MAX_PAYLOAD_SIZE=1000000
+ROBYN_COMPRESSION=True
 ```
 
 With the web application deployed and running smoothly, Batman had a powerful new tool at his disposal. The Robyn framework had provided him with the flexibility, scalability, and performance needed to create an effective crime-fighting application, giving him a technological edge in his ongoing battle to protect Gotham City.

--- a/docs_src/src/pages/documentation/en/api_reference/robyn_env.mdx
+++ b/docs_src/src/pages/documentation/en/api_reference/robyn_env.mdx
@@ -22,7 +22,7 @@ Batman wanted to configure the server through an environment file. Changing code
  - `ROBYN_MAX_PAYLOAD_SIZE`: Sets the maximum payload size for HTTP requests and WebSocket messages in bytes.
     - Default: `1000000` bytes
     - Example: `ROBYN_MAX_PAYLOAD_SIZE=1000000`
- - `ROBYN_COMPRESSION`: Enables automatic gzip/brotli/zstd compression of responses, negotiated via the request's `Accept-Encoding` header. Streaming responses (SSE) always opt out of compression to preserve real-time delivery.
+ - `ROBYN_COMPRESSION`: Enables automatic gzip/brotli/zstd compression of responses, negotiated via the request's `Accept-Encoding` header. Streaming responses always opt out of compression, regardless of `media_type`, to preserve real-time delivery.
     - Default: `False`
     - Example: `ROBYN_COMPRESSION=True`
 

--- a/docs_src/src/pages/documentation/zh/api_reference/robyn_env.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/robyn_env.mdx
@@ -21,6 +21,9 @@ export const description = '在本节中，我们将学习如何通过配置文�
 - `ROBYN_MAX_PAYLOAD_SIZE`：设置 HTTP 请求和 WebSocket 消息的最大负载大小（以字节为单位）。
   - 默认值：1000000 bytes
   - 示例：`ROBYN_MAX_PAYLOAD_SIZE=1000000`
+- `ROBYN_COMPRESSION`：根据请求的 `Accept-Encoding` 头，自动对响应进行 gzip/brotli/zstd 压缩。流式响应（SSE）始终不会被压缩，以保证实时性。
+  - 默认值：`False`
+  - 示例：`ROBYN_COMPRESSION=True`
 
 您可以使用 `robyn.env` 文件自动加载这些环境变量。
 
@@ -44,6 +47,7 @@ RANDOM_ENV=123
 ROBYN_BROWSER_OPEN=True
 ROBYN_DEV_MODE=True
 ROBYN_MAX_PAYLOAD_SIZE=1000000
+ROBYN_COMPRESSION=True
 ```
 
 随着 Web 应用程序的顺利部署和运行，蝙蝠侠拥有了一个强大的新工具。Robyn 框架为他提供了创建高效打击犯罪应用所需的灵活性、可扩展性和高性能，使他在保护哥谭市的战斗中获得了技术上的优势。

--- a/docs_src/src/pages/documentation/zh/api_reference/robyn_env.mdx
+++ b/docs_src/src/pages/documentation/zh/api_reference/robyn_env.mdx
@@ -21,7 +21,7 @@ export const description = '在本节中，我们将学习如何通过配置文�
 - `ROBYN_MAX_PAYLOAD_SIZE`：设置 HTTP 请求和 WebSocket 消息的最大负载大小（以字节为单位）。
   - 默认值：1000000 bytes
   - 示例：`ROBYN_MAX_PAYLOAD_SIZE=1000000`
-- `ROBYN_COMPRESSION`：根据请求的 `Accept-Encoding` 头，自动对响应进行 gzip/brotli/zstd 压缩。流式响应（SSE）始终不会被压缩，以保证实时性。
+- `ROBYN_COMPRESSION`：根据请求的 `Accept-Encoding` 头，自动对响应进行 gzip/brotli/zstd 压缩。无论 `media_type` 为何，流式响应始终不会被压缩，以保证实时性。
   - 默认值：`False`
   - 示例：`ROBYN_COMPRESSION=True`
 

--- a/integration_tests/base_routes.py
+++ b/integration_tests/base_routes.py
@@ -463,6 +463,11 @@ async def async_str_const_get():
     return "async str const get"
 
 
+@app.get("/sync/str/large")
+def sync_str_large_get():
+    return "compress me " * 5000
+
+
 # dict
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -43,12 +43,14 @@ def start_server(domain: str, port: int, is_dev: bool = False, extra_env: dict[s
     if is_dev:
         command.append("--dev")
 
-    # Ensure environment variables are properly set for the subprocess
+    # Ensure environment variables are properly set for the subprocess. extra_env
+    # is applied first so it can never override the domain/port this fixture
+    # is about to poll for readiness.
     env = os.environ.copy()
-    env["ROBYN_HOST"] = domain
-    env["ROBYN_PORT"] = str(port)
     if extra_env:
         env.update(extra_env)
+    env["ROBYN_HOST"] = domain
+    env["ROBYN_PORT"] = str(port)
 
     process = spawn_process(command, env)
 
@@ -78,7 +80,9 @@ def session():
     domain = "127.0.0.1"
     port = 8080
     os.environ["ROBYN_HOST"] = domain
-    process = start_server(domain, port)
+    # Explicitly disable compression so this default server isn't affected by
+    # a ROBYN_COMPRESSION already set in the developer's or CI's shell
+    process = start_server(domain, port, extra_env={"ROBYN_COMPRESSION": "0"})
     yield
     kill_process(process)
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -5,19 +5,18 @@ import signal
 import socket
 import subprocess
 import time
-from typing import List
 
 import pytest
 
 from integration_tests.helpers.network_helpers import get_network_host
 
 
-def spawn_process(command: List[str]) -> subprocess.Popen:
+def spawn_process(command: list[str], env: dict[str, str] | None = None) -> subprocess.Popen:
     if platform.system() == "Windows":
         command[0] = "python"
-        process = subprocess.Popen(command, shell=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+        process = subprocess.Popen(command, shell=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP, env=env)
         return process
-    process = subprocess.Popen(command, preexec_fn=os.setsid)
+    process = subprocess.Popen(command, preexec_fn=os.setsid, env=env)
     return process
 
 
@@ -33,7 +32,7 @@ def kill_process(process: subprocess.Popen) -> None:
         pass
 
 
-def start_server(domain: str, port: int, is_dev: bool = False) -> subprocess.Popen:
+def start_server(domain: str, port: int, is_dev: bool = False, extra_env: dict[str, str] | None = None) -> subprocess.Popen:
     """
     Call this method to wait for the server to start
     """
@@ -48,8 +47,10 @@ def start_server(domain: str, port: int, is_dev: bool = False) -> subprocess.Pop
     env = os.environ.copy()
     env["ROBYN_HOST"] = domain
     env["ROBYN_PORT"] = str(port)
+    if extra_env:
+        env.update(extra_env)
 
-    process = spawn_process(command)
+    process = spawn_process(command, env)
 
     # Wait for the server to be reachable
     timeout = 15  # The maximum time we will wait for an answer
@@ -109,6 +110,17 @@ def dev_session():
     os.environ["ROBYN_PORT"] = str(port)
     # This doesn't test is_dev=True!!!!
     process = start_server(domain, port)
+    yield
+    kill_process(process)
+
+
+@pytest.fixture(scope="session")
+def compression_session():
+    domain = "127.0.0.1"
+    port = 8084
+    # extra_env keeps the flag scoped to this server; mutating os.environ would
+    # leak compression into every session server started after this fixture
+    process = start_server(domain, port, extra_env={"ROBYN_COMPRESSION": "1"})
     yield
     kill_process(process)
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -91,7 +91,9 @@ def session():
 def default_session():
     domain = "127.0.0.1"
     port = 8080
-    process = start_server(domain, port)
+    # Explicitly disable compression so this default server isn't affected by
+    # a ROBYN_COMPRESSION already set in the developer's or CI's shell
+    process = start_server(domain, port, extra_env={"ROBYN_COMPRESSION": "0"})
     yield
     kill_process(process)
 
@@ -101,7 +103,9 @@ def global_session():
     domain = get_network_host()
     port = 8080
     os.environ["ROBYN_HOST"] = domain
-    process = start_server(domain, port)
+    # Explicitly disable compression so this default server isn't affected by
+    # a ROBYN_COMPRESSION already set in the developer's or CI's shell
+    process = start_server(domain, port, extra_env={"ROBYN_COMPRESSION": "0"})
     yield
     kill_process(process)
 
@@ -113,7 +117,9 @@ def dev_session():
     os.environ["ROBYN_HOST"] = domain
     os.environ["ROBYN_PORT"] = str(port)
     # This doesn't test is_dev=True!!!!
-    process = start_server(domain, port)
+    # Explicitly disable compression so this default server isn't affected by
+    # a ROBYN_COMPRESSION already set in the developer's or CI's shell
+    process = start_server(domain, port, extra_env={"ROBYN_COMPRESSION": "0"})
     yield
     kill_process(process)
 
@@ -135,7 +141,9 @@ def test_session():
     port = 8080
     os.environ["ROBYN_HOST"] = domain
     os.environ["ROBYN_PORT"] = str(port)
-    process = start_server(domain, port, is_dev=True)
+    # Explicitly disable compression so this default server isn't affected by
+    # a ROBYN_COMPRESSION already set in the developer's or CI's shell
+    process = start_server(domain, port, is_dev=True, extra_env={"ROBYN_COMPRESSION": "0"})
     yield
     kill_process(process)
 

--- a/integration_tests/test_compression.py
+++ b/integration_tests/test_compression.py
@@ -1,0 +1,36 @@
+import requests
+
+from integration_tests.helpers.http_methods_helpers import BASE_URL
+
+COMPRESSION_BASE_URL = "http://127.0.0.1:8084"
+
+
+def test_compression_disabled_by_default(session):
+    """Without ROBYN_COMPRESSION set, responses are not compressed."""
+    r = requests.get(f"{BASE_URL}/sync/str/large", headers={"Accept-Encoding": "gzip"})
+    assert r.status_code == 200
+    assert r.headers.get("Content-Encoding") is None
+    assert r.text == "compress me " * 5000
+
+
+def test_compression_enabled_gzips_large_responses(compression_session):
+    """With ROBYN_COMPRESSION=1, a client that accepts gzip gets a compressed response."""
+    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": "gzip"})
+    assert r.status_code == 200
+    assert r.headers.get("Content-Encoding") == "gzip"
+    # requests transparently decodes gzip, so the body is unaffected
+    assert r.text == "compress me " * 5000
+
+
+def test_compression_skipped_without_accept_encoding(compression_session):
+    """A client that doesn't advertise gzip support gets an uncompressed response."""
+    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": "identity"})
+    assert r.status_code == 200
+    assert r.headers.get("Content-Encoding") is None
+
+
+def test_compression_skips_sse_streams(compression_session):
+    """SSE responses opt out of compression so real-time delivery isn't buffered (#485)."""
+    r = requests.get(f"{COMPRESSION_BASE_URL}/sse/basic", stream=True, headers={"Accept-Encoding": "gzip"}, timeout=5)
+    assert r.status_code == 200
+    assert r.headers.get("Content-Encoding") == "identity"

--- a/integration_tests/test_compression.py
+++ b/integration_tests/test_compression.py
@@ -1,13 +1,15 @@
+import pytest
 import requests
 
 from integration_tests.helpers.http_methods_helpers import BASE_URL
 
 COMPRESSION_BASE_URL = "http://127.0.0.1:8084"
+TIMEOUT = 5
 
 
 def test_compression_disabled_by_default(session):
     """Without ROBYN_COMPRESSION set, responses are not compressed."""
-    r = requests.get(f"{BASE_URL}/sync/str/large", headers={"Accept-Encoding": "gzip"})
+    r = requests.get(f"{BASE_URL}/sync/str/large", headers={"Accept-Encoding": "gzip"}, timeout=TIMEOUT)
     assert r.status_code == 200
     assert r.headers.get("Content-Encoding") is None
     assert r.text == "compress me " * 5000
@@ -15,22 +17,30 @@ def test_compression_disabled_by_default(session):
 
 def test_compression_enabled_gzips_large_responses(compression_session):
     """With ROBYN_COMPRESSION=1, a client that accepts gzip gets a compressed response."""
-    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": "gzip"})
+    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": "gzip"}, timeout=TIMEOUT)
     assert r.status_code == 200
     assert r.headers.get("Content-Encoding") == "gzip"
     # requests transparently decodes gzip, so the body is unaffected
     assert r.text == "compress me " * 5000
 
 
+@pytest.mark.parametrize("codec", ["gzip", "br", "zstd"])
+def test_compression_negotiates_requested_codec(compression_session, codec):
+    """Each codec actix advertises is actually selectable via Accept-Encoding."""
+    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": codec}, timeout=TIMEOUT)
+    assert r.status_code == 200
+    assert r.headers.get("Content-Encoding") == codec
+
+
 def test_compression_skipped_without_accept_encoding(compression_session):
     """A client that doesn't advertise gzip support gets an uncompressed response."""
-    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": "identity"})
+    r = requests.get(f"{COMPRESSION_BASE_URL}/sync/str/large", headers={"Accept-Encoding": "identity"}, timeout=TIMEOUT)
     assert r.status_code == 200
     assert r.headers.get("Content-Encoding") is None
 
 
 def test_compression_skips_sse_streams(compression_session):
     """SSE responses opt out of compression so real-time delivery isn't buffered (#485)."""
-    r = requests.get(f"{COMPRESSION_BASE_URL}/sse/basic", stream=True, headers={"Accept-Encoding": "gzip"}, timeout=5)
-    assert r.status_code == 200
-    assert r.headers.get("Content-Encoding") == "identity"
+    with requests.get(f"{COMPRESSION_BASE_URL}/sse/basic", stream=True, headers={"Accept-Encoding": "gzip"}, timeout=TIMEOUT) as r:
+        assert r.status_code == 200
+        assert r.headers.get("Content-Encoding") == "identity"

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,6 +39,8 @@ use pyo3_async_runtimes::TaskLocals;
 const MAX_PAYLOAD_SIZE: &str = "ROBYN_MAX_PAYLOAD_SIZE";
 const DEFAULT_MAX_PAYLOAD_SIZE: usize = 1_000_000; // 1Mb
 
+const COMPRESSION: &str = "ROBYN_COMPRESSION";
+
 static STARTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone)]
@@ -132,6 +134,10 @@ impl Server {
                     "Failed to parse environment variable {MAX_PAYLOAD_SIZE} - {e}"
                 ))
             })?;
+
+        let compression_enabled = env::var(COMPRESSION)
+            .map(|v| matches!(v.trim().to_lowercase().as_str(), "1" | "true"))
+            .unwrap_or(false);
 
         thread::spawn(move || {
             actix_web::rt::System::new().block_on(async move {
@@ -281,6 +287,10 @@ impl Server {
                                 .await;
                                 response.respond_to(&req_ref)
                             },
+                        ))
+                        .wrap(middleware::Condition::new(
+                            compression_enabled,
+                            middleware::Compress::default(),
                         ))
                 })
                 .keep_alive(KeepAlive::Os)

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -110,7 +110,8 @@ impl Responder for StreamingResponse {
             .append_header(("X-Accel-Buffering", "no")) // Disable nginx buffering
             .append_header(("Cache-Control", "no-cache, no-store, must-revalidate"))
             .append_header(("Pragma", "no-cache"))
-            .append_header(("Expires", "0"));
+            .append_header(("Expires", "0"))
+            .append_header(("Content-Encoding", "identity")); // opt out of ROBYN_COMPRESSION, which would buffer chunks
 
         // Create the optimized stream from the Python generator
         let stream = create_python_stream(self.content_generator);

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -110,8 +110,8 @@ impl Responder for StreamingResponse {
             .append_header(("X-Accel-Buffering", "no")) // Disable nginx buffering
             .append_header(("Cache-Control", "no-cache, no-store, must-revalidate"))
             .append_header(("Pragma", "no-cache"))
-            .append_header(("Expires", "0"))
-            .append_header(("Content-Encoding", "identity")); // opt out of ROBYN_COMPRESSION, which would buffer chunks
+            .insert_header(("Expires", "0"))
+            .insert_header(("Content-Encoding", "identity")); // opt out of ROBYN_COMPRESSION, which would buffer chunks
 
         // Create the optimized stream from the Python generator
         let stream = create_python_stream(self.content_generator);


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

## Summary

Closes #485. Adds automatic response compression (gzip/brotli/zstd, content-negotiated via `Accept-Encoding`), wired up the way `Noborita9` outlined in the issue: actix-web already ships this middleware, so this is a thin configuration layer on top of it.

- New `ROBYN_COMPRESSION` env var (`robyn.env` or process env). **Off by default** — zero behavior change unless explicitly enabled.
- When enabled, wraps the actix `App` in `middleware::Compress` in `src/server.rs`, following the same env-var pattern already used by `ROBYN_MAX_PAYLOAD_SIZE`.
- `StreamingResponse` (SSE) explicitly opts out via `Content-Encoding: identity`. I verified empirically that without this, enabling compression buffers SSE chunks (all messages arrive at once after ~1.5s instead of streaming every ~0.5s), which would break the existing real-time SSE guarantees and the timing-sensitive tests in `test_sse.py`. With the opt-out, SSE is provably unaffected even with compression globally enabled.
- Docs updated in both `en` and `zh` versions of `robyn_env.mdx` (matching the existing bilingual-docs convention for env vars).

## Test plan

- [x] `cargo check` / `cargo test` / `cargo fmt --check` / `cargo clippy` — clean
- [x] New `integration_tests/test_compression.py`: compression off by default, gzip applied when `Accept-Encoding` is sent, skipped when the client doesn't advertise support, and SSE responses stay uncompressed
- [x] Full integration + unit suite via `nox` (544 tests) — all passing, no regressions
- [x] Manual verification with curl: 50,000-byte response compresses to 266 bytes with `ROBYN_COMPRESSION=1`, and is untouched (raw `Content-Length: 50000`) by default
- [x] Manual timing script confirming SSE messages still arrive in real time (~0.5s apart) with compression enabled globally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional HTTP response compression controlled by `ROBYN_COMPRESSION`.
  - Enabled responses negotiate gzip, Brotli, or Zstandard based on `Accept-Encoding`.
  - Requests using `Accept-Encoding: identity` receive uncompressed responses.
  - Streaming and SSE responses remain uncompressed for real-time delivery.
- **Documentation**
  - Documented `ROBYN_COMPRESSION` and updated English and Chinese `robyn.env` examples.
- **Tests**
  - Added integration coverage for compression, codec negotiation, identity responses, and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
