### PR TITLE
Fix robyn.env parser crash on blank lines and truncation of '=' values

### DIFF
--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -15,16 +15,13 @@ def parser(config_path=None, project_root=""):
         with open(config_path, "r") as f:
             for line in f:
                 line = line.strip()
-                # Skip blank lines and comments so they do not yield a
-                # malformed (key-only) pair that crashes load_vars().
                 if not line or line.startswith("#"):
                     continue
-                if "=" not in line:
+                key, sep, value = line.partition("=")
+                if not sep or not key:
                     logger.warning(" Ignoring malformed robyn.env line: %r", line)
                     continue
-                # maxsplit=1 so values containing '=' (e.g. base64 secrets)
-                # are preserved instead of being truncated at the first '='.
-                yield line.split("=", 1)
+                yield [key, value]
 
 
 # check for the environment variables set in cli and if not set them

--- a/robyn/env_populator.py
+++ b/robyn/env_populator.py
@@ -14,9 +14,17 @@ def parser(config_path=None, project_root=""):
     if config_path.exists():
         with open(config_path, "r") as f:
             for line in f:
-                if line.startswith("#"):
+                line = line.strip()
+                # Skip blank lines and comments so they do not yield a
+                # malformed (key-only) pair that crashes load_vars().
+                if not line or line.startswith("#"):
                     continue
-                yield line.strip().split("=")
+                if "=" not in line:
+                    logger.warning(" Ignoring malformed robyn.env line: %r", line)
+                    continue
+                # maxsplit=1 so values containing '=' (e.g. base64 secrets)
+                # are preserved instead of being truncated at the first '='.
+                yield line.split("=", 1)
 
 
 # check for the environment variables set in cli and if not set them

--- a/unit_tests/test_env_populator.py
+++ b/unit_tests/test_env_populator.py
@@ -38,3 +38,33 @@ def test_env_population(env_file):
     HOST = os.environ["ROBYN_HOST"]
     assert PORT == "8080"
     assert HOST == "127.0.0.1"
+
+
+def test_parser_skips_blank_and_malformed_lines(tmp_path):
+    env_path = tmp_path / "robyn.env"
+    # Blank line, whitespace-only line, comment and a valueless line must not
+    # crash the parser or produce malformed pairs.
+    env_path.write_text("ROBYN_PORT=8080\n\n   \n# a comment\nNO_EQUALS\nROBYN_HOST=127.0.0.1\n")
+    result = list(parser(config_path=env_path))
+    assert result == [["ROBYN_PORT", "8080"], ["ROBYN_HOST", "127.0.0.1"]]
+
+
+def test_parser_preserves_equals_in_value(tmp_path):
+    env_path = tmp_path / "robyn.env"
+    env_path.write_text("SECRET_KEY=abc=123==\n")
+    result = list(parser(config_path=env_path))
+    assert result == [["SECRET_KEY", "abc=123=="]]
+
+
+def test_load_vars_with_blank_line_does_not_crash(tmp_path):
+    env_path = tmp_path / "robyn.env"
+    env_path.write_text("ROBYN_PORT=8081\n\nROBYN_HOST=0.0.0.0\n")
+    for key in ("ROBYN_PORT", "ROBYN_HOST"):
+        os.environ.pop(key, None)
+    try:
+        load_vars(variables=parser(config_path=env_path))
+        assert os.environ["ROBYN_PORT"] == "8081"
+        assert os.environ["ROBYN_HOST"] == "0.0.0.0"
+    finally:
+        for key in ("ROBYN_PORT", "ROBYN_HOST"):
+            os.environ.pop(key, None)

--- a/unit_tests/test_env_populator.py
+++ b/unit_tests/test_env_populator.py
@@ -42,9 +42,7 @@ def test_env_population(env_file):
 
 def test_parser_skips_blank_and_malformed_lines(tmp_path):
     env_path = tmp_path / "robyn.env"
