### PR TITLE
fix: fallback to application/octet-stream for unrecognized MIME types in serve_file

### DIFF
--- a/robyn/responses.py
+++ b/robyn/responses.py
@@ -53,7 +53,7 @@ def serve_file(file_path: str, file_name: str | None = None) -> FileResponse:
     """
     file_name = file_name or os.path.basename(file_path)
 
-    mime_type = mimetypes.guess_type(file_name)[0]
+    mime_type = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
 
     headers = Headers({"Content-Type": mime_type})
     headers.append("Content-Disposition", f"attachment; filename={file_name}")


### PR DESCRIPTION
## Summary

Fixes `serve_file()` sending a literal `Content-Type: None` header for files with unrecognized extensions.

`mimetypes.guess_type()` returns `None` for extensions it doesn't recognize (e.g. `.log`, `.dat`). When this `None` is passed into `Headers()`, it becomes the string `"None"` via `str(None)`, resulting in an invalid HTTP header.

**Fix:** Fall back to `application/octet-stream` when MIME type cannot be guessed.

Closes #1428


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured file downloads always include a `Content-Type` header.
  * Added a safe fallback content type when the file type cannot be detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->