### PR TITLE
fix: skip blank/malformed lines in robyn.env parser to prevent IndexError

### DIFF
--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -14,9 +14,10 @@ def parser(config_path=None, project_root=""):
     if config_path.exists():
         with open(config_path, "r") as f:
             for line in f:
-                if line.startswith("#"):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#") or "=" not in stripped:
                     continue
-                yield line.strip().split("=")
+                yield stripped.split("=", 1)
 
 
 # check for the environment variables set in cli and if not set them


### PR DESCRIPTION
## Summary

Fixes `IndexError` in `robyn/env_populator.py` when `robyn.env` contains blank lines, whitespace-only lines, or lines without `=`.

### The Bug

`parser()` splits every non-comment line on `=` unconditionally. A blank line or whitespace-only line produces `[""]`, so `var[1]` in `load_vars()` raises `IndexError: list index out of range`.

### The Fix

- Skip blank lines (`not stripped`)
- Skip lines without `=` (`"=" not in stripped`)
- Use `split("=", 1)` to handle values containing `=`

### Test Cases

| Input | Before | After |
|-------|--------|-------|
| Blank line | `IndexError` | Skipped |
| Whitespace only | `IndexError` | Skipped |
| `BROKEN` (no `=`) | `IndexError` | Skipped |
| `KEY=val=extra` | `["KEY", "val", "extra"]` | `["KEY", "val=extra"]` |

Closes #1426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing by ignoring blank lines, comments, and invalid entries.
  * Preserved values containing additional `=` characters.
  * Added support for leading and trailing whitespace around configuration lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->