-    # Blank line, whitespace-only line, comment and a valueless line must not
-    # crash the parser or produce malformed pairs.
-    env_path.write_text("ROBYN_PORT=8080\n\n   \n# a comment\nNO_EQUALS\nROBYN_HOST=127.0.0.1\n")
+    env_path.write_text("ROBYN_PORT=8080\n\n   \n# a comment\nNO_EQUALS\n=NO_KEY\nROBYN_HOST=127.0.0.1\n")
     result = list(parser(config_path=env_path))
     assert result == [["ROBYN_PORT", "8080"], ["ROBYN_HOST", "127.0.0.1"]]
 
@@ -59,12 +57,14 @@ def test_parser_preserves_equals_in_value(tmp_path):
 def test_load_vars_with_blank_line_does_not_crash(tmp_path):
     env_path = tmp_path / "robyn.env"
     env_path.write_text("ROBYN_PORT=8081\n\nROBYN_HOST=0.0.0.0\n")
-    for key in ("ROBYN_PORT", "ROBYN_HOST"):
-        os.environ.pop(key, None)
+    saved = {key: os.environ.pop(key, None) for key in ("ROBYN_PORT", "ROBYN_HOST")}
     try:
         load_vars(variables=parser(config_path=env_path))
         assert os.environ["ROBYN_PORT"] == "8081"
         assert os.environ["ROBYN_HOST"] == "0.0.0.0"
     finally:
-        for key in ("ROBYN_PORT", "ROBYN_HOST"):
-            os.environ.pop(key, None)
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value


### PR DESCRIPTION
Re-opening #1433 at @sansyrox's request. GitHub wouldn't let the original be reopened once its source branch was gone, so this re-submits the identical commit. Original thread: #1433.

---

Fixes #1426

### Problem

`robyn/env_populator.py` `parser()` splits every non-comment line on `=` and yields the result unconditionally, and `load_vars()` indexes `var[0]`/`var[1]`:

```python
yield line.strip().split("=")
...
os.environ[var[0]] = var[1]
```

Two bugs:

1. A blank/whitespace-only line yields `['']`, and a line without `=` yields a one-element list. `load_vars` then hits `var[1]` -> `IndexError`, crashing the app **before it starts** (`load_vars` runs whenever a `robyn.env` exists, from `cli.py` and `BaseRobyn.__init__`).
2. `split("=")` has no `maxsplit`, so a value containing `=` (e.g. a base64 secret `SECRET_KEY=abc=123==`) is truncated to `abc`.

Reproduce:

```python
from pathlib import Path
from robyn.env_populator import load_vars, parser
Path("robyn.env").write_text("ROBYN_PORT=8080\n\nROBYN_HOST=127.0.0.1\n")
load_vars(variables=parser(config_path=Path("robyn.env")))   # IndexError
```

### Fix

In `parser()`: strip each line, skip blanks/comments and lines without `=`, and use `split("=", 1)` so values keep their `=` characters. `load_vars` now only ever receives well-formed 2-element pairs.

Before/after on the same input:

```
before: [['ROBYN_PORT','8080'], [''], [''], ['NO_EQUALS'], ['SECRET','abc','123','',''], ['ROBYN_HOST','127.0.0.1']]
after:  [['ROBYN_PORT','8080'], ['SECRET','abc=123=='], ['ROBYN_HOST','127.0.0.1']]
```

### Tests

Added tests in `unit_tests/test_env_populator.py` covering blank/whitespace/comment/valueless lines and `=`-in-value preservation, plus a `load_vars` blank-line smoke test. (The Robyn package import pulls in the compiled Rust extension, so I also exercised `env_populator` directly to confirm the crash before the change and clean parsing after.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment file parsing by trimming whitespace around keys and values.
  - Blank lines, comments, malformed entries, and entries without keys are skipped with warnings that identify the line and file without exposing contents.
  - Values containing additional equals signs are handled correctly.
  - Environment variable values are no longer written to logs; only variable names are shown.

- **Tests**
  - Added coverage for parsing edge cases, whitespace handling, logging safety, and loading files with blank lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->