### PR TITLE
fix: parse ROBYN_BROWSER_OPEN env var as boolean string instead of bool()

### DIFF
--- a/robyn/__init__.py
+++ b/robyn/__init__.py
@@ -976,7 +976,7 @@ class Robyn(BaseRobyn):
         port = int(os.getenv("ROBYN_PORT", port))
         client_timeout = int(os.getenv("ROBYN_CLIENT_TIMEOUT", client_timeout))
         keep_alive_timeout = int(os.getenv("ROBYN_KEEP_ALIVE_TIMEOUT", keep_alive_timeout))
-        open_browser = bool(os.getenv("ROBYN_BROWSER_OPEN", self.config.open_browser))
+        open_browser = os.getenv("ROBYN_BROWSER_OPEN", str(self.config.open_browser)).strip().lower() in ("1", "true", "yes")
 
         if _check_port:
             while self.is_port_in_use(port):


### PR DESCRIPTION
## Summary

Fixes `ROBYN_BROWSER_OPEN=False` paradoxically opening the browser.

`os.getenv("ROBYN_BROWSER_OPEN", ...)` always returns a string when the variable is set, and `bool("False")` is `True` in Python — any non-empty string is truthy. Setting `ROBYN_BROWSER_OPEN=False` in a `robyn.env` file (exactly as shown in the project docs) does the opposite of what it says.

**Fix:** Parse the string explicitly using `.strip().lower() in ("1", "true", "yes")`, matching the existing pattern used for `ROBYN_DEV_MODE` at line 161.

Closes #1427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the `ROBYN_BROWSER_OPEN` setting by recognizing enabled values consistently regardless of letter case.
  * Only `"1"`, `"true"`, and `"yes"` activate the setting; other values are treated as disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